### PR TITLE
Redirect to relative URLs

### DIFF
--- a/lektor/admin/modules/dash.py
+++ b/lektor/admin/modules/dash.py
@@ -36,7 +36,9 @@ def edit_redirect():
     path = fs_path_to_url_path(record.path.split('@')[0])
     if record.alt != PRIMARY_ALT:
         path += '+' + record.alt
-    return redirect(url_for('dash.edit', path=path))
+    response = redirect(url_for('dash.edit', path=path))
+    response.autocorrect_location_header = False
+    return response
 
 
 def generic_endpoint(**kwargs):


### PR DESCRIPTION
By changing the location header to be relative in this redirect, Lektor can be accessed from locations other than localhost. This fixes the otherwise broken edit link on the preview in such setups.
