### PR TITLE
Fix serve crash with python3

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -18,7 +18,7 @@ bp = Blueprint('serve', __name__)
 def rewrite_html_for_editing(fp, edit_url):
     contents = fp.read()
 
-    button = b'''
+    button = '''
     <style type="text/css">
       #lektor-edit-link {
         position: fixed;
@@ -62,10 +62,10 @@ def rewrite_html_for_editing(fp, edit_url):
       })();
     </script>
     ''' % {
-        b'edit_url': edit_url.encode('utf-8'),
+        'edit_url': edit_url,
     }
 
-    return BytesIO(contents + button)
+    return BytesIO(contents + button.encode('utf-8'))
 
 
 def send_file(filename):


### PR DESCRIPTION
Hi,

`lektor server` crashes while serving the quickstart default app with python<3.5 because it cannot use % operand for a `bytes` string.

```
Traceback (most recent call last):
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 2000, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1991, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1567, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 149, in serve_artifact
    return serve_up_artifact(path)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 143, in serve_up_artifact
    return send_file(filename)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 89, in send_file
    edit_url=posixpath.join('/', request.script_root, 'admin/edit'))
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 65, in rewrite_html_for_editing
    b'edit_url': edit_url.encode('utf-8'),
TypeError: unsupported operand type(s) for %: 'bytes' and 'dict'
Traceback (most recent call last):
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 2000, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1991, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1567, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/emmanuel/projects/touilleman.xyz/venv/lib/python3.4/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 149, in serve_artifact
    return serve_up_artifact(path)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 143, in serve_up_artifact
    return send_file(filename)
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 89, in send_file
    edit_url=posixpath.join('/', request.script_root, 'admin/edit'))
  File "/home/emmanuel/projects/lektor/lektor/admin/modules/serve.py", line 65, in rewrite_html_for_editing
    b'edit_url': edit_url.encode('utf-8'),
TypeError: unsupported operand type(s) for %: 'bytes' and 'dict'
```
