### PR TITLE
New option: _always_build.

### DIFF
--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -214,9 +214,9 @@ class DataModel(object):
 
     def __init__(self, env, id, name_i18n, label_i18n=None,
                  filename=None, hidden=None, protected=None,
-                 child_config=None, attachment_config=None,
-                 pagination_config=None, fields=None,
-                 primary_field=None, parent=None):
+                 always_build=None, child_config=None, 
+                 attachment_config=None, pagination_config=None, 
+                 fields=None, primary_field=None, parent=None):
         self.env = env
         self.filename = filename
         self.id = id
@@ -228,6 +228,9 @@ class DataModel(object):
         if protected is None:
             protected = False
         self.protected = protected
+        if always_build is None:
+            always_build = False
+        self.always_build = always_build
         if child_config is None:
             child_config = ChildConfig()
         self.child_config = child_config
@@ -443,6 +446,7 @@ def datamodel_data_from_ini(id, inifile):
         primary_field=inifile.get('model.primary_field'),
         hidden=inifile.get_bool('model.hidden', default=None),
         protected=inifile.get_bool('model.protected', default=None),
+        always_build=inifile.get_bool('model.always_build', default=False),
         child_config=dict(
             enabled=inifile.get_bool('children.enabled', default=None),
             slug_format=inifile.get('children.slug_format'),
@@ -526,6 +530,7 @@ def datamodel_from_data(env, model_data, parent=None):
         label_i18n=get_value('label_i18n'),
         hidden=get_value('hidden'),
         protected=get_value('protected'),
+        always_build=get_value('always_build'),
         child_config=ChildConfig(
             enabled=get_value('child_config.enabled'),
             slug_format=get_value('child_config.slug_format'),
@@ -680,3 +685,8 @@ add_system_field('_discoverable', type='boolean', default='yes',
 add_system_field('_attachment_for', type='string')
 add_system_field('_attachment_type', type='string',
                  label_i18n='ATTACHMENT_TYPE', addon_label='[[paperclip]]')
+
+# Always build this page even if nothing depends on it.
+add_system_field('_always_build', type='boolean', default='no',
+                 label_i18n='ALWAYS_BUILD',
+                 checkbox_label_i18n='ALWAYS_BUILD_EXPLANATION')

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -321,6 +321,11 @@ class Record(SourceObject):
         """Indicates if the page is discoverable without knowing the URL."""
         return self._data['_discoverable'] and not self.is_hidden
 
+    @property
+    def always_build(self):
+        """Always build this record, even if nothing depends on it."""
+        return self._data['_always_build']
+
     @cached_property
     def pagination(self):
         """Returns the pagination controller for the record."""
@@ -1372,6 +1377,11 @@ class Pad(object):
             rv = [self.root]
 
         rv.append(self.asset_root)
+
+        for child in self.root.children.include_undiscoverable(True):
+            if child.always_build or child.datamodel.always_build:
+                rv.append(child)
+
         return rv
 
     def get_virtual(self, record, virtual_path):

--- a/tests/always-build-option-project/Website.lektorproject
+++ b/tests/always-build-option-project/Website.lektorproject
@@ -1,0 +1,2 @@
+[site]
+name = Test Of always_build option

--- a/tests/always-build-option-project/content/always-build-model-record/contents.lr
+++ b/tests/always-build-option-project/content/always-build-model-record/contents.lr
@@ -1,0 +1,1 @@
+_model: always-build

--- a/tests/always-build-option-project/content/contents.lr
+++ b/tests/always-build-option-project/content/contents.lr
@@ -1,0 +1,1 @@
+_model: page

--- a/tests/always-build-option-project/content/hidden-page/contents.lr
+++ b/tests/always-build-option-project/content/hidden-page/contents.lr
@@ -1,0 +1,3 @@
+_model: page
+---
+_always_build: yes

--- a/tests/always-build-option-project/models/always-build.ini
+++ b/tests/always-build-option-project/models/always-build.ini
@@ -1,0 +1,3 @@
+[model]
+name = A model that is always built
+always_build = yes

--- a/tests/always-build-option-project/models/page.ini
+++ b/tests/always-build-option-project/models/page.ini
@@ -1,0 +1,7 @@
+[model]
+name = Page
+label = {{ this.title }}
+
+[pagination]
+enabled = yes
+items = this.children.filter(F._model == 'doesnt-exist')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,21 @@ def scratch_builder(request, scratch_pad):
     return make_builder(request, scratch_pad)
 
 
+# Builder for always-build-option-project, a project to test "_always_build".
+@pytest.fixture(scope='function')
+def always_build_builder(request):
+    from lektor.db import Database
+    from lektor.environment import Environment
+    from lektor.project import Project
+
+    project = Project.from_path(os.path.join(os.path.dirname(__file__),
+                                             'always-build-option-project'))
+    env = Environment(project)
+    pad = Database(env).new_pad()
+
+    return make_builder(request, pad)
+
+
 @pytest.fixture(scope='function')
 def F():
     from lektor.db import F

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -172,3 +172,17 @@ def test_asset_processing(pad, builder):
     with prog.artifacts[0].open('rb') as f:
         rv = f.read().decode('utf-8').strip()
         assert 'color: red' in rv
+
+
+def test_always_build_record(always_build_builder):
+    builder = always_build_builder
+    q = builder.get_initial_build_queue()
+    # hidden-page/contents.lr has "_always_build = yes".
+    assert builder.pad.get('hidden-page') in q
+
+
+def test_always_build_datamodel(always_build_builder):
+    builder = always_build_builder
+    q = builder.get_initial_build_queue()
+    # The datamodel always-build.ini has "always_build = yes".
+    assert builder.pad.get('always-build-model-record') in q


### PR DESCRIPTION
Ensure some artifacts are built even if nothing depends on them. For example, on my site, there is an Atom feed consumed by Planet Python but nothing on my site links to it. Or, if you have HTML redirect pages from old locations on your site, you want those built even though nothing refers to them on your own site.
