### PR TITLE
Add S3 as deploy target

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -6,9 +6,14 @@ import hashlib
 import tempfile
 import posixpath
 import subprocess
+import mimetypes
 from contextlib import contextmanager
 from cStringIO import StringIO
+from hashlib import md5
 
+import boto3
+from boto3.session import Session
+import botocore.exceptions
 from werkzeug import urls
 
 from lektor.utils import portable_popen, locate_executable
@@ -591,6 +596,176 @@ class GithubPagesPublisher(Publisher):
                 yield line
 
 
+class S3Publisher(Publisher):
+
+    def __init__(self, env, output_path):
+        super(S3Publisher, self).__init__(env, output_path)
+        self.s3 = None
+        self.bucket = None
+        self.key_prefix = ''
+
+    def split_bucket_uri(self, target_url):
+        bucket = target_url.netloc
+        key = target_url.path
+        if key != '':
+            if key.startswith('/'):
+                key = key[1:]
+            if not key.endswith('/'):
+                key = key + '/'
+        return bucket, key
+
+    def verify_bucket_exists(self):
+        exists = True
+        try:
+            self.s3.meta.client.head_bucket(Bucket=self.bucket.name)
+        except botocore.exceptions.ClientError as e:
+            error_code = int(e.response['Error']['Code'])
+            if error_code == 404:
+                exists = False
+        return exists
+
+    def list_remote(self):
+        return self.bucket.objects.filter(Prefix=self.key_prefix)
+
+    def list_local(self):
+        all_files = []
+        for path, _, files in os.walk(self.output_path):
+            for f in files:
+                fullpath = os.path.join(path, f)
+                relpath = os.path.relpath(fullpath, self.output_path)
+                if os.path.dirname(relpath) != ".lektor":
+                    all_files.append(os.path.relpath(fullpath, self.output_path))
+
+        return all_files
+
+    def file_md5(self, filename):
+        '''Compute the md5 checksum for a file.'''
+        md5sum = md5()
+        with open(filename, 'rb') as f:
+            data = f.read(8192)
+            while len(data) > 0:
+                md5sum.update(data)
+                data = f.read(8192)
+        return md5sum.hexdigest()
+
+    def obj_md5(self, obj):
+        """Compute the md5 checksum for an S3 object.
+
+        MD5s can be stored in the 'ETag' field of S3 objects. The
+        field doesn't store the MD5 in two cases: objects uploaded
+        with Multipart Upload and objects encrypted with SSE-C or
+        SSE-KMS. In those cases, we'll just return an empty string.
+
+        """
+
+        # Multipart-uploaded messages have etags that look like 'xxx-nnn'
+        if '-' in obj.e_tag:
+            return ''
+
+        # SSE-C and SSE-KMS-encrypted objects have a few values set
+        # when you call HeadObject on them
+        obj_meta = self.s3.meta.client.head_object(
+            Bucket=obj.bucket_name,
+            Key=obj.key,
+        )
+        if obj_meta.get('SSECustomerAlgorithm') is not None:
+            return ''
+        if obj_meta.get('ServerSideEncryption') == 'aws:kms':
+            return ''
+
+        # Else, the etag stores an md5 checksum enclosed in double quotes
+        return obj.e_tag.strip('"')
+
+    def different(self, local_filename, remote_obj):
+        """Return true if the local file is different than the remote object."""
+        abs_filename = os.path.join(self.output_path, local_filename)
+        # Check size first.
+        if remote_obj.size != os.path.getsize(abs_filename):
+            return True
+
+        # check md5
+        if self.file_md5(abs_filename) != self.obj_md5(remote_obj):
+            return True
+
+        # they're the same
+        return False
+
+    def compute_diff(self, local, remote):
+        """Compute the changeset for updating remote to match local"""
+        diff = {
+            'add': [],
+            'update': [],
+            'delete': [],
+        }
+        remote_keys = {o.key: o for o in remote}
+        for f in local:
+            key = self.key_prefix + f
+            if key in remote_keys:
+                if self.different(f, remote_keys[key]):
+                    diff['update'].append(f)
+            else:
+                diff['add'].append(f)
+        for k in remote_keys:
+            if k not in local:
+                diff['delete'].append(k)
+        return diff
+
+    def add(self, filename):
+        abs_filename = os.path.join(self.output_path, filename)
+        key = self.key_prefix + filename
+
+        mime, _ = mimetypes.guess_type(filename)
+        if mime is None:
+            mime = "text/plain"
+        self.bucket.upload_file(abs_filename, key, ExtraArgs={'ContentType': mime})
+
+    def update(self, filename):
+        # Updates are just overwrites in S3
+        self.add(filename)
+
+    def delete_batch(self, filenames):
+        if len(filenames) == 0:
+            return
+        self.bucket.delete_objects(
+            Delete={'Objects': [{'Key': self.key_prefix + f} for f in filenames]}
+        )
+
+    def connect(self, credentials):
+        self.s3 = boto3.resource(
+            service_name='s3',
+            region_name='us-west-2'  # todo: make configurable
+        )
+
+    def publish(self, target_url, credentials=None):
+        if credentials is None:
+            credentials = {}
+        self.connect(credentials)
+
+        bucket_uri, self.key_prefix = self.split_bucket_uri(target_url)
+        self.bucket = self.s3.Bucket(bucket_uri)
+        if not self.verify_bucket_exists():
+            raise PublishError(
+                's3 bucket "%s" does not exist, please create it first'
+                % bucket_uri
+            )
+
+        local = self.list_local()
+        remote = self.list_remote()
+        diff = self.compute_diff(local, remote)
+
+        for f in diff['add']:
+            yield 'adding %s' % f
+            self.add(f)
+
+        for f in diff['update']:
+            yield 'updating %s' % f
+            self.update(f)
+
+        for f in diff['delete']:
+            yield 'deleting %s' % f
+        self.delete_batch(diff['delete'])
+
+
 publishers = {
     'rsync': RsyncPublisher,
     'ftp': FtpPublisher,
@@ -598,6 +773,7 @@ publishers = {
     'ghpages': GithubPagesPublisher,
     'ghpages+https': GithubPagesPublisher,
     'ghpages+ssh': GithubPagesPublisher,
+    's3': S3Publisher,
 }
 
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -731,10 +731,7 @@ class S3Publisher(Publisher):
         )
 
     def connect(self, credentials):
-        self.s3 = boto3.resource(
-            service_name='s3',
-            region_name='us-west-2'  # todo: make configurable
-        )
+        self.s3 = boto3.resource(service_name='s3')
 
     def publish(self, target_url, credentials=None):
         if credentials is None:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         'Jinja2>=2.4',
         'click>=6.0',
+        'boto3>=1.1.4',
         'watchdog',
         'mistune',
         'Flask',


### PR DESCRIPTION
This works for me locally. 

One big quirk: this is just letting boto handle credentials, so it looks in ~/.aws/credentials and in the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for creds instead of using lektor's flow. I didn't want to muck with cli.py too much before getting a second opinion on whether it's important to unify credential input.

Also todo: writing docs. Again, I wanted to get a feel for whether this code is worthwhile before diving into those.
