### PR TITLE
gitignore project name in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 dist
 venv
 lektor/admin/static/gen
+example-project
 
 node_modules
 gui/build

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ . venv/bin/activate
 $ pip install --editable .
 $ make build-js
 $ export LEKTOR_DEV=1
-$ lektor quickstart --path dev-example
-$ lektor --project dev-example server
+$ lektor quickstart --path example-project
+$ lektor --project example-project server
 ```
 
 If you want to run the test suite instead:


### PR DESCRIPTION
So that developers don't accidentally commit their sample project. Replacement for #232.
