### PR TITLE
Customizable buildstate path

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -948,12 +948,16 @@ def process_build_flags(flags):
 
 class Builder(object):
 
-    def __init__(self, pad, destination_path, build_flags=None):
+    def __init__(self, pad, destination_path, buildstate_path=None,
+                 build_flags=None):
         self.build_flags = process_build_flags(build_flags)
         self.pad = pad
         self.destination_path = os.path.abspath(os.path.join(
             pad.db.env.root_path, destination_path))
-        self.meta_path = os.path.join(self.destination_path, '.lektor')
+        if buildstate_path:
+            self.meta_path = buildstate_path
+        else:
+            self.meta_path = os.path.join(self.destination_path, '.lektor')
         self.failure_controller = FailureController(pad, self.destination_path)
 
         try:

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -133,12 +133,16 @@ def cli(ctx, project=None, language=None):
               'source info is used by the web admin panel to quickly find '
               'information about the source files (for instance jump to '
               'files).')
+@click.option('--buildstate-path', type=click.Path(), default=None,
+              help='Path to a directory that Lektor will use for coordinating '
+              'the state of the build. Defaults to a directory named '
+              '`.lektor` inside the output path.')
 @buildflag
 @click.option('--profile', is_flag=True,
               help='Enable build profiler.')
 @pass_context
 def build_cmd(ctx, output_path, watch, prune, verbosity,
-              source_info_only, profile, build_flags):
+              source_info_only, buildstate_path, profile, build_flags):
     """Builds the entire project into the final artifacts.
 
     The default behavior is to build the project into the default build
@@ -168,6 +172,7 @@ def build_cmd(ctx, output_path, watch, prune, verbosity,
 
     def _build():
         builder = Builder(env.new_pad(), output_path,
+                          buildstate_path=buildstate_path,
                           build_flags=build_flags)
         if source_info_only:
             builder.update_all_source_infos()


### PR DESCRIPTION
SQLite has many documented problems on NFS filesystems, and it's best to avoid trying to use it on NFS. However, when using Lektor as a build server, it is useful to output to a NFS-mounted build volume. This pull request adds a `--buildstate-path` option that allows the user to specify a buildstate path that is different from the output path, to avoid hitting this problem.
