### PR TITLE
Make Created At correspond to actual creation date and add Modified At.

### DIFF
--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -165,6 +165,15 @@ class EXIFInfo(object):
     @property
     def created_at(self):
         try:
+            print(self._mapping)
+            return datetime.strptime(self._mapping['EXIF DateTimeOriginal'].printable,
+                                     '%Y:%m:%d %H:%M:%S')
+        except (KeyError, ValueError):
+            return None
+
+    @property
+    def modified_at(self):
+        try:
             return datetime.strptime(self._mapping['Image DateTime'].printable,
                                      '%Y:%m:%d %H:%M:%S')
         except (KeyError, ValueError):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -22,6 +22,7 @@ def test_exif(pad):
     assert image.exif.camera_model == 'iPhone 6'
     assert image.exif.copyright is None
     assert image.exif.created_at == datetime(2015, 12, 6, 11, 37, 34)
+    assert image.exif.modified_at == datetime(2015, 12, 6, 11, 37, 34)
     assert image.exif.exposure_time == '1/33'
     assert image.exif.f == u'\u0192/2.2'
     assert almost_equal(image.exif.f_num, 2.2)


### PR DESCRIPTION
I noticed that the created_at image item didn't seem to correspond to the actual date the photograph was taken, so I modified the property to use the correct EXIF field. I also added a modified_at item.
