### PR TITLE
Use dest_path if file is moved. Fixes #261.

### DIFF
--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -2,7 +2,7 @@ import os
 import time
 
 from watchdog.observers import Observer
-from watchdog.events import FileSystemEventHandler, DirModifiedEvent
+from watchdog.events import FileSystemEventHandler, DirModifiedEvent, FileMovedEvent
 
 from lektor._compat import queue
 
@@ -22,7 +22,8 @@ class EventHandler(FileSystemEventHandler):
 
     def on_any_event(self, event):
         if not isinstance(event, DirModifiedEvent):
-            item = (time.time(), event.event_type, event.src_path)
+            path = event.dest_path if isinstance(event, FileMovedEvent) else event.src_path
+            item = (time.time(), event.event_type, path)
             if self.queue is not None:
                 self.queue.put(item)
             else:


### PR DESCRIPTION
Use the `dest_path` value from `FileMovedEvent` class instances so changes will not be ignored.

Fixes #261.
