### PR TITLE
Allow extra values in [server] config.

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -278,7 +278,7 @@ def deploy_cmd(ctx, server, output_path, **credentials):
 
     try:
         event_iter = publish(env, server_info.target, output_path,
-                             credentials=credentials)
+                             credentials=credentials, server_info=server_info)
     except PublishError as e:
         raise click.UsageError('Server "%s" is not configured for a valid '
                                'publishing method: %s' % (server, e))

--- a/lektor/i18n.py
+++ b/lektor/i18n.py
@@ -50,16 +50,17 @@ def load_i18n_block(key):
     return rv
 
 
-def get_i18n_block(inifile_or_dict, key):
+def get_i18n_block(inifile_or_dict, key, pop=False):
     """Extracts an i18n block from an ini file or dictionary for a given
-    key.
+    key. If "pop", delete keys from "inifile_or_dict".
     """
     rv = {}
-    for k, v in inifile_or_dict.iteritems():
+    for k in list(inifile_or_dict):
         if k == key:
             # English is the internal default language with preferred
             # treatment.
-            rv['en'] = v
+            rv['en'] = inifile_or_dict.pop(k) if pop else inifile_or_dict[k]
         elif k.startswith(key + '['):
-            rv[k[len(key) + 1:-1]] = v
+            rv[k[len(key) + 1:-1]] = (inifile_or_dict.pop(k) if pop
+                                      else inifile_or_dict[k])
     return rv

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -614,9 +614,9 @@ builtin_publishers = {
 }
 
 
-def publish(env, target, output_path, credentials=None):
+def publish(env, target, output_path, credentials=None, **extra):
     url = urls.url_parse(unicode(target))
     publisher = env.publishers.get(url.scheme)
     if publisher is None:
         raise PublishError('"%s" is an unknown scheme.' % url.scheme)
-    return publisher(env, output_path).publish(url, credentials)
+    return publisher(env, output_path).publish(url, credentials, **extra)

--- a/tests/demo-project/Website.lektorproject
+++ b/tests/demo-project/Website.lektorproject
@@ -15,3 +15,5 @@ url_prefix = /de/
 enabled = yes
 name = Production
 target = rsync://myserver.com/path/to/website
+name[de] = Produktion
+extra_field = extra_value

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,6 @@
+def test_get_server(env):
+    server = env.load_config().get_server('production')
+    assert server.name == 'Production'
+    assert server.name_i18n['de'] == 'Produktion'
+    assert server.target == 'rsync://myserver.com/path/to/website'
+    assert server.extra == {'extra_field': 'extra_value'}


### PR DESCRIPTION
Makes it possible to add configuration for publisher plugins, besides just adding all the options to the target URL.
