### PR TITLE
Use pyftpsync for FTP support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Next feature release
   can be used by publishers to affect the processing.
 - The thumbnails will now always have the correct width and height set
   as an attribute.
+- Migrated FTP publisher to pyftpsync, an optional dependency.
 
 1.2
 ---

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -1,13 +1,9 @@
 import os
-import errno
 import select
 import shutil
-import hashlib
 import tempfile
-import posixpath
 import subprocess
 from contextlib import contextmanager
-from cStringIO import StringIO
 
 from werkzeug import urls
 
@@ -206,289 +202,36 @@ class RsyncPublisher(Publisher):
                     yield line
 
 
-class FtpConnection(object):
-
-    def __init__(self, url, credentials=None):
-        credentials = credentials or {}
-        self.con = self.make_connection()
-        self.url = url
-        self.username = credentials.get('username') or url.username
-        self.password = credentials.get('password') or url.password
-        self.log_buffer = []
-        self._known_folders = set()
-
-    def make_connection(self):
-        from ftplib import FTP
-        return FTP()
-
-    def drain_log(self):
-        log = self.log_buffer[:]
-        del self.log_buffer[:]
-        for chunk in log:
-            for line in chunk.splitlines():
-                if isinstance(line, str):
-                    line = line.decode('utf-8', 'replace')
-                yield line.rstrip()
-
-    def connect(self):
-        options = self.url.decode_query()
-
-        log = self.log_buffer
-        log.append('000 Connecting to server ...')
-        try:
-            log.append(self.con.connect(self.url.ascii_host,
-                                        self.url.port or 21))
-        except Exception as e:
-            log.append('000 Could not connect.')
-            log.append(str(e))
-            return False
-
-        try:
-            log.append(self.con.login(self.username.encode('utf-8'),
-                                      self.password.encode('utf-8')))
-        except Exception as e:
-            log.append('000 Could not authenticate.')
-            log.append(str(e))
-            return False
-
-        passive = options.get('passive') in ('on', 'yes', 'true', '1', None)
-        log.append('000 Using passive mode: %s' % (passive and 'yes' or 'no'))
-        self.con.set_pasv(passive)
-
-        try:
-            log.append(self.con.cwd(self.url.path.encode('utf-8')))
-        except Exception as e:
-            log.append(str(e))
-            return False
-
-        log.append('000 Connected!')
-        return True
-
-    def mkdir(self, path, recursive=True):
-        if isinstance(path, unicode):
-            path = path.encode('utf-8')
-        if path in self._known_folders:
-            return
-        dirname, basename = posixpath.split(path)
-        if dirname and recursive:
-            self.mkdir(dirname)
-        try:
-            self.con.mkd(path)
-        except Exception as e:
-            msg = str(e)
-            if msg[:4] != '550 ':
-                self.log_buffer.append(e)
-                return
-        self._known_folders.add(path)
-
-    def append(self, filename, data):
-        if isinstance(filename, unicode):
-            filename = filename.encode('utf-8')
-        input = StringIO(data)
-        try:
-            self.con.storbinary('APPE ' + filename, input)
-        except Exception as e:
-            self.log_buffer.append(str(e))
-            return False
-        return True
-
-    def get_file(self, filename, out=None):
-        if isinstance(filename, unicode):
-            filename = filename.encode('utf-8')
-        getvalue = False
-        if out is None:
-            out = StringIO()
-            getvalue = True
-        try:
-            self.con.retrbinary('RETR ' + filename, out.write)
-        except Exception as e:
-            msg = str(e)
-            if msg[:4] != '550 ':
-                self.log_buffer.append(e)
-            return None
-        if getvalue:
-            return out.getvalue()
-        return out
-
-    def upload_file(self, filename, src, mkdir=False):
-        if isinstance(src, basestring):
-            src = StringIO(src)
-        if mkdir:
-            directory = posixpath.dirname(filename)
-            if directory:
-                self.mkdir(directory, recursive=True)
-        if isinstance(filename, unicode):
-            filename = filename.encode('utf-8')
-        try:
-            self.con.storbinary('STOR ' + filename, src,
-                                blocksize=32768)
-        except Exception as e:
-            self.log_buffer.append(str(e))
-            return False
-        return True
-
-    def rename_file(self, src, dst):
-        try:
-            self.con.rename(src, dst)
-        except Exception as e:
-            self.log_buffer.append(str(e))
-            try:
-                self.con.delete(dst)
-            except Exception as e:
-                self.log_buffer.append(str(e))
-            try:
-                self.con.rename(src, dst)
-            except Exception as e:
-                self.log_buffer.append(str(e))
-
-    def delete_file(self, filename):
-        if isinstance(filename, unicode):
-            filename = filename.encode('utf-8')
-        try:
-            self.con.delete(filename)
-        except Exception as e:
-            self.log_buffer.append(str(e))
-
-    def delete_folder(self, filename):
-        if isinstance(filename, unicode):
-            filename = filename.encode('utf-8')
-        try:
-            self.con.rmd(filename)
-        except Exception as e:
-            self.log_buffer.append(str(e))
-        self._known_folders.discard(filename)
-
-
-class FtpTlsConnection(FtpConnection):
-
-    def make_connection(self):
-        from ftplib import FTP_TLS
-        return FTP_TLS()
-
-
 class FtpPublisher(Publisher):
