### PR TITLE
--project argument supports paths starting with '~'

### DIFF
--- a/lektor/project.py
+++ b/lektor/project.py
@@ -41,7 +41,7 @@ class Project(object):
     @classmethod
     def from_path(cls, path, extension_required=False):
         """Locates the project for a path."""
-        path = os.path.abspath(path)
+        path = os.path.abspath(os.path.expanduser(path))
         if os.path.isfile(path) and (not extension_required or
                                      path.endswith('.lektorproject')):
             return cls.from_file(path)


### PR DESCRIPTION
It's handy to be able to specify paths
starting with '~' rather than having to supply
the full path to a project. This commit calls
os.path.expanduser when building a Project from a path,
which is safe because if the path cannot be expanded
then it is returned unaltered.

Prior to this commit, a path like the following:
lektor --project=~/Documents/code/my-blog server
Would raise this error:
Error: Could not find project "~/Documents/code/my-blog"
