### PR TITLE
Use TLS for FTPS data channel

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,7 @@ Release date to be decided
 - Fixed scrolling in the admin for firefox and some other browsers.
 - Fixed a problem with deleting large projects due to sqlite limitations.
 - Fixed admin preview of root page in firefox.
+- Changed FTPS data channel to use TLS.
 
 1.1
 ---

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -365,6 +365,13 @@ class FtpTlsConnection(FtpConnection):
         from ftplib import FTP_TLS
         return FTP_TLS()
 
+    def connect(self):
+        connected = super(FtpTlsConnection, self).connect(self)
+        if connected:
+            # Upgrade data connection to TLS.
+            self.con.prot_p()
+        return connected
+
 
 class FtpPublisher(Publisher):
     connection_class = FtpConnection


### PR DESCRIPTION
Need to explicitly ask for data channel encryption, refer
to Python documentation:
https://docs.python.org/2/library/ftplib.html#ftplib.FTP_TLS
