### PR TITLE
changing url of the 'Visit Website' menu link in app

### DIFF
--- a/gui/static/js/app.jsx
+++ b/gui/static/js/app.jsx
@@ -304,7 +304,7 @@ class App extends Component {
           {
             label: i18n.trans('VISIT_WEBSITE'),
             click: () => {
-              shell.openExternal('http://www.github.com/mitsuhiko/lektor');
+              shell.openExternal('https://www.getlektor.com/');
             }
           }
         ]


### PR DESCRIPTION
Link in the app was pointing to archive repo, changed to https://www.getlektor.com/ 
