### PR TITLE
If we don't have imagemagick available, skip tests that require it

### DIFF
--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,14 @@
+import pytest
+from lektor.imagetools import find_imagemagick
+
+
+try:
+    im_path = find_imagemagick()
+except RuntimeError:
+    im_path = None
+
+
+imagemagick = pytest.mark.skipif(
+    not im_path,
+    reason="imagemagick required but not found",
+)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,7 +1,11 @@
+from markers import imagemagick
+
+
 def get_child_sources(prog):
     return sorted(list(prog.iter_child_sources()), key=lambda x: x['_id'])
 
 
+@imagemagick
 def test_basic_build(pad, builder):
     root = pad.root
 


### PR DESCRIPTION
This change makes it easier to identify a test failure that is not actually due to a problem in the code.
