### PR TITLE
added first_page and last_page pagination

### DIFF
--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -67,6 +67,34 @@ class Pagination(object):
         return self.config.get_record_for_page(self.current,
                                                self.page + 1)
 
+    @property
+    def first_num(self):
+        """Number of the first page"""
+        num = list(range_type(1, self.pages + 1))
+        return min(num)
+
+    @property
+    def last_num(self):
+        """Number of the last page"""
+        num = list(range_type(1, self.pages + 1))
+        return max(num)
+
+    @property
+    def first_page(self):
+        """Returns the record for first page of pagination"""
+        if self.pages == 0:
+            return None
+        else:
+            return self.config.get_record_for_page(self.current, self.first_num)
+
+    @property
+    def last_page(self):
+        """Reutrns the record for last page of pagination"""
+        if self.pages == 0:
+            return None
+        else:
+            return self.config.get_record_for_page(self.current, self.last_num)
+
     def for_page(self, page):
         """Returns the pagination for a specific page."""
         if 1 <= page <= self.pages:


### PR DESCRIPTION
Accidently deleted my original branch (relearning git)

Reopening PR for first_page and last_page pagination properties.

first_num and last_num pull an int value of first page and last page respectively
first_page and last_page pull the record of those pages resepectivly and can be used in template such as

 `<a href="{{ this.pagination.last_page|url }}"> Last Page </a>`

Now i'm a beginner and it could use some refined checks for edge cases but i know it at least provides a functional base..

I would also like propose adding these to the siblings option in a form if we can.
