### PR TITLE
Allow quickstart in current folder

### DIFF
--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -68,11 +68,13 @@ class Generator(object):
 
     @contextmanager
     def make_target_directory(self, path):
+        here = os.path.abspath(os.getcwd())
         path = os.path.abspath(path)
-        try:
-            os.makedirs(path)
-        except OSError as e:
-            self.abort('Could not create target folder: %s' % e)
+        if here != path:
+            try:
+                os.makedirs(path)
+            except OSError as e:
+                self.abort('Could not create target folder: %s' % e)
 
         if os.path.isdir(path):
             try:


### PR DESCRIPTION
Hello hello :) haven't even tried lektor yet but found a place which I feel needs to be improved :)
#### Why

When I want to start a new project I create a folder and go into it. Then I run wizard on that folder and it's very annoying when the wizard actually creates a subfolder in your shiny new folder. So this is how my dialog looked like:

```
Step 2:
| This is the path where the project will be located.  You can move a
| project around later if you do not like the path.  If you provide a
| relative path it will be relative to the working directory.
> Project Path [/Users/antares/project]: .
```

So I wanted to specify that I want magic to happen here and now. But it didn't work because it was always crashing on trying to create already existing folder. Now it's fixed.
#### Test cases

I tested different cases but didn't find any automated tests for that, could you please point me to them if any?

Cases I tested manually:

```
> Project Path [/Users/antares/project]: .
> Project Path [/Users/antares/project]: ./
> Project Path [/Users/antares/project]: ../project
```

```
lektor quickstart --path .
lektor quickstart --path ./
lektor quickstart --path ../project/
```
#### Things to know

The only side effect is that it will not accept if existing folder has any data in it. But I think it's perfectly fine, we need to have clear folder and we assume that if you say you want to start in CWD it means you just don't want us to create a folder for you.

Please let me know if you have any questions or comments. Thanks!
