### PR TITLE
Ask the user to enable JavaScript when disabled

### DIFF
--- a/lektor/admin/templates/dash.html
+++ b/lektor/admin/templates/dash.html
@@ -4,6 +4,7 @@
   <div id=dash>
     <div class=loadbox>
       <p>Loading Interface ...</p>
+      <noscript>You must enable JavaScript to use the editing interface.</noscript>
     </div>
   </div>
   <script type=text/javascript>


### PR DESCRIPTION
Some users turn off JavaScript by default. In this case, it is helpful to remind them of this limitation by displaying a message.
