### PR TITLE
Add datetime type

### DIFF
--- a/lektor/types/__init__.py
+++ b/lektor/types/__init__.py
@@ -94,7 +94,7 @@ class Type(object):
 
 from lektor.types.primitives import \
      StringType, StringsType, TextType, HtmlType, IntegerType, \
-     FloatType, BooleanType, DateType
+     FloatType, BooleanType, DateType, DateTimeType
 from lektor.types.multi import CheckboxesType, SelectType
 from lektor.types.special import SortKeyType, SlugType, UrlType
 from lektor.types.formats import MarkdownType
@@ -112,6 +112,7 @@ builtin_types = {
     'float': FloatType,
     'boolean': BooleanType,
     'date': DateType,
+    'datetime': DateTimeType,
 
     # Multi
     'checkboxes': CheckboxesType,

--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -7,8 +7,8 @@ from lektor.environment import PRIMARY_ALT
 from lektor.utils import bool_from_string
 from lektor.i18n import get_i18n_block
 
-from pytz import FixedOffset, timezone
-from pytz.exceptions import UnknownTimeZoneError
+from babel.dates import get_timezone
+from pytz import FixedOffset
 
 
 class SingleInputType(Type):
@@ -129,8 +129,8 @@ class DateTimeType(SingleInputType):
 
             if len(chunks) > 2:
                 try:
-                    tz = timezone(chunks[-1])
-                except UnknownTimeZoneError:
+                    tz = get_timezone(chunks[-1])
+                except LookupError:
                     if len(chunks[-1]) > 5:
                         chunks[-1] = chunks[-1][-5:]
                     delta = int(chunks[-1][1:3]) * 60 + int(chunks[-1][3:])

--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from markupsafe import Markup
 
@@ -6,6 +6,9 @@ from lektor.types import Type
 from lektor.environment import PRIMARY_ALT
 from lektor.utils import bool_from_string
 from lektor.i18n import get_i18n_block
+
+from pytz import FixedOffset, timezone
+from pytz.exceptions import UnknownTimeZoneError
 
 
 class SingleInputType(Type):
@@ -107,5 +110,35 @@ class DateType(SingleInputType):
             return raw.missing_value('Missing date')
         try:
             return date(*map(int, raw.value.split('-')))
+        except Exception:
+            return raw.bad_value('Bad date format')
+
+
+class DateTimeType(SingleInputType):
+    widget = 'singleline-text'
+
+    def value_from_raw(self, raw):
+        if raw.value is None:
+            return raw.missing_value('Missing datetime')
+        try:
+            chunks = raw.value.split(' ')
+            date_info = map(int, chunks[0].split('-'))
+            time_info = map(int, chunks[1].split(':'))
+            datetime_info = date_info + time_info
+            result = datetime(*datetime_info)
+
+            if len(chunks) > 2:
+                try:
+                    tz = timezone(chunks[-1])
+                except UnknownTimeZoneError:
+                    if len(chunks[-1]) > 5:
+                        chunks[-1] = chunks[-1][-5:]
+                    delta = int(chunks[-1][1:3]) * 60 + int(chunks[-1][3:])
+                    if chunks[-1][0] == '-':
+                        delta *= -1
+                    tz = FixedOffset(delta)
+                return tz.localize(result)
+
+            return result
         except Exception:
             return raw.bad_value('Bad date format')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,7 +7,7 @@ from lektor.types import Undefined, BadValue
 
 from markupsafe import escape, Markup
 
-from pytz import timezone, utc
+from babel.dates import get_timezone
 
 class DummySource(object):
     url_path = '/'
@@ -189,7 +189,7 @@ def test_datetime(env, pad):
         assert rv.hour == 1
         assert rv.minute == 2
         assert rv.second == 3
-        assert rv.tzinfo is utc
+        assert rv.tzinfo is get_timezone('UTC')
 
         # Known timezone name, EST
         rv = field.deserialize_value('2016-04-30 01:02:03 EST', pad=pad)
@@ -200,7 +200,7 @@ def test_datetime(env, pad):
         assert rv.hour == 1
         assert rv.minute == 2
         assert rv.second == 3
-        assert rv.tzinfo is timezone('EST')
+        assert rv.tzinfo is get_timezone('EST')
 
         # Known location name, Asia/Seoul
         rv = field.deserialize_value('2016-04-30 01:02:03 Asia/Seoul', pad=pad)
@@ -211,7 +211,7 @@ def test_datetime(env, pad):
         assert rv.hour == 1
         assert rv.minute == 2
         assert rv.second == 3
-        assert rv.tzinfo in timezone('Asia/Seoul')._tzinfos.values()
+        assert rv.tzinfo in get_timezone('Asia/Seoul')._tzinfos.values()
 
         # KST - http://www.timeanddate.com/time/zones/kst
         rv = field.deserialize_value('2016-04-30 01:02:03 +0900', pad=pad)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,5 @@
+import datetime
+
 from lektor.datamodel import Field
 from lektor.types.formats import MarkdownDescriptor
 from lektor.context import Context
@@ -5,6 +7,7 @@ from lektor.types import Undefined, BadValue
 
 from markupsafe import escape, Markup
 
+from pytz import timezone, utc
 
 class DummySource(object):
     url_path = '/'
@@ -148,3 +151,130 @@ def test_boolean(env, pad):
         for s in 'false', 'FALSE', 'False', '0', 'no':
             rv = field.deserialize_value(s, pad=pad)
             assert rv is False
+
+
+def test_datetime(env, pad):
+    field = make_field(env, 'datetime')
+
+    with Context(pad=pad):
+        # default
+        rv = field.deserialize_value('2016-04-30 01:02:03', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo is None
+
+        # It is not datetime, it is None
+        rv = field.deserialize_value(None, pad=pad)
+        assert isinstance(rv, Undefined)
+
+        # It is not datetime, it is empty string
+        rv = field.deserialize_value('', pad=pad)
+        assert isinstance(rv, BadValue)
+
+        # It is not datetime, it is date
+        rv = field.deserialize_value('2016-04-30', pad=pad)
+        assert isinstance(rv, BadValue)
+
+        # Known timezone name, UTC
+        rv = field.deserialize_value('2016-04-30 01:02:03 UTC', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo is utc
+
+        # Known timezone name, EST
+        rv = field.deserialize_value('2016-04-30 01:02:03 EST', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo is timezone('EST')
+
+        # Known location name, Asia/Seoul
+        rv = field.deserialize_value('2016-04-30 01:02:03 Asia/Seoul', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo in timezone('Asia/Seoul')._tzinfos.values()
+
+        # KST - http://www.timeanddate.com/time/zones/kst
+        rv = field.deserialize_value('2016-04-30 01:02:03 +0900', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, 9*60*60)
+
+        # ACST - http://www.timeanddate.com/time/zones/acst
+        rv = field.deserialize_value('2016-04-30 01:02:03 +0930', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, (9*60+30)*60)
+
+        # MST - http://www.timeanddate.com/time/zones/mst
+        rv = field.deserialize_value('2016-04-30 01:02:03 -0700', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, -7*60*60)
+
+        # MART - http://www.timeanddate.com/time/zones/mart
+        rv = field.deserialize_value('2016-04-30 01:02:03 -0930', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, -(9*60+30)*60)
+
+        # with timezone name (case 1)
+        rv = field.deserialize_value('2016-04-30 01:02:03 KST +0900', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, 9*60*60)
+
+        # with timezone name (case 2)
+        rv = field.deserialize_value('2016-04-30 01:02:03 KST+0900', pad=pad)
+        assert isinstance(rv, datetime.datetime)
+        assert rv.year == 2016
+        assert rv.month == 4
+        assert rv.day == 30
+        assert rv.hour == 1
+        assert rv.minute == 2
+        assert rv.second == 3
+        assert rv.tzinfo._offset == datetime.timedelta(0, 9*60*60)


### PR DESCRIPTION
This PR implemented datetime type with timezone.
# Usage
## settings

``` ini
[fields.pub_date]
label = Publication date
type = datetime
```
## printing

``` html+jinja
{{ this.pub_date | datetimeformat('YYYY-MM-dd HH:mm:ss') }}
```
## Python default

```
pub_date: 2016-01-13 01:02:03
```
## With timezone abbreviations

```
pub_date: 2016-01-13 01:02:03 EST
```
## With timezone name

```
pub_date: 2016-01-13 01:02:03 America/Dominica
```
## With timedelta

```
pub_date: 2016-01-13 01:02:03 +0900
```
