### PR TITLE
Restore the about page in the example project

### DIFF
--- a/example/content/about/contents.lr
+++ b/example/content/about/contents.lr
@@ -1,0 +1,7 @@
+title: About this Website
+---
+body:
+
+This is a website that was made with the Lektor quickstart.
+
+And it does not contain a lot of information.


### PR DESCRIPTION
It looks like the about page in the example project was accidentally removed in commit 7cab136c3cbd36c0413db5e83f2c9e355dac1ff7. This PR restores the missing page.