### PR TITLE
Ignore the cache directory when watching for changes

### DIFF
--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -5,6 +5,7 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, DirModifiedEvent, FileMovedEvent
 
 from lektor._compat import queue
+from lektor.utils import get_cache_dir
 
 # Alias this as this can be called during interpreter shutdown
 _Empty = queue.Empty
@@ -60,12 +61,16 @@ class Watcher(BasicWatcher):
         BasicWatcher.__init__(self, paths=[env.root_path])
         self.env = env
         self.output_path = output_path
+        self.cache_dir = os.path.abspath(get_cache_dir())
 
     def is_interesting(self, time, event_type, path):
+        path = os.path.abspath(path)
+
         if self.env.is_uninteresting_source_name(os.path.basename(path)):
             return False
-        if self.output_path is not None and \
-           os.path.abspath(path).startswith(self.output_path):
+        if path.startswith(self.cache_dir):
+            return False
+        if self.output_path is not None and path.startswith(self.output_path):
             return False
         return True
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,23 @@
+import py.path
+import functools
+
+from lektor import utils
+from lektor import watcher
+
+
+def test_is_interesting(env):
+    cache_dir = py.path.local(utils.get_cache_dir())
+    build_dir = py.path.local("build")
+
+    w = watcher.Watcher(env, str(build_dir))
+
+    # This partial makes the testing code shorter
+    is_interesting = functools.partial(w.is_interesting, 0, "generic")
+
+    assert is_interesting("a.file")
+    assert not is_interesting(".file")
+    assert not is_interesting(str(cache_dir / "another.file"))
+    assert not is_interesting(str(build_dir / "output.file"))
+
+    w.output_path = None
+    assert is_interesting(str(build_dir / "output.file"))


### PR DESCRIPTION
In my setup I have the lektor cache directory in a subfolder of the project (changed with the `$XDG_CACHE_HOME` environment variable here in linux), but since `lektor server` writes in that directory after each build, when I start the development server lektor starts spamming empty builds, without stopping.

This patch tweaks the watcher to ignore events from the cache directory Lektor uses.
