### PR TITLE
Fix bug in LektorInfo.resolve_artifact (fix #16)

### DIFF
--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask, request, abort
 from flask.helpers import safe_join
 from werkzeug.utils import append_slash_redirect
@@ -66,6 +68,11 @@ class LektorInfo(object):
 
         if filename is None:
             filename = safe_join(self.output_path, path.strip('/'))
+            if os.path.isdir(filename):
+                if os.path.isfile(safe_join(filename, 'index.html')):
+                    filename = safe_join(filename, 'index.html')
+                elif os.path.isfile(safe_join(filename, 'index.htm')):
+                    filename = safe_join(filename, 'index.htm')
 
         return artifact_name, filename
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,18 @@ def webui(request, env, pad):
     from lektor.admin.webui import WebUI
     output_path = tempfile.mkdtemp()
 
+    dir_have_index_html = os.path.join(output_path, 'dir_have_index_html')
+    os.mkdir(dir_have_index_html)
+    index_html = os.path.join(dir_have_index_html, 'index.html')
+    with open(index_html, 'w') as f:
+        f.write('<h1>It works!</h1>')
+
+    dir_have_index_htm = os.path.join(output_path, 'dir_have_index_htm')
+    os.mkdir(dir_have_index_htm)
+    index_htm = os.path.join(dir_have_index_htm, 'index.htm')
+    with open(index_htm, 'w') as f:
+        f.write('<h1>It works also!</h1>')
+
     def cleanup():
         try:
             shutil.rmtree(output_path)

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -41,3 +41,12 @@ def test_index_html(webui):
     assert resolve('/empty') == (None, artifact_path)
     artifact_path = os.path.join(info.output_path, 'doesnt_exist')
     assert resolve('/doesnt_exist') == (None, artifact_path)
+
+    # If givin artifact_path is dir and it have index.htm(l) file, resolve it.
+    artifact_path = os.path.join(info.output_path, 'dir_have_index_html',
+                                 'index.html')
+    assert resolve('/dir_have_index_html') == (None, artifact_path)
+
+    artifact_path = os.path.join(info.output_path, 'dir_have_index_htm',
+                                 'index.htm')
+    assert resolve('/dir_have_index_htm') == (None, artifact_path)


### PR DESCRIPTION
lektor.admin.webui.resolve_artifact must need path param.
But if given path is pagination dir, older method return None and cause 404.
My patch make to test filename for checking its type. If it is dir, method find index file in it and resolve it.
