### PR TITLE
Use pytest tmpdir fixture more in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,132 +1,115 @@
 import os
 import pwd
 import pytest
-import shutil
 import subprocess
-import tempfile
+import textwrap
 
 
 @pytest.fixture(scope='function')
-def project(request):
+def project():
     from lektor.project import Project
     return Project.from_path(os.path.join(os.path.dirname(__file__),
                                           'demo-project'))
 
 
 @pytest.fixture(scope='function')
-def scratch_project(request):
-    base = tempfile.mkdtemp()
-    with open(os.path.join(base, 'Scratch.lektorproject'), 'w') as f:
-        f.write(
-            '[project]\n'
-            'name = Scratch\n\n'
-            '[alternatives.en]\n'
-            'primary = yes\n'
-            '[alternatives.de]\n'
-            'url_prefix = /de/\n'
-        )
+def scratch_project(tmpdir):
+    base = tmpdir.mkdir("scratch-proj")
+    lektorfile_text = textwrap.dedent(u"""
+        [project]
+        name = Scratch
 
-    os.mkdir(os.path.join(base, 'content'))
-    with open(os.path.join(base, 'content', 'contents.lr'), 'w') as f:
-        f.write(
-            '_model: page\n'
-            '---\n'
-            'title: Index\n'
-            '---\n'
-            'body: Hello World!\n'
-        )
-    os.mkdir(os.path.join(base, 'templates'))
-    with open(os.path.join(base, 'templates', 'page.html'), 'w') as f:
-        f.write('<h1>{{ this.title }}</h1>\n{{ this.body }}\n')
-    os.mkdir(os.path.join(base, 'models'))
-    with open(os.path.join(base, 'models', 'page.ini'), 'w') as f:
-        f.write(
-            '[model]\n'
-            'label = {{ this.title }}\n\n'
-            '[fields.title]\n'
-            'type = string\n'
-            '[fields.body]\n'
-            'type = markdown\n'
-        )
+        [alternatives.en]
+        primary = yes
+        [alternatives.de]
+        url_prefix = /de/
+    """)
+    base.join("Scratch.lektorproject").write_text(lektorfile_text, "utf8", ensure=True)
+    content_text = textwrap.dedent(u"""
+        _model: page
+        ---
+        title: Index
+        ---
+        body: Hello World!
+    """)
+    base.join("content", "contents.lr").write_text(content_text, "utf8", ensure=True)
+    template_text = textwrap.dedent(u"""
+        <h1>{{ this.title }}</h1>
+        {{ this.body }}
+    """)
+    base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
+    model_text = textwrap.dedent(u"""
+        [model]
+        label = {{ this.title }}
 
-    def cleanup():
-        try:
-            shutil.rmtree(base)
-        except (OSError, IOError):
-            pass
-    request.addfinalizer(cleanup)
+        [fields.title]
+        type = string
+        [fields.body]
+        type = markdown
+    """)
+    base.join("models", "page.ini").write_text(model_text, "utf8", ensure=True)
 
     from lektor.project import Project
-    return Project.from_path(base)
+    return Project.from_path(str(base))
 
 
 @pytest.fixture(scope='function')
-def env(request, project):
+def env(project):
     from lektor.environment import Environment
     return Environment(project)
 
 
 @pytest.fixture(scope='function')
-def scratch_env(request, scratch_project):
+def scratch_env(scratch_project):
     from lektor.environment import Environment
     return Environment(scratch_project)
 
 
 @pytest.fixture(scope='function')
-def pad(request, env):
+def pad(env):
     from lektor.db import Database
     return Database(env).new_pad()
 
 
 @pytest.fixture(scope='function')
-def scratch_pad(request, scratch_env):
+def scratch_pad(scratch_env):
     from lektor.db import Database
     return Database(scratch_env).new_pad()
 
 
 @pytest.fixture(scope='function')
-def scratch_tree(request, scratch_pad):
+def scratch_tree(scratch_pad):
     from lektor.db import Tree
     return Tree(scratch_pad)
 
 
-def make_builder(request, pad):
+@pytest.fixture(scope='function')
+def builder(tmpdir, pad):
     from lektor.builder import Builder
-    out = tempfile.mkdtemp()
-    builder = Builder(pad, out)
-    def cleanup():
-        try:
-            shutil.rmtree(out)
-        except (OSError, IOError):
-            pass
-    request.addfinalizer(cleanup)
-    return builder
+    return Builder(pad, str(tmpdir.mkdir("output")))
 
 
 @pytest.fixture(scope='function')
-def builder(request, pad):
-    return make_builder(request, pad)
-
-
-@pytest.fixture(scope='function')
-def scratch_builder(request, scratch_pad):
-    return make_builder(request, scratch_pad)
+def scratch_builder(tmpdir, scratch_pad):
+    from lektor.builder import Builder
+    return Builder(scratch_pad, str(tmpdir.mkdir("output")))
 
 
 # Builder for child-sources-test-project, a project to test that child sources
 # are built even if they're filtered out by a pagination query.
 @pytest.fixture(scope='function')
