### PR TITLE
Add medium editor

### DIFF
--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -24,6 +24,7 @@
     "react": "^0.14.1",
     "react-addons-update": "^0.14.1",
     "react-dom": "^0.14.1",
+    "react-medium-editor": "^1.6.2",
     "react-router": "^1.0.3",
     "style-loader": "^0.8.3",
     "webpack": "^1.7.2",

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -15,6 +15,7 @@ var i18n = require('./i18n');
 var widgetComponents = {
   'singleline-text': primitiveWidgets.SingleLineTextInputWidget,
   'multiline-text': primitiveWidgets.MultiLineTextInputWidget,
+  'wysiwyg': primitiveWidgets.WysiwygWidget,
   'datepicker': primitiveWidgets.DateInputWidget,
   'integer': primitiveWidgets.IntegerInputWidget,
   'float': primitiveWidgets.FloatInputWidget,

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -8,6 +8,8 @@ var i18n = require('../i18n');
 
 // required for medium editor
 var Editor = require('react-medium-editor');
+require('medium-editor/dist/css/medium-editor.css');
+require('medium-editor/dist/css/themes/default.css');
 
 function isTrue(value) {
   return value == 'true' || value == 'yes' || value == '1';

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -8,8 +8,6 @@ var i18n = require('../i18n');
 
 // required for medium editor
 var Editor = require('react-medium-editor');
-require('medium-editor/dist/css/medium-editor.css');
-require('medium-editor/dist/css/themes/default.css');
 
 function isTrue(value) {
   return value == 'true' || value == 'yes' || value == '1';

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -6,6 +6,9 @@ var utils = require('../utils');
 var userLabel = require('../userLabel');
 var i18n = require('../i18n');
 
+// required for medium editor
+var Editor = require('react-medium-editor');
+
 function isTrue(value) {
   return value == 'true' || value == 'yes' || value == '1';
 }
@@ -341,6 +344,27 @@ var BooleanInputWidget = React.createClass({
   }
 });
 
+var WysiwygWidget = React.createClass({
+  mixins: [BasicWidgetMixin],
+
+  onChange: function(value) {
+    if (this.postprocessValue) {
+      value = this.postprocessValue(value);
+    }
+    this.props.onChange(value);
+  },
+
+  render: function() {
+    return (
+      <div>
+        <Editor
+          text={this.props.value}
+          onChange={this.onChange ? this.onChange : undefined} />
+      </div>
+    )
+  }
+});
+
 module.exports = {
   SingleLineTextInputWidget: SingleLineTextInputWidget,
   SlugInputWidget: SlugInputWidget,
@@ -350,4 +374,5 @@ module.exports = {
   UrlInputWidget: UrlInputWidget,
   MultiLineTextInputWidget: MultiLineTextInputWidget,
   BooleanInputWidget: BooleanInputWidget,
+  WysiwygWidget: WysiwygWidget,
 };

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -1,13 +1,11 @@
 'use strict';
 
 var React = require('react');
+var Editor = require('react-medium-editor');
 var {BasicWidgetMixin, ValidationFailure} = require('./mixins');
 var utils = require('../utils');
 var userLabel = require('../userLabel');
 var i18n = require('../i18n');
-
-// required for medium editor
-var Editor = require('react-medium-editor');
 
 function isTrue(value) {
   return value == 'true' || value == 'yes' || value == '1';

--- a/lektor/admin/static/less/bootstrap-overrides.less
+++ b/lektor/admin/static/less/bootstrap-overrides.less
@@ -5,6 +5,10 @@
 // Font awesome
 @import "~font-awesome/less/font-awesome";
 
+// Medium editor
+@import "~medium-editor/dist/css/medium-editor.css";
+@import "~medium-editor/dist/css/themes/default.css";
+
 // Reset and dependencies
 @import "~bootstrap/less/normalize";
 @import "~bootstrap/less/print";

--- a/lektor/types/__init__.py
+++ b/lektor/types/__init__.py
@@ -94,7 +94,7 @@ class Type(object):
 
 from lektor.types.primitives import \
      StringType, StringsType, TextType, HtmlType, IntegerType, \
-     FloatType, BooleanType, DateType, DateTimeType
+     FloatType, BooleanType, DateType, DateTimeType, WysiwygType
 from lektor.types.multi import CheckboxesType, SelectType
 from lektor.types.special import SortKeyType, SlugType, UrlType
 from lektor.types.formats import MarkdownType
@@ -125,6 +125,7 @@ builtin_types = {
 
     # Formats
     'markdown': MarkdownType,
+    'wysiwyg': WysiwygType,
 
     # Flow
     'flow': FlowType,

--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -57,6 +57,10 @@ class HtmlType(Type):
         return Markup(raw.value)
 
 
+class WysiwygType(HtmlType):
+    widget = 'wysiwyg'
+
+
 class IntegerType(SingleInputType):
     widget = 'integer'
 


### PR DESCRIPTION
This PR adds the [react-medium-editor](http://wangzuo.github.io/react-medium-editor/) (React implementation of [this editor](https://yabwe.github.io/medium-editor/)). To see it in action, you need to change a field's `type` to `wsyiwyg`. I'm definitely open to other field name suggestions if you have them.