-    connection_class = FtpConnection
 
-    def read_existing_artifacts(self, con):
-        contents = con.get_file('.lektor/listing')
-        if not contents:
-            return {}, set()
-        duplicates = set()
-        rv = {}
-        # Later records override earlier ones.  There can be duplicate
-        # entries if the file was not compressed.
-        for line in contents.splitlines():
-            items = line.split('|')
-            if len(items) == 2:
-                artifact_name = items[0].decode('utf-8')
-                if artifact_name in rv:
-                    duplicates.add(artifact_name)
-                rv[artifact_name] = items[1]
-        return rv, duplicates
-
-    def iter_artifacts(self):
-        """Iterates over all artifacts in the build folder and yields the
-        artifacts.
-        """
-        for dirpath, dirnames, filenames in os.walk(self.output_path):
-            dirnames[:] = [x for x in dirnames
-                           if not self.env.is_ignored_artifact(x)]
-            for filename in filenames:
-                if self.env.is_ignored_artifact(filename):
-                    continue
-                full_path = os.path.join(self.output_path, dirpath, filename)
-                local_path = full_path[len(self.output_path):] \
-                    .lstrip(os.path.sep)
-                if os.path.altsep:
-                    local_path = local_path.lstrip(os.path.altsep)
-                h = hashlib.sha1()
-                try:
-                    with open(full_path, 'rb') as f:
-                        while 1:
-                            item = f.read(4096)
-                            if not item:
-                                break
-                            h.update(item)
-                except IOError as e:
-                    if e.errno != errno.ENOENT:
-                        raise
-                yield (
-                    local_path.replace(os.path.sep, '/'),
-                    full_path,
-                    h.hexdigest(),
-                )
-
-    def get_temp_filename(self, filename):
-        dirname, basename = posixpath.split(filename)
-        return posixpath.join(dirname, '.' + basename + '.tmp')
-
-    def upload_artifact(self, con, artifact_name, source_file, checksum):
-        with open(source_file, 'rb') as source:
-            tmp_dst = self.get_temp_filename(artifact_name)
-            con.log_buffer.append('000 Updating %s' % artifact_name)
-            con.upload_file(tmp_dst, source, mkdir=True)
-            con.rename_file(tmp_dst, artifact_name)
-            con.append('.lektor/listing', '%s|%s\n' % (
-                artifact_name.encode('utf-8'), checksum
-            ))
-
-    def consolidate_listing(self, con, current_artifacts):
-        server_artifacts, duplicates = self.read_existing_artifacts(con)
-        known_folders = set()
-        for artifact_name in current_artifacts.iterkeys():
-            known_folders.add(posixpath.dirname(artifact_name))
-
-        for artifact_name, checksum in server_artifacts.iteritems():
-            if artifact_name not in current_artifacts:
-                con.log_buffer.append('000 Deleting %s' % artifact_name)
-                con.delete_file(artifact_name)
-                folder = posixpath.dirname(artifact_name)
-                if folder not in known_folders:
-                    con.log_buffer.append('000 Deleting %s' % folder)
-                    con.delete_folder(folder)
-
-        if duplicates or server_artifacts != current_artifacts:
-            listing = []
-            for artifact_name, checksum in current_artifacts.iteritems():
-                listing.append('%s|%s\n' % (artifact_name, checksum))
-            listing.sort()
-            con.upload_file('.lektor/.listing.tmp', ''.join(listing))
-            con.rename_file('.lektor/.listing.tmp', '.lektor/listing')
+    def make_target(self, url, credentials=None):
+        try:
+            from ftpsync.targets import make_target
+        except ImportError:
+            self.fail("Please install pyftpsync for FTP support.")
+        target = make_target(url.to_url())
+        if credentials:
+            username = credentials.get('username')
+            if username:
+                target.username = username
+            password = credentials.get('password')
+            if password:
+                target.password = password
+        return target
 
     def publish(self, target_url, credentials=None, **extra):
