### PR TITLE
Maintain ordering of alternatives in environment

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -4,6 +4,7 @@ import os
 import re
 import uuid
 from functools import update_wrapper
+from collections import OrderedDict
 
 import jinja2
 from babel import dates
@@ -67,7 +68,7 @@ DEFAULT_CONFIG = {
         'url_style': 'relative',
     },
     'PACKAGES': {},
-    'ALTERNATIVES': {},
+    'ALTERNATIVES': OrderedDict(),
     'PRIMARY_ALTERNATIVE': None,
     'SERVERS': {},
 }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -41,12 +41,12 @@ def test_alt_fallback(pad):
     assert wolf_page['_source_alt'] == '_primary'
     assert wolf_page['name'] == 'Wolf'
 
-    # If we ask for the lats of that page, we will only get english
+    # If we ask for the alts of that page, we will only get english
     assert get_alts(wolf_page) == ['en']
 
-    # Unless we include fallbacks in which case we will also see english
+    # Unless we include fallbacks in which case we will also see german
     # show up in the list.
-    assert get_alts(wolf_page, fallback=True) == ['de', 'en']
+    assert get_alts(wolf_page, fallback=True) == ['en', 'de']
 
 
 def test_alt_parent(pad):
@@ -66,12 +66,12 @@ def test_url_matching_with_customized_slug_in_alt(pad):
     assert de['_source_alt'] == 'de'
     assert de.path == '/projects/slave'
 
-    assert get_alts(en) == ['de', 'en']
+    assert get_alts(en) == ['en', 'de']
 
 
 def test_basic_alts(pad):
     with Context(pad=pad):
-        assert get_alts() == ['de', 'en']
+        assert get_alts() == ['en', 'de']
 
 
 def test_basic_query_syntax(pad, F):


### PR DESCRIPTION
The environment file was populating a regular (unordered) Python dictionary with alternatives, and then the tests were asserting on the order of these alternatives via the `get_alts()` function. As a result, these tests were fragile: the order of the list could change at any time, and if it did, these tests would fail. In fact, the tests were asserting on an ordering that did not match the ordering in the `.lektorproject` file.

With this change, the ordering of the alternatives is maintained in the environment. The output of the `get_alts()` is consistent, and can be safely asserted on.
