### PR TITLE
Data model’s [attachment]order_by is ignored.

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -872,7 +872,14 @@ class Query(object):
             return self._order_by
         base_record = self.pad.get(self.path)
         if base_record is not None:
-            return base_record.datamodel.child_config.order_by
+            if self._include_attachments and not self._include_pages:
+                return base_record.datamodel.attachment_config.order_by
+            elif self._include_pages and not self._include_attachments:
+                return base_record.datamodel.child_config.order_by
+            # Otherwise the query includes either both or neither
+            # attachments and/nor children.  I have no idea which
+            # value of order_by to use.  We could punt and return
+            # child_config.order_by, but for now, just return None.
 
     def include_hidden(self, value):
         """Controls if hidden records should be included which will not

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -242,3 +242,30 @@ def test_undefined_order(pad):
 
     ids = [c['_id'] for c in TestQuery('test', pad).order_by('-pub_date')]
     assert ['3', '2', '1', '4'] == ids
+
+
+def test_default_order_by(scratch_project, scratch_env):
+    from lektor.db import Database
+
+    tree = scratch_project.tree
+    with open(os.path.join(tree, 'models', 'mymodel.ini'), 'w') as f:
+        f.write(
+            '[children]\n'
+            'order_by = title\n'
+            '[attachments]\n'
+            'order_by = attachment_filename\n'
+            )
+    os.mkdir(os.path.join(tree, 'content', 'myobj'))
+    with open(os.path.join(tree, 'content', 'myobj', 'contents.lr'), 'w') as f:
+        f.write(
+            '_model: mymodel\n'
+            '---\n'
+            'title: My Test Object\n'
+            )
+
+    pad = Database(scratch_env).new_pad()
+    myobj = pad.get('/myobj')
+    children = myobj.children
+    assert list(children.get_order_by()) == ['title']
+    assert list(children.order_by('explicit').get_order_by()) == ['explicit']
+    assert list(myobj.attachments.get_order_by()) == ['attachment_filename']


### PR DESCRIPTION
Attachment queries currently use the sort order specified by the value of `order_by` in the `[children]` section of the data model’s `.ini` file.  They should instead use the value of `order_by` in the `[attachments]` section.  This fixes that.
