### PR TITLE
Set sqlite isolation level to autocommit

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -984,6 +984,7 @@ class Builder(object):
 
     def connect_to_database(self):
         con = sqlite3.connect(self.buildstate_database_filename,
+                              isolation_level=None,
                               timeout=10, check_same_thread=False)
         if PY2:
             # This code block solve lektor/lektor#243 issue


### PR DESCRIPTION
Python 3.6 no longer implicitly commits an open transaction before DDL statements, which causes PRAGMA statements to throw an exception. Setting the isolation_level to None fixes this issue.