### PR TITLE
Switch to codecov-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,14 @@ before_install:
 
 install:
   - travis_retry pip install --upgrade pytest
+  - travis_retry pip install --upgrade codecov
   - travis_retry pip install --editable .[test]
   - travis_retry make build-js
 
 script: make coverage
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - codecov
 
 notifications:
   webhooks:


### PR DESCRIPTION
@singingwolfboy This should get codecov reporting properly. I'm not entirely sure why, but I'm not seeing errors using codecov-python. It seems like it should work properly the way it was originally, but there may be an issue with codecov-bash.