### PR TITLE
Correct Py3 encoding issue for GitHub publisher

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -544,7 +544,7 @@ class GithubPagesPublisher(Publisher):
 
     def update_git_config(self, repo, url, branch, credentials=None):
         ssh_command = None
-        path = (url.host + u'/' + url.path.strip(u'/')).encode('utf-8')
+        path = url.host + u'/' + url.path.strip(u'/')
         cred = None
         if url.scheme in ('ghpages', 'ghpages+ssh'):
             push_url = 'git@github.com:%s.git' % path

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,6 +1,26 @@
+import textwrap
+from lektor.publisher import GithubPagesPublisher
+from werkzeug.urls import url_parse
+
 def test_get_server(env):
     server = env.load_config().get_server('production')
     assert server.name == 'Production'
     assert server.name_i18n['de'] == 'Produktion'
     assert server.target == 'rsync://myserver.com/path/to/website'
     assert server.extra == {'extra_field': 'extra_value'}
+
+
+def test_ghpages_update_git_config(tmpdir, env):
+    output_path = tmpdir.mkdir("output")
+    publisher = GithubPagesPublisher(env, str(output_path))
+    repo_path = tmpdir.mkdir("repo")
+    repo_config = repo_path.mkdir(".git").join("config").ensure(file=True)
+    target_url = url_parse("ghpages://user/repo")
+    branch = "master"
+    publisher.update_git_config(str(repo_path), target_url, branch)
+    expected = textwrap.dedent("""
+        [remote "origin"]
+        url = git@github.com:user/repo.git
+        fetch = +refs/heads/master:refs/remotes/origin/master
+    """).strip()
+    assert repo_config.read().strip() == expected


### PR DESCRIPTION
Before this change, the `.git/config` file would contain a line that looked like this: `url = git@github.com:b'user/repo'.git`. After this change, it works correctly.
