### PR TITLE
Add `.git` to the end of the ghpages+https URL

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -553,7 +553,7 @@ class GithubPagesPublisher(Publisher):
             if keyfile or url.port:
                 ssh_command = _get_ssh_cmd(url.port, keyfile)
         else:
-            push_url = 'https://github.com/%s' % path
+            push_url = 'https://github.com/%s.git' % path
             cred = self.get_credentials(url, credentials)
 
         with open(os.path.join(repo, '.git', 'config'), 'a') as f:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -24,3 +24,19 @@ def test_ghpages_update_git_config(tmpdir, env):
         fetch = +refs/heads/master:refs/remotes/origin/master
     """).strip()
     assert repo_config.read().strip() == expected
+
+
+def test_ghpages_update_git_config_https(tmpdir, env):
+    output_path = tmpdir.mkdir("output")
+    publisher = GithubPagesPublisher(env, str(output_path))
+    repo_path = tmpdir.mkdir("repo")
+    repo_config = repo_path.mkdir(".git").join("config").ensure(file=True)
+    target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
+    branch = "lektor"
+    publisher.update_git_config(str(repo_path), target_url, branch)
+    expected = textwrap.dedent("""
+        [remote "origin"]
+        url = https://github.com/pybee/pybee.github.io.git
+        fetch = +refs/heads/lektor:refs/remotes/origin/lektor
+    """).strip()
+    assert repo_config.read().strip() == expected


### PR DESCRIPTION
This fixes a problem that @pybee and others have had when trying to deploy to a `ghpages+https` URL. Apparently the `.git` was getting left off the URL, which meant that Git couldn't find the repository, which caused everything to fail. @mitsuhiko, can you review this?

To build against this branch on Travis CI, edit your `.travis.yml` file to change this line:

```
install: "pip install lektor"
```

to this line:

```
install: "pip install git+https://github.com/singingwolfboy/lektor.git@fix-ghpages-https-deploy#egg=lektor"
```

Note that once this pull request is merged, I will probably delete this branch from my fork of the repo. When that happens, that `install` line will fail, but you'll be able to replace `singingwolfboy/lektor` with `lektor/lektor` and remove `@fix-ghpages-https-deploy` from the URL.
