### PR TITLE
Added pagination properties for first and last

### DIFF
--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -67,6 +67,34 @@ class Pagination(object):
         return self.config.get_record_for_page(self.current,
                                                self.page + 1)
 
+    @property
+    def first_num(self):
+        """Number of the first page"""
+        num = list(range_type(1, self.pages + 1))
+        return min(num)
+
+    @property
+    def last_num(self):
+        """Number of the last page"""
+        num = list(range_type(1, self.pages + 1))
+        return max(num)
+
+    @property
+    def first_page(self):
+        """Returns the record for first page of pagination"""
+        if self.pages == 0:
+            return None
+        else:
+            return self.config.get_record_for_page(self.current, self.first_num)
+
+    @property
+    def last_page(self):
+        """Reutrns the record for last page of pagination"""
+        if self.pages == 0:
+            return None
+        else:
+            return self.config.get_record_for_page(self.current, self.last_num)
+
     def for_page(self, page):
         """Returns the pagination for a specific page."""
         if 1 <= page <= self.pages:


### PR DESCRIPTION
I added pagination properties for first page and last page, these can useful for First and Last links for pagination such as

`<a href="{{ pagination.last_page|url }}"> Last page </a>`

This is my very first pull request and I'm a beginner! but I believe these could be useful shortcuts for templates. I would like to attempt making the same effect for siblings and children pages but that takes a bit more poking around and understanding.
