### PR TITLE
Fix ja.json translation of "UPLOAD"

### DIFF
--- a/lektor/translations/ja.json
+++ b/lektor/translations/ja.json
@@ -18,7 +18,7 @@
   "ATTACHMENTS": "アタッチメント",
   "ADD_ATTACHMENT_TO": "“%s”にアタッチメントを追加する",
   "ADD_ATTACHMENT_NOTE": "ここに新しいアタッチメントをアップロードできます",
-  "UPLOAD": "アンロード",
+  "UPLOAD": "アップロード",
   "PROGRESS": "プログレス",
   "ERROR_PREFIX": "エラー: ",
   "ERROR_NO_ID_PROVIDED": "IDがありません",


### PR DESCRIPTION
Current Japanese translation of "UPLOAD" is not correct. Meaning of that word is "Unload".
