### PR TITLE
Add Query.distinct() method.

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -839,6 +839,20 @@ class Query(object):
             rv += 1
         return rv
 
+    def distinct(self, fieldname):
+        """Set of unique values for the given field."""
+        rv = set()
+
+        for item in self:
+            if fieldname in item._data:
+                value = item._data[fieldname]
+                if isinstance(value, (list, tuple)):
+                    rv |= set(value)
+                else:
+                    rv.add(value)
+
+        return rv
+
     def get(self, id, page_num=Ellipsis):
         """Gets something by the local path."""
         # If we're not pristine, we need to query here

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -848,7 +848,7 @@ class Query(object):
                 value = item._data[fieldname]
                 if isinstance(value, (list, tuple)):
                     rv |= set(value)
-                else:
+                elif not isinstance(value, Undefined):
                     rv.add(value)
 
         return rv

--- a/tests/demo-project/content/blog/post1/contents.lr
+++ b/tests/demo-project/content/blog/post1/contents.lr
@@ -5,3 +5,10 @@ pub_date: 2015-12-12
 body:
 
 Look at my [attachment](hello.txt).
+---
+category: My Category
+---
+tags:
+
+tag1
+tag2

--- a/tests/demo-project/content/blog/post1/contents.lr
+++ b/tests/demo-project/content/blog/post1/contents.lr
@@ -1,6 +1,6 @@
 title: Post 1
 ---
-pub_date: 12-12-2015
+pub_date: 2015-12-12
 ---
 body:
 

--- a/tests/demo-project/content/blog/post1/contents.lr
+++ b/tests/demo-project/content/blog/post1/contents.lr
@@ -2,6 +2,8 @@ title: Post 1
 ---
 pub_date: 2015-12-12
 ---
+summary: hello
+---
 body:
 
 Look at my [attachment](hello.txt).

--- a/tests/demo-project/content/blog/post2/contents.lr
+++ b/tests/demo-project/content/blog/post2/contents.lr
@@ -1,0 +1,12 @@
+title: Post 2
+---
+pub_date: 2015-12-13
+---
+body: aha
+---
+category: My Category
+---
+tags:
+
+tag1
+tag3

--- a/tests/demo-project/models/blog-post.ini
+++ b/tests/demo-project/models/blog-post.ini
@@ -14,3 +14,11 @@ type = date
 [fields.body]
 label = Body
 type = markdown
+
+[fields.category]
+label = Category
+type = string
+
+[fields.tags]
+label = Tags
+type = strings

--- a/tests/demo-project/models/blog-post.ini
+++ b/tests/demo-project/models/blog-post.ini
@@ -11,6 +11,10 @@ type = string
 label = Publication date
 type = date
 
+[fields.summary]
+label = Summary
+type = string
+
 [fields.body]
 label = Body
 type = markdown

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -153,3 +153,6 @@ def test_distinct(pad):
     assert distinct_tags == set(['tag1', 'tag2', 'tag3'])
     distinct_pub_dates = posts.distinct('pub_date')
     assert distinct_pub_dates == set([date(2015, 12, 12), date(2015, 12, 13)])
+    assert posts.distinct('foo') == set()
+    # Post 2 has no summary; check we don't include Undefined in distinct().
+    assert posts.distinct('summary') == set(['hello'])

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,6 @@
+from datetime import date
+
+
 def test_root(pad):
     record = pad.root
 
@@ -138,3 +141,15 @@ def test_query_normalization(pad):
     assert pad.get('/projects') is projects
     assert pad.get('/projects/.') is projects
     assert pad.get('//projects/.') is projects
+
+
+def test_distinct(pad):
+    posts = pad.query('blog')
+    distinct_categories = posts.distinct('category')
+    assert isinstance(distinct_categories, set)
+    assert distinct_categories == set(['My Category'])
+    distinct_tags = posts.distinct('tags')
+    assert isinstance(distinct_tags, set)
+    assert distinct_tags == set(['tag1', 'tag2', 'tag3'])
+    distinct_pub_dates = posts.distinct('pub_date')
+    assert distinct_pub_dates == set([date(2015, 12, 12), date(2015, 12, 13)])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -191,12 +191,13 @@ def test_pagination_items_filter(pad):
     assert blog.datamodel.pagination_config.items == \
         "this.children.filter(F._model == 'blog-post')"
 
-    assert blog.children.count() == 2
+    assert blog.children.count() == 3
     assert sorted(x['_id'] for x in blog.children) == [
-        'dummy.xml', 'post1']
+        'dummy.xml', 'post1', 'post2']
 
-    assert blog.pagination.items.count() == 1
-    assert blog.pagination.items.first()['_id'] == 'post1'
+    assert blog.pagination.items.count() == 2
+    # Sort order is pub_date descending, so post 2 is first.
+    assert blog.pagination.items.first()['_id'] == 'post2'
 
     dummy = blog.children.get('dummy.xml')
     assert dummy is not None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -45,7 +45,7 @@ def test_markdown_linking(pad, builder):
     prog, _ = builder.build(blog_index)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'Look at my <a href="../blog/post1/hello.txt">'
+            b'Look at my <a href="../blog/2015/12/post1/hello.txt">'
             b'attachment</a>'
         ) in f.read()
 
@@ -55,7 +55,7 @@ def test_markdown_linking(pad, builder):
     prog, _ = builder.build(blog_post)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'Look at my <a href="../../blog/post1/hello.txt">'
+            b'Look at my <a href="../../../../blog/2015/12/post1/hello.txt">'
             b'attachment</a>'
         ) in f.read()
 


### PR DESCRIPTION
For example, this is useful to generate a set of tags from a set of blog posts, without having to manually create each tag and then assign the tag to some blog posts.

This is different from the "categories" example in the documentation.
