### PR TITLE
Ignore dev-example suggested in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 dist
 venv
 lektor/admin/static/gen
+/dev-example
 
 node_modules
 gui/build


### PR DESCRIPTION
As the dev-example folder is suggested in the README for local testing it is nice to ignore this for convenience and to prevent developers from accidentally committing their example project.
