### PR TITLE
Buglet: really pass current environment to command

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -110,7 +110,7 @@ class Command(object):
         environ = dict(os.environ)
         if env:
             environ.update(env)
-        kwargs = {'cwd': cwd, 'env': env}
+        kwargs = {'cwd': cwd, 'env': environ}
         if silent:
             kwargs['stdout'] = devnull
             kwargs['stderr'] = devnull


### PR DESCRIPTION
It looks like this was the intention all along, even though it wasn't really happening.

Without this fix, e.g., use of and `ssh-agent` for `rsync` authentication is broken (since this relies on `os.environ['SSH_AUTH_SOCK']`.)
