### PR TITLE
Correctly handle admin preview of root page in firefox. This fixes #59

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Release date to be decided
   files to not upload correctly.
 - Improved error message for when imagemagick cannot be found.
 - Fixed scrolling in the admin for firefox and some other browsers.
+- Fixed admin preview of root page in firefox.
 
 1.1
 ---

--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -73,9 +73,12 @@ class PreviewPage extends RecordComponent {
   }
 
   getFramePath() {
-    var frame = this.refs.iframe;
+    var frameLocation = this.refs.iframe.contentWindow.location;
+    if (frameLocation.href === 'about:blank') {
+        return frameLocation.href;
+    }
     return utils.fsPathFromAdminObservedPath(
-      frame.contentWindow.location.pathname);
+      frameLocation.pathname);
   }
 
   onFrameNavigated() {


### PR DESCRIPTION
Apparently Firefox sets the href of the fresh iframe (containing about:config) to an empty string. As a consequence Firefox thinks it's already rendering the root page and doesn't update the iframe contents.

Chromium sets it to "about", as such there is no issue for the root page.

Fixes #59 
