### PR TITLE
Implemented relative URL processing for images in markdown.

### DIFF
--- a/lektor/markdown.py
+++ b/lektor/markdown.py
@@ -21,6 +21,14 @@ class ImprovedRenderer(mistune.Renderer):
                                           base_url=get_ctx().base_url)
         return mistune.Renderer.link(self, link, title, text)
 
+    def image(self, src, title, text):
+        if self.record is not None:
+            url = url_parse(src)
+            if not url.scheme:
+                src = self.record.url_to('!' + src,
+                                         base_url=get_ctx().base_url)
+        return mistune.Renderer.image(self, src, title, text)
+
 
 class MarkdownConfig(object):
 


### PR DESCRIPTION
With this patch I can get relative urls to images in markdown

for example if I have  and example article like this with an image:

```
content/articles/example/contents.lr
content/articles/example/picture.png
```

I can do this in `contents.lr`

``` markdown

---
body:

This is a text
![Image example](picture.png)
```
