### PR TITLE
Load admin fonts protocol agnostic

### DIFF
--- a/lektor/admin/static/less/bootstrap-overrides.less
+++ b/lektor/admin/static/less/bootstrap-overrides.less
@@ -31,7 +31,7 @@
 @import "~bootstrap/less/responsive-utilities";
 
 // Fonts
-@import url(http://fonts.googleapis.com/css?family=Roboto+Slab:400,300,300italic,400italic,500,500italic);
+@import url(//fonts.googleapis.com/css?family=Roboto+Slab:400,300,300italic,400italic,500,500italic);
 @font-family-serif: 'Roboto Slab', 'Georgia', 'Times New Roman', serif;
 @font-family-base: @font-family-serif;
 


### PR DESCRIPTION
Fixes font issue on https with Strict Transport Security enabled.

My setup serves admin interface over a https connection and my browser kept complaining about this.  
