### PR TITLE
Allow extra flags for `lektor deploy`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ These are all the changes in Lektor since the first public release.
 ---
 
 - Switch to newer mistune (markdown parser).
+- Rename `--build-flags` to `--extra-flags`, allow the deploy command to also
+  accept extra flags.
 
 2.4
 ---

--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -11,12 +11,12 @@ from lektor.reporter import CliReporter
 
 class LektorInfo(object):
 
-    def __init__(self, env, output_path, ui_lang='en', build_flags=None,
+    def __init__(self, env, output_path, ui_lang='en', extra_flags=None,
                  verbosity=0):
         self.env = env
         self.ui_lang = ui_lang
         self.output_path = output_path
-        self.build_flags = build_flags
+        self.extra_flags = extra_flags
         self.verbosity = verbosity
 
     def get_pad(self):
@@ -25,7 +25,7 @@ class LektorInfo(object):
     def get_builder(self, pad=None):
         if pad is None:
             pad = self.get_pad()
-        return Builder(pad, self.output_path, build_flags=self.build_flags)
+        return Builder(pad, self.output_path, extra_flags=self.extra_flags)
 
     def get_failure_controller(self, pad=None):
         if pad is None:
@@ -73,10 +73,10 @@ class LektorInfo(object):
 class WebUI(Flask):
 
     def __init__(self, env, debug=False, output_path=None, ui_lang='en',
-                 verbosity=0, build_flags=None):
+                 verbosity=0, extra_flags=None):
         Flask.__init__(self, 'lektor.admin', static_url_path='/admin/static')
         self.lektor_info = LektorInfo(env, output_path, ui_lang,
-                                      build_flags=build_flags,
+                                      extra_flags=extra_flags,
                                       verbosity=verbosity)
         self.debug = debug
         self.config['PROPAGATE_EXCEPTIONS'] = True

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -934,7 +934,7 @@ class PathCache(object):
         return rv
 
 
-def process_build_flags(flags):
+def process_extra_flags(flags):
     if isinstance(flags, dict):
         return flags
     rv = {}
@@ -950,8 +950,8 @@ def process_build_flags(flags):
 class Builder(object):
 
     def __init__(self, pad, destination_path, buildstate_path=None,
-                 build_flags=None):
-        self.build_flags = process_build_flags(build_flags)
+                 extra_flags=None):
+        self.extra_flags = process_extra_flags(extra_flags)
         self.pad = pad
         self.destination_path = os.path.abspath(os.path.join(
             pad.db.env.root_path, destination_path))

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ tests_require = [
     'pytest',
     'pytest-cov',
     'pytest-mock',
+    'pytest-click',
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pwd
 import pytest
+import shutil
 import subprocess
 import textwrap
 
@@ -171,3 +172,18 @@ def git_user_email(request):
     email = "lektortest@example.com"
     subprocess.check_call(['git', 'config', 'user.email', email])
     return email
+
+
+@pytest.fixture(scope='function')
+def project_cli_runner(isolated_cli_runner, project):
+    """
+    Copy the project files into the isolated file system used by the
+    Click test runner.
+    """
+    for entry in os.listdir(project.tree):
+        entry_path = os.path.join(project.tree, entry)
+        if os.path.isdir(entry_path):
+            shutil.copytree(entry_path, entry)
+        else:
+            shutil.copy2(entry_path, entry)
+    return isolated_cli_runner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+import re
+import shutil
+from lektor.cli import cli
+
+
+def test_build_no_project(isolated_cli_runner):
+    result = isolated_cli_runner.invoke(cli, ["build"])
+    assert result.exit_code == 2
+    assert "Could not automatically discover project." in result.output
+
+
+def test_build(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["build"])
+    assert result.exit_code == 0
+    start_matches = re.findall(r"Started build", result.output)
+    assert len(start_matches) == 1
+    finish_matches = re.findall(r"Finished build in \d+\.\d{2} sec", result.output)
+    assert len(finish_matches) == 1
+
+
+def test_build_extra_flag(project_cli_runner, mocker):
+    mock_builder = mocker.patch('lektor.builder.Builder')
+    mock_builder.return_value.build_all.return_value = 0
+    result = project_cli_runner.invoke(cli, ["build", "-f", "webpack"])
+    assert result.exit_code == 0
+    assert mock_builder.call_args[1]["extra_flags"] == ("webpack",)
+    assert 'use --extra-flag instead of --build-flag' not in result.output
+
+
+def test_deprecated_build_flag(project_cli_runner, mocker):
+    mock_builder = mocker.patch('lektor.builder.Builder')
+    mock_builder.return_value.build_all.return_value = 0
+    result = project_cli_runner.invoke(cli, ["build", "--build-flag", "webpack"])
+    assert result.exit_code == 0
+    assert mock_builder.call_args[1]["extra_flags"] == ("webpack",)
+    assert 'use --extra-flag instead of --build-flag' in result.output
+
+
+def test_deploy_extra_flag(project_cli_runner, mocker):
+    mock_publish = mocker.patch('lektor.publisher.publish')
+    result = project_cli_runner.invoke(cli, ["deploy", "-f", "draft"])
+    assert result.exit_code == 0
+    assert mock_publish.call_args[1]["extra_flags"] == ("draft",)


### PR DESCRIPTION
Replacement for #138. This pull request deprecates the `--build-flag` option, and introduces a new `--extra-flag` option to replace it. This pull request also allows the `deploy` command to also accept extra flags. I've also added some basic tests for the Click CLI to cover this change.