### PR TITLE
Shift cache to local appdata on Windows

### DIFF
--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -625,9 +625,11 @@ def get_app_dir():
 
 def get_cache_dir():
     if is_windows:
-        folder = os.environ.get('APPDATA')
+        folder = os.environ.get('LOCALAPPDATA')
         if folder is None:
-            folder = os.path.expanduser('~')
+            folder = os.environ.get('APPDATA')
+            if folder is None:
+                folder = os.path.expanduser('~')
         return os.path.join(folder, 'Lektor', 'Cache')
     if sys.platform == 'darwin':
         return os.path.join(os.path.expanduser('~/Library/Caches/Lektor'))


### PR DESCRIPTION
Lektor has been storing its cache in the roaming app data directory (`%APPDATA%`, typically `C:\Users\username\AppData\Roaming` but quite possibly on a remote machine, either genuinely living on another machine or uploaded when you log out and synchronised again when you log in).

For Vista and later, this is not appropriate; the local app data directory (`%LOCALAPPDATA%`, typically `C:\Users\username\AppData\Local` and defined as not being on a remote machine) is where it should be instead, because it is machine-specific (for example, two machines may have different versions of Python, or different architectures).

APPDATA remains as a fallback before ~, because XP won’t have LOCALAPPDATA set.
