### PR TITLE
Fix updating attachment_types config from ini file

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -93,12 +93,9 @@ def update_config_from_ini(config, inifile):
     set_simple(target='LESSC_EXECUTABLE',
                source_path='env.lessc_executable')
 
-    config['ATTACHMENT_TYPES'].update(
-        (k.encode('ascii', 'replace'), v.encode('ascii', 'replace'))
-        for k, v in iteritems(inifile.section_as_dict('attachment_types')))
-
-    config['PROJECT'].update(inifile.section_as_dict('project'))
-    config['PACKAGES'].update(inifile.section_as_dict('packages'))
+    for section_name in ('ATTACHMENT_TYPES', 'PROJECT', 'PACKAGES'):
+        section_config = inifile.section_as_dict(section_name.lower())
+        config[section_name].update(section_config)
 
     for sect in inifile.sections():
         if sect.startswith('servers.'):

--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -95,7 +95,7 @@ def update_config_from_ini(config, inifile):
 
     config['ATTACHMENT_TYPES'].update(
         (k.encode('ascii', 'replace'), v.encode('ascii', 'replace'))
-        for k, v in inifile.section_as_dict('attachment_types'))
+        for k, v in iteritems(inifile.section_as_dict('attachment_types')))
 
     config['PROJECT'].update(inifile.section_as_dict('project'))
     config['PACKAGES'].update(inifile.section_as_dict('packages'))

--- a/tests/demo-project/Website.lektorproject
+++ b/tests/demo-project/Website.lektorproject
@@ -21,4 +21,4 @@ name[de] = Produktion
 extra_field = extra_value
 
 [attachment_types]
-.md = text
+.foo = text

--- a/tests/demo-project/Website.lektorproject
+++ b/tests/demo-project/Website.lektorproject
@@ -19,3 +19,6 @@ name = Production
 target = rsync://myserver.com/path/to/website
 name[de] = Produktion
 extra_field = extra_value
+
+[attachment_types]
+.md = text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,3 @@
+def test_custom_attachment_types(env):
+    attachment_types = env.load_config().values['ATTACHMENT_TYPES']
+    assert attachment_types['.md'] == 'text'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,3 @@
 def test_custom_attachment_types(env):
     attachment_types = env.load_config().values['ATTACHMENT_TYPES']
-    assert attachment_types['.md'] == 'text'
+    assert attachment_types['.foo'] == 'text'


### PR DESCRIPTION
I saw there is some code that checks the project config for additional attachment types and adds them to the ones from the default config. So I added this to my `.lektorproject` file:

``` ini
[attachment_types]
.mp4 = video
```

Unfortunately it didn't work but gave me this error:

```
…
File "/usr/local/lib/lektor/lib/python2.7/site-packages/lektor/environment.py", line 98, in <genexpr>
    for k, v in inifile.section_as_dict('attachment_types'))
ValueError: too many values to unpack
```

This commit fixes this by using `iteritems()` for the section dict.