-        con = self.connection_class(target_url, credentials)
-        connected = con.connect()
-        for event in con.drain_log():
-            yield event
-        if not connected:
-            return
-
-        yield '000 Reading server state ...'
-        con.mkdir('.lektor')
-        committed_artifacts, _ = self.read_existing_artifacts(con)
-        for event in con.drain_log():
-            yield event
-
-        yield '000 Begin sync ...'
-        current_artifacts = {}
-        for artifact_name, filename, checksum in self.iter_artifacts():
-            current_artifacts[artifact_name] = checksum
-            if checksum != committed_artifacts.get(artifact_name):
-                self.upload_artifact(con, artifact_name, filename, checksum)
-                for event in con.drain_log():
-                    yield event
-        yield '000 Sync done!'
-
-        yield '000 Consolidating server state ...'
-        self.consolidate_listing(con, current_artifacts)
-        for event in con.drain_log():
-            yield event
-
-        yield '000 All done!'
-
-
-class FtpTlsPublisher(FtpPublisher):
-    connection_class = FtpTlsConnection
+        try:
+            from ftpsync.targets import FsTarget
+            from ftpsync.synchronizers import UploadSynchronizer
+        except ImportError:
+            self.fail("Please install pyftpsync for FTP support.")
+        local = FsTarget(self.output_path)
+        remote = self.make_target(target_url, credentials)
+        opts = {'dry_run': False, 'omit': '.lektor,.lektor/*'}
+        opts.update(extra)
+        sync = UploadSynchronizer(local, remote, opts)
+        sync.run()
+        return []  # ftpsync logs directly to stdout
 
 
 class GithubPagesPublisher(Publisher):
@@ -607,7 +350,7 @@ class GithubPagesPublisher(Publisher):
 builtin_publishers = {
     'rsync': RsyncPublisher,
     'ftp': FtpPublisher,
-    'ftps': FtpTlsPublisher,
+    'ftps': FtpPublisher,
     'ghpages': GithubPagesPublisher,
     'ghpages+https': GithubPagesPublisher,
     'ghpages+ssh': GithubPagesPublisher,

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
         'pip',
         'requests[security]',
     ],
+    extras_require={
+        'ftp': ['pyftpsync>=1.0.4'],
+    },
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
To improve FTP support, use pyftpsync, which is in turn receiving
support for FTPS (TLS) in mar10/pyftpsync#8.
This also fixes the lack of encryption on the FTP data channel.
For now, pyftpsync is specified as an optional dependency.
