### PR TITLE
Make GH Pages branch detection case-insensitive

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -606,10 +606,7 @@ class GithubPagesPublisher(Publisher):
             with open(os.path.join(path, 'CNAME'), 'w') as f:
                 f.write('%s\n' % cname)
 
-    def publish(self, target_url, credentials=None, **extra):
-        if not locate_executable('git'):
-            self.fail('git executable not found; cannot deploy.')
-
+    def detect_target_branch(self, target_url):
         # When pushing to the username.github.io repo we need to push to
         # master, otherwise to gh-pages
         if (target_url.host.lower() + '.github.io' ==
@@ -617,6 +614,13 @@ class GithubPagesPublisher(Publisher):
             branch = 'master'
         else:
             branch = 'gh-pages'
+        return branch
+
+    def publish(self, target_url, credentials=None, **extra):
+        if not locate_executable('git'):
+            self.fail('git executable not found; cannot deploy.')
+
+        branch = self.detect_target_branch(target_url)
 
         with _temporary_folder(self.env) as path:
             ssh_command = None

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -612,7 +612,8 @@ class GithubPagesPublisher(Publisher):
 
         # When pushing to the username.github.io repo we need to push to
         # master, otherwise to gh-pages
-        if target_url.host + '.github.io' == target_url.path.strip('/'):
+        if (target_url.host.lower() + '.github.io' ==
+                target_url.path.strip('/').lower()):
             branch = 'master'
         else:
             branch = 'gh-pages'

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -50,6 +50,30 @@ def test_ghpages_write_cname(tmpdir, env):
     assert (output_path / 'CNAME').read() == "pybee.org\n"
 
 
+def test_ghpages_detect_branch_username(tmpdir, env):
+    output_path = tmpdir.mkdir('output')
+    publisher = GithubPagesPublisher(env, str(output_path))
+    target_url = url_parse('ghpages+https://MacDownApp/MacDownApp.github.io')
+    branch = publisher.detect_target_branch(target_url)
+    assert branch == 'master'
+
+
+def test_ghpages_detect_branch_username_case_insensitive(tmpdir, env):
+    output_path = tmpdir.mkdir('output')
+    publisher = GithubPagesPublisher(env, str(output_path))
+    target_url = url_parse('ghpages+https://MacDownApp/macdownapp.github.io')
+    branch = publisher.detect_target_branch(target_url)
+    assert branch == 'master'
+
+
+def test_ghpages_detect_branch_project(tmpdir, env):
+    output_path = tmpdir.mkdir('output')
+    publisher = GithubPagesPublisher(env, str(output_path))
+    target_url = url_parse('ghpages+https://MacDownApp/MacDownApp.github.io/macdown')
+    branch = publisher.detect_target_branch(target_url)
+    assert branch == 'gh-pages'
+
+
 def test_rsync_command(tmpdir, mocker, env):
     output_path = tmpdir.mkdir("output")
     publisher = RsyncPublisher(env, str(output_path))


### PR DESCRIPTION
GitHub usernames (and org names) are case-insensitive, and for a user named Foo the user page's URL would be normalized to <foo.github.io>. This patch mimics this behavior by converting both target_url's host and path to lowercase before comparing.