### PR TITLE
Store publishers in environment so they can be mutated by plugins safely

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -403,6 +403,9 @@ class Environment(object):
         from lektor.types import builtin_types
         self.types = builtin_types.copy()
 
+        from lektor.publishers import builtin_publishers
+        self.publishers = builtin_publishers.copy()
+
         # The plugins that are loaded for this environment.  This is
         # modified by the plugin controller and registry methods on the
         # environment.

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -591,7 +591,7 @@ class GithubPagesPublisher(Publisher):
                 yield line
 
 
-publishers = {
+builtin_publishers = {
     'rsync': RsyncPublisher,
     'ftp': FtpPublisher,
     'ftps': FtpTlsPublisher,
@@ -603,6 +603,6 @@ publishers = {
 
 def publish(env, target, output_path, credentials=None):
     url = urls.url_parse(unicode(target))
-    publisher = publishers.get(url.scheme)
+    publisher = env.publishers.get(url.scheme)
     if publisher is not None:
         return publisher(env, output_path).publish(url, credentials)


### PR DESCRIPTION
As discussed in #24, this will make it a little safer to write plugins that change the set of available publishers.
