### PR TITLE
refactor url error handling for publishing targets

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -291,8 +291,7 @@ def deploy_cmd(ctx, server, output_path, **credentials):
         event_iter = publish(env, server_info.target, output_path,
                              credentials=credentials, server_info=server_info)
     except PublishError as e:
-        raise click.UsageError('Server "%s" is not configured for a valid '
-                               'publishing method: %s' % (server, e))
+        raise click.UsageError('%s' % e)
 
     click.echo('Deploying to %s' % server_info.name)
     click.echo('  Build cache: %s' % output_path)

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -658,7 +658,7 @@ def publish(env, target, output_path, credentials=None, **extra):
     url = urls.url_parse(text_type(target))
     publisher = env.publishers.get(url.scheme)
     if url.host is None:
-        raise PublishError('missing host name')
+        raise PublishError(('Publishing target does not have a host name: %s' % target))
     if publisher is None:
         raise PublishError('Server "%s" is not configured for a valid '
             'publishing method: %s is an unknown scheme.' % (url.host, url.scheme))

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -657,6 +657,9 @@ builtin_publishers = {
 def publish(env, target, output_path, credentials=None, **extra):
     url = urls.url_parse(text_type(target))
     publisher = env.publishers.get(url.scheme)
+    if url.host is None:
+        raise PublishError('missing host name')
     if publisher is None:
-        raise PublishError('"%s" is an unknown scheme.' % url.scheme)
+        raise PublishError('Server "%s" is not configured for a valid '
+            'publishing method: %s is an unknown scheme.' % (url.host, url.scheme))
     return publisher(env, output_path).publish(url, credentials, **extra)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,7 +2,6 @@ import textwrap
 from lektor.publisher import GithubPagesPublisher, RsyncPublisher, publish
 from werkzeug.urls import url_parse
 import pytest
-import re
 
 
 def test_get_server(env):
@@ -97,11 +96,12 @@ def test_rsync_command_username_in_url(tmpdir, mocker, env):
 def test_publish_target_url_error_handling(tmpdir, mocker, env):
     output_path = tmpdir.mkdir("output")
     target_url = None
-    publisher = None
-    mocked_publish = mocker.patch("lektor.publisher.publish")
-    with pytest.raises(Exception) as mocked_publish:   
-        raise Exception('PublishError: Publishing target does not have a host name: ')   
-    assert "target does not have a host name" in mocked_publish.value.message
+    publisher = GithubPagesPublisher(env, str(output_path))
+    
+    with pytest.raises(Exception) as exception_info:
+        mocked_publish = mocker.patch("lektor.publisher.publish")   
+        raise Exception('PublishError: Publishing target does not have a host name: ')
+    assert 'Publishing target does not have a host name: ' in str(exception_info._excinfo[1]) 
 
 
 def test_publisher_error_handling(tmpdir, mocker, env):
@@ -109,6 +109,7 @@ def test_publisher_error_handling(tmpdir, mocker, env):
     target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
     publisher = None
     mocked_publish = mocker.patch("lektor.publisher.publish")
-    with pytest.raises(Exception) as mocked_publish:   
+    with pytest.raises(Exception) as exception_info:   
         raise Exception('Server "%s" is not configured for a valid publishing method')
-    assert 'is not configured for a valid' in mocked_publish.value.message 
+    assert 'Server "%s" is not configured for a valid publishing method' in\
+             str(exception_info._excinfo[1]) 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,6 +1,8 @@
 import textwrap
-from lektor.publisher import GithubPagesPublisher, RsyncPublisher
+from lektor.publisher import GithubPagesPublisher, RsyncPublisher, publish
 from werkzeug.urls import url_parse
+import pytest
+
 
 def test_get_server(env):
     server = env.load_config().get_server('production')
@@ -89,3 +91,23 @@ def test_rsync_command_username_in_url(tmpdir, mocker, env):
         str(output_path) + '/',
         'fakeuser@example.com:/'
     ],)
+
+
+def test_publish_target_url_error_handling(tmpdir, mocker, env):
+    output_path = tmpdir.mkdir("output")
+    target_url = None
+    # publisher = None
+    mocked_publish = mocker.patch("lektor.publisher.publish")
+    with pytest.raises(Exception) as mocked_publish:   
+        raise Exception('PublishError: Publishing target does not have a host name: ')   
+    assert mocked_publish.value.message == 'PublishError: Publishing target does not have a host name: ' 
+    # assert mock_publish == "PublishError: Publishing target does not have a host name: None"
+
+def test_publisher_error_handling(tmpdir, mocker, env):
+    output_path = tmpdir.mkdir("output")
+    target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
+    publisher = None
+    mocked_publish = mocker.patch("lektor.publisher.publish")
+    with pytest.raises(Exception) as mocked_publish:   
+        raise Exception('Server "%s" is not configured for a valid '
+            'publishing method: %s is an unknown scheme.' % (mocked_publish.url.host, mocked_publish.url.scheme))   

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,6 +2,7 @@ import textwrap
 from lektor.publisher import GithubPagesPublisher, RsyncPublisher, publish
 from werkzeug.urls import url_parse
 import pytest
+import re
 
 
 def test_get_server(env):
@@ -96,12 +97,12 @@ def test_rsync_command_username_in_url(tmpdir, mocker, env):
 def test_publish_target_url_error_handling(tmpdir, mocker, env):
     output_path = tmpdir.mkdir("output")
     target_url = None
-    # publisher = None
+    publisher = None
     mocked_publish = mocker.patch("lektor.publisher.publish")
     with pytest.raises(Exception) as mocked_publish:   
         raise Exception('PublishError: Publishing target does not have a host name: ')   
-    assert mocked_publish.value.message == 'PublishError: Publishing target does not have a host name: ' 
-    # assert mock_publish == "PublishError: Publishing target does not have a host name: None"
+    assert "target does not have a host name" in mocked_publish.value.message
+
 
 def test_publisher_error_handling(tmpdir, mocker, env):
     output_path = tmpdir.mkdir("output")
@@ -109,5 +110,5 @@ def test_publisher_error_handling(tmpdir, mocker, env):
     publisher = None
     mocked_publish = mocker.patch("lektor.publisher.publish")
     with pytest.raises(Exception) as mocked_publish:   
-        raise Exception('Server "%s" is not configured for a valid '
-            'publishing method: %s is an unknown scheme.' % (mocked_publish.url.host, mocked_publish.url.scheme))   
+        raise Exception('Server "%s" is not configured for a valid publishing method')
+    assert 'is not configured for a valid' in mocked_publish.value.message 


### PR DESCRIPTION
This PR resolves issue #286, It generalizes the 

```
raise PublishError('Server "%s" is not configured for a valid '
            'publishing method: %s is an unknown scheme.' % (url.host, url.scheme))
```

in cli.py to apply to all of the various publisher targets 
