### PR TITLE
Allow extra args to "lektor deploy".

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,7 +33,7 @@ Next feature release
 - Markdown processing now correctly adjusts links relative to where the
   rendered output is rendered.
 - Added Dutch translations.
-- Added Record.get_prev/next_sibling()
+- Added Record.get_siblings()
 - Added various utilties: build_url, join_path, parse_path
 - Added support for virtual paths and made pagination work with it.
 - Added support for Query.distinct

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -240,8 +240,9 @@ def clean_cmd(ctx, output_path, verbosity):
 @click.option('--key', envvar='LEKTOR_DEPLOY_KEY',
               help='The contents of a key file directly a string that should '
               'be used for authentication of the deployment.')
+@buildflag
 @pass_context
-def deploy_cmd(ctx, server, output_path, **credentials):
+def deploy_cmd(ctx, server, output_path, build_flags, **credentials):
     """This command deploys the entire contents of the build folder
     (`--output-path`) onto a configured remote server.  The name of the
     server must fit the name from a target in the project configuration.
@@ -278,7 +279,8 @@ def deploy_cmd(ctx, server, output_path, **credentials):
 
     try:
         event_iter = publish(env, server_info.target, output_path,
-                             credentials=credentials, server_info=server_info)
+                             credentials=credentials, server_info=server_info,
+                             build_flags=build_flags)
     except PublishError as e:
         raise click.UsageError('Server "%s" is not configured for a valid '
                                'publishing method: %s' % (server, e))


### PR DESCRIPTION
Allow extra args to "lektor deploy".

Publisher plugins can access them in click.get_current_context().args.