-def child_sources_test_project_builder(request):
+def child_sources_test_project_builder(tmpdir):
     from lektor.db import Database
     from lektor.environment import Environment
     from lektor.project import Project
+    from lektor.builder import Builder
 
     project = Project.from_path(os.path.join(os.path.dirname(__file__),
                                              'child-sources-test-project'))
     env = Environment(project)
     pad = Database(env).new_pad()
 
-    return make_builder(request, pad)
+    return Builder(pad, str(tmpdir.mkdir("output")))
 
 
 @pytest.fixture(scope='function')
@@ -154,18 +137,9 @@ def reporter(request, env):
 
 
 @pytest.fixture(scope='function')
-def webui(request, env, pad):
+def webui(tmpdir, env):
     from lektor.admin.webui import WebUI
-    output_path = tempfile.mkdtemp()
-
-    def cleanup():
-        try:
-            shutil.rmtree(output_path)
-        except (OSError, IOError):
-            pass
-    request.addfinalizer(cleanup)
-
-    return WebUI(env, output_path=output_path)
+    return WebUI(env, output_path=str(tmpdir.mkdir("webui")))
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_prev_next_sibling.py
+++ b/tests/test_prev_next_sibling.py
@@ -3,7 +3,6 @@ import shutil
 
 import pytest
 
-from conftest import make_builder
 from lektor.builder import Builder
 from lektor.reporter import Reporter
 
@@ -55,9 +54,9 @@ def pntest_reporter(request, pntest_env):
     return reporter
 
 
-def test_prev_next_dependencies(request, pntest_env, pntest_reporter):
+def test_prev_next_dependencies(request, tmpdir, pntest_env, pntest_reporter):
     env, reporter = pntest_env, pntest_reporter
-    builder = make_builder(request, env.new_pad())
+    builder = Builder(env.new_pad(), str(tmpdir.mkdir("output")))
     builder.build_all()
 
     # We start with posts 1, 2, and 4. Posts 1 and 2 depend on each other,

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,10 +1,8 @@
 # coding: utf-8
 import os
-import shutil
-import tempfile
 
 
-def get_unicode_builder():
+def get_unicode_builder(tmpdir):
     from lektor.project import Project
     from lektor.environment import Environment
     from lektor.db import Database
@@ -15,34 +13,27 @@ def get_unicode_builder():
     env = Environment(proj)
     pad = Database(env).new_pad()
 
-    out = tempfile.mkdtemp()
-    return pad, Builder(pad, out)
+    return pad, Builder(pad, str(tmpdir.mkdir('output')))
 
 
-def test_unicode_project_folder():
-    pad, builder = get_unicode_builder()
-    try:
-        prog, _ = builder.build(pad.root)
-        with prog.artifacts[0].open('rb') as f:
-            assert f.read() == b'<h1>Hello</h1>\n<p>W\xc3\xb6rld</p>\n\n'
-    finally:
-        shutil.rmtree(builder.destination_path)
+def test_unicode_project_folder(tmpdir):
+    pad, builder = get_unicode_builder(tmpdir)
+    prog, _ = builder.build(pad.root)
+    with prog.artifacts[0].open('rb') as f:
+        assert f.read() == b'<h1>Hello</h1>\n<p>W\xc3\xb6rld</p>\n\n'
 
 
-def test_bad_file_ignored():
+def test_bad_file_ignored(tmpdir):
     from lektor.reporter import BufferReporter
     from lektor.build_programs import BuildError
 
-    pad, builder = get_unicode_builder()
-    try:
-        record = pad.root.children.first()
-        with BufferReporter(builder.env) as reporter:
-            prog, _ = builder.build(record)
-            failures = reporter.get_failures()
-            assert len(failures) == 1
-            exc_info = failures[0]['exc_info']
-            assert exc_info[0] is BuildError
-            assert 'The URL for this record contains non ' \
-                'ASCII characters' in exc_info[1].message
-    finally:
-        shutil.rmtree(builder.destination_path)
+    pad, builder = get_unicode_builder(tmpdir)
+    record = pad.root.children.first()
+    with BufferReporter(builder.env) as reporter:
+        prog, _ = builder.build(record)
+        failures = reporter.get_failures()
+        assert len(failures) == 1
+        exc_info = failures[0]['exc_info']
+        assert exc_info[0] is BuildError
+        assert 'The URL for this record contains non ' \
+            'ASCII characters' in exc_info[1].message


### PR DESCRIPTION
The [tmpdir](http://doc.pytest.org/en/latest/tmpdir.html) fixture for pytest is really nice: it makes the code more concise and clearer. @mitsuhiko, are you OK with changing the tests like this?
