### PR TITLE
ES6 module import syntax. Fixes #347

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build-js
 build-js:
 	@echo "---> building static files"
 	@cd lektor/admin; npm install .
-	@cd lektor/admin/static; ../node_modules/.bin/webpack
+	@cd lektor/admin; npm run webpack
 
 pex:
 	virtualenv pex-build-cache

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -40,7 +40,8 @@
   },
   "scripts": {
     "test": "nyc mocha static/js/**/*.test.js",
-    "report-coverage": "nyc report --reporter=lcov > coverage.lcov"
+    "report-coverage": "nyc report --reporter=lcov > coverage.lcov",
+    "webpack": "webpack --config ./static/webpack.config.js --context ./static"
   },
   "babel": {
     "presets": [

--- a/lektor/admin/static/js/components/BaseComponent.jsx
+++ b/lektor/admin/static/js/components/BaseComponent.jsx
@@ -5,7 +5,7 @@
 
 'use strict'
 
-import React from 'react'
+import React from 'react';
 
 
 class BaseComponent extends React.Component {
@@ -21,6 +21,7 @@ class BaseComponent extends React.Component {
 
   componentWillReceiveProps(nextProps) {
   }
+
 }
 
-export default BaseComponent
+export default BaseComponent;

--- a/lektor/admin/static/js/components/BreadCrumbs.jsx
+++ b/lektor/admin/static/js/components/BreadCrumbs.jsx
@@ -9,7 +9,7 @@ import dialogSystem from '../dialogSystem'
 import FindFiles from '../dialogs/findFiles'
 import Publish from '../dialogs/publish'
 import Refresh from '../dialogs/Refresh'
-
+import makeRichPromise from '../richPromise';
 
 class BreadCrumbs extends RecordComponent {
 
@@ -47,7 +47,7 @@ class BreadCrumbs extends RecordComponent {
       return;
     }
 
-    utils.loadData('/pathinfo', {path: path})
+    utils.loadData('/pathinfo', {path: path}, null, makeRichPromise)
       .then((resp) => {
         this.setState({
           recordPathInfo: {
@@ -70,7 +70,7 @@ class BreadCrumbs extends RecordComponent {
     utils.loadData('/previewinfo', {
       path: this.getRecordPath(),
       alt: this.getRecordAlt()
-    })
+    }, null, makeRichPromise)
     .then((resp) => {
       if (resp.url === null) {
         window.location.href = utils.getCanonicalUrl('/');

--- a/lektor/admin/static/js/components/DialogSlot.jsx
+++ b/lektor/admin/static/js/components/DialogSlot.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Router from "react-router"
 import Component from '../components/Component'
 import dialogSystem from '../dialogSystem'
-import {DialogChangedEvent} from '../events'
+import { DialogChangedEvent } from '../events'
 import hub from '../hub'
 
 
@@ -66,4 +66,4 @@ class DialogSlot extends Component {
   }
 }
 
-export default DialogSlot
+export default DialogSlot;

--- a/lektor/admin/static/js/components/Link.jsx
+++ b/lektor/admin/static/js/components/Link.jsx
@@ -1,11 +1,11 @@
 'use strict'
 
-import React from 'react'
-import ReactRouter from 'react-router'
-import Component from './Component'
+import React from 'react';
+import { Link } from 'react-router';
+import Component from './Component';
 
 
-class Link extends Component {
+class LektorLink extends Component {
 
   render() {
     let path = this.props.to;
@@ -13,16 +13,16 @@ class Link extends Component {
       path = $LEKTOR_CONFIG.admin_root + '/' + path;
     }
     return (
-      <ReactRouter.Link to={path} activeClassName="active">
+      <Link to={path} activeClassName="active">
         {this.props.children}
-      </ReactRouter.Link>
+      </Link>
     );
   }
 }
 
-Link.propTypes = {
+LektorLink.propTypes = {
   to: React.PropTypes.string
-}
+};
 
 
-module.exports = Link
+module.exports = LektorLink;

--- a/lektor/admin/static/js/components/ServerStatus.jsx
+++ b/lektor/admin/static/js/components/ServerStatus.jsx
@@ -5,7 +5,7 @@ import Router from "react-router";
 import Component from '../components/Component';
 import utils from '../utils';
 import i18n from '../i18n';
-
+import makeRichPromise from '../richPromise';
 
 class ServerStatus extends Component {
 
@@ -34,7 +34,7 @@ class ServerStatus extends Component {
   }
 
   onInterval() {
-    utils.loadData('/ping')
+    utils.loadData('/ping', {}, null, makeRichPromise)
       .then((resp) => {
         if (this.state.projectId === null) {
           this.setState({

--- a/lektor/admin/static/js/components/Sidebar.jsx
+++ b/lektor/admin/static/js/components/Sidebar.jsx
@@ -151,7 +151,7 @@ class Sidebar extends RecordComponent {
     utils.apiRequest('/browsefs', {data: {
       path: this.getRecordPath(),
       alt: this.getRecordAlt()
-    }, method: 'POST'})
+    }, method: 'POST'}, makeRichPromise)
       .then((resp) => {
         if (!resp.okay) {
           alert(i18n.trans('ERROR_CANNOT_BROWSE_FS'));

--- a/lektor/admin/static/js/components/Sidebar.jsx
+++ b/lektor/admin/static/js/components/Sidebar.jsx
@@ -7,7 +7,7 @@ import hub from '../hub'
 import {AttachmentsChangedEvent} from '../events'
 import RecordComponent from './RecordComponent'
 import Link from '../components/Link'
-
+import makeRichPromise from '../richPromise';
 
 function getBrowseButtonTitle() {
   const platform = utils.getPlatform();
@@ -118,7 +118,7 @@ class Sidebar extends RecordComponent {
     this.setState({
       lastRecordRequest: path,
     }, () => {
-      utils.loadData('/recordinfo', {path: path})
+      utils.loadData('/recordinfo', {path: path}, null, makeRichPromise)
         .then((resp) => {
           // we're already fetching something else.
           if (path !== this.state.lastRecordRequest) {

--- a/lektor/admin/static/js/components/SlideDialog.jsx
+++ b/lektor/admin/static/js/components/SlideDialog.jsx
@@ -43,9 +43,16 @@ class SlideDialog extends Component {
     return (
       <div className={className} {...props}>
         <div className="col-md-6 col-md-offset-4">
-          {hasCloseButton}
-            <a href="#" className="close-btn" onClick={
-              this._onCloseClick.bind(this)}>{i18n.trans('CLOSE')}</a> : null}
+          {
+            hasCloseButton &&
+            <a
+                href="#"
+                className="close-btn"
+                onClick={this._onCloseClick.bind(this)}
+            >
+                { i18n.trans('CLOSE') }
+            </a>
+          }
           <h3>{title}</h3>
           {children}
         </div>

--- a/lektor/admin/static/js/dialogs/Refresh.jsx
+++ b/lektor/admin/static/js/dialogs/Refresh.jsx
@@ -6,6 +6,7 @@ import SlideDialog from '../components/SlideDialog'
 import utils from '../utils'
 import i18n from '../i18n'
 import dialogSystem from '../dialogSystem'
+import makeRichPromise from '../richPromise';
 
 
 class Refresh extends Component {
@@ -37,7 +38,7 @@ class Refresh extends Component {
     });
     utils.apiRequest('/clean', {
       method: 'POST'
-    }).then((resp) => {
+    }, makeRichPromise).then((resp) => {
       this.setState({
         currentState: 'DONE'
       })

--- a/lektor/admin/static/js/dialogs/findFiles.jsx
+++ b/lektor/admin/static/js/dialogs/findFiles.jsx
@@ -1,14 +1,13 @@
 'use strict'
 
-import React from 'react'
-import Router from 'react-router'
-var {Link, RouteHandler} = Router
+import React from 'react';
+import { Link, RouteHandler } from 'react-router';
 
-import RecordComponent from '../components/RecordComponent'
-import SlideDialog from '../components/SlideDialog'
-import utils from '../utils'
-import i18n from '../i18n'
-import dialogSystem from '../dialogSystem'
+import RecordComponent from '../components/RecordComponent';
+import SlideDialog from '../components/SlideDialog';
+import utils from '../utils';
+import i18n from '../i18n';
+import dialogSystem from '../dialogSystem';
 
 class FindFiles extends RecordComponent {
 

--- a/lektor/admin/static/js/dialogs/findFiles.jsx
+++ b/lektor/admin/static/js/dialogs/findFiles.jsx
@@ -8,6 +8,7 @@ import SlideDialog from '../components/SlideDialog';
 import utils from '../utils';
 import i18n from '../i18n';
 import dialogSystem from '../dialogSystem';
+import makeRichPromise from '../richPromise';
 
 class FindFiles extends RecordComponent {
 
@@ -46,7 +47,7 @@ class FindFiles extends RecordComponent {
           lang: i18n.currentLanguage
         },
         method: 'POST'
-      }).then((resp) => {
+      }, makeRichPromise).then((resp) => {
         this.setState({
           results: resp.results,
           currentSelection: Math.min(this.state.currentSelection,

--- a/lektor/admin/static/js/dialogs/publish.jsx
+++ b/lektor/admin/static/js/dialogs/publish.jsx
@@ -6,7 +6,7 @@ import SlideDialog from '../components/SlideDialog'
 import utils from '../utils'
 import i18n from '../i18n'
 import dialogSystem from '../dialogSystem'
-
+import makeRichPromise from '../richPromise';
 
 class Publish extends Component {
 
@@ -39,12 +39,14 @@ class Publish extends Component {
   }
 
   syncDialog() {
-    utils.loadData('/servers')
-      .then((resp) => {
+    utils.loadData('/servers', {}, null, makeRichPromise)
+      .then(({ servers }) => {
         this.setState({
-          servers: resp.servers,
-          activeTarget: resp.servers[0].id
-        })
+          servers: servers,
+          activeTarget: servers && servers.length
+                     ?  servers[0].id
+                      : null
+        });
       });
   }
 
@@ -106,7 +108,7 @@ class Publish extends Component {
   componentDidUpdate() {
     super.componentDidUpdate();
     const node = this.refs.log;
-    if (node !== null) {
+    if (node) {
       node.scrollTop = node.scrollHeight;
     }
   }
@@ -142,11 +144,16 @@ class Publish extends Component {
         <p>{i18n.trans('PUBLISH_NOTE')}</p>
         <dl>
           <dt>{i18n.trans('PUBLISH_SERVER')}</dt>
-          <dd><div className="input-group">
-            <select value={this.state.activeTarget}
-              onChange={this.onSelectServer.bind(this)}
-              className="form-control">{servers}</select>
-          </div></dd>
+          <dd>
+              <div className="input-group">
+                  <select
+                      value={this.state.activeTarget}
+                      onChange={this.onSelectServer.bind(this)}
+                      className="form-control">
+                      {servers}
+                  </select>
+              </div>
+          </dd>
         </dl>
         <div className="actions">
           <button type="submit" className="btn btn-primary"
@@ -163,4 +170,4 @@ class Publish extends Component {
   }
 }
 
-export default Publish
+export default Publish;

--- a/lektor/admin/static/js/dialogs/publish.jsx
+++ b/lektor/admin/static/js/dialogs/publish.jsx
@@ -72,7 +72,7 @@ class Publish extends Component {
     });
     utils.apiRequest('/build', {
       method: 'POST'
-    }).then((resp) => {
+    }, makeRichPromise).then((resp) => {
       this._beginPublish();
     });
   }

--- a/lektor/admin/static/js/events.jsx
+++ b/lektor/admin/static/js/events.jsx
@@ -1,7 +1,6 @@
 'use strict'
 
-import React from 'react'
-
+import React from 'react';
 
 class Event {
 
@@ -51,9 +50,9 @@ class DialogChangedEvent extends Event {
 }
 
 
-export default {
-  Event: Event,
-  RecordEvent: RecordEvent,
-  AttachmentsChangedEvent: AttachmentsChangedEvent,
-  DialogChangedEvent: DialogChangedEvent,
-}
+export {
+  Event,
+  RecordEvent,
+  AttachmentsChangedEvent,
+  DialogChangedEvent
+};

--- a/lektor/admin/static/js/main.jsx
+++ b/lektor/admin/static/js/main.jsx
@@ -1,20 +1,29 @@
 'use strict';
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var {Router, Route, IndexRoute} = require('react-router');
-var Component = require('./components/Component');
-var i18n = require('./i18n');
-var {useBeforeUnload} = require('history');
-var createBrowserHistory = require('history/lib/createBrowserHistory');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Router, Route, IndexRoute} from 'react-router';
+import Component from './components/Component';
+import i18n from './i18n';
+import {useBeforeUnload} from 'history';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
 
-require('bootstrap');
-require('./bootstrap-extras');
-require('font-awesome/css/font-awesome.css');
+import Bootstrap from 'bootstrap';
+import BootstrapExtras from './bootstrap-extras';
+import FACss from 'font-awesome/css/font-awesome.css';
 
 // polyfill for internet explorer
-require('native-promise-only');
-require('event-source-polyfill');
+import PromiseOnly from 'native-promise-only';
+import EventSource from 'event-source-polyfill';
+
+// route targets
+import App from './views/App';
+import Dash from './views/Dash';
+import EditPage from './views/EditPage';
+import DeletePage from './views/DeletePage';
+import PreviewPage from './views/PreviewPage';
+import AddChildPage from './views/AddChildPage';
+import AddAttachmentPage from './views/AddAttachmentPage';
 
 i18n.currentLanguage = $LEKTOR_CONFIG.lang;
 
@@ -35,15 +44,6 @@ BadRoute.contextTypes = {
 };
 
 var routes = (function() {
-  // route targets
-  var App = require('./views/App');
-  var Dash = require('./views/Dash');
-  var EditPage = require('./views/EditPage');
-  var DeletePage = require('./views/DeletePage');
-  var PreviewPage = require('./views/PreviewPage');
-  var AddChildPage = require('./views/AddChildPage');
-  var AddAttachmentPage = require('./views/AddAttachmentPage');
-
   // route setup
   return (
     <Route name="app" path={$LEKTOR_CONFIG.admin_root} component={App}>
@@ -58,7 +58,8 @@ var routes = (function() {
   );
 })();
 
-var dash = document.getElementById('dash')
+var dash = document.getElementById('dash');
+
 if (dash) {
   ReactDOM.render((
     <Router history={useBeforeUnload(createBrowserHistory)()}>

--- a/lektor/admin/static/js/richPromise.jsx
+++ b/lektor/admin/static/js/richPromise.jsx
@@ -1,7 +1,8 @@
+import ErrorDialog from './dialogs/errorDialog';
+import dialogSystem from './dialogSystem';
+
 function bringUpDialog(error) {
   // we need to import this here due to circular dependencies
-  const ErrorDialog = require('./dialogs/errorDialog')
-  const dialogSystem = require('./dialogSystem')
   if (!dialogSystem.dialogIsOpen()) {
     dialogSystem.showDialog(ErrorDialog, {
       error: error
@@ -9,30 +10,26 @@ function bringUpDialog(error) {
   }
 }
 
-
-function makeRichPromise(callback, fallback) {
-  if (!fallback) {
-    fallback = bringUpDialog;
-  }
-
-  const rv = new Promise(callback)
-  const then = rv.then
+function makeRichPromise(callback, fallback = bringUpDialog) {
+  const rv = new Promise(callback);
+  const then = rv.then;
   let hasRejectionHandler = false;
+
   rv.then(null, (value) => {
     if (!hasRejectionHandler) {
       return fallback(value);
     }
   });
+
   rv.then = (onFulfilled, onRejected) => {
     if (onRejected) {
       hasRejectionHandler = true;
     }
     return then.call(rv, onFulfilled, onRejected);
   };
+
   return rv;
 }
 
 
-export default {
-  makeRichPromise: makeRichPromise
-}
+export default makeRichPromise;

--- a/lektor/admin/static/js/utils.jsx
+++ b/lektor/admin/static/js/utils.jsx
@@ -230,7 +230,7 @@ const utils = {
     });
   },
 
-  apiRequest(url, options) {
+  apiRequest(url, options, createPromise) {
     options = options || {};
     options.url = utils.getApiUrl(url);
     if (options.json !== undefined) {
@@ -242,7 +242,7 @@ const utils = {
       options.method = 'GET';
     }
 
-    return makeRichPromise((resolve, reject) => {
+    return createPromise((resolve, reject) => {
       jQuery.ajax(options)
         .done((data) => {
           resolve(data);

--- a/lektor/admin/static/js/utils.jsx
+++ b/lektor/admin/static/js/utils.jsx
@@ -1,6 +1,3 @@
-import {makeRichPromise} from './richPromise'
-
-
 function slug(string, opts) {
   opts = opts || {};
   string = string.toString();
@@ -216,9 +213,9 @@ const utils = {
     return $LEKTOR_CONFIG.admin_root + '/api' + url;
   },
 
-  loadData(url, params, options) {
+  loadData(url, params, options, createPromise) {
     options = options || {};
-    return makeRichPromise((resolve, reject) => {
+    return createPromise((resolve, reject) => {
       jQuery.ajax({
         url: utils.getApiUrl(url),
         data: params,

--- a/lektor/admin/static/js/views/AddAttachmentPage.jsx
+++ b/lektor/admin/static/js/views/AddAttachmentPage.jsx
@@ -9,6 +9,7 @@ import {AttachmentsChangedEvent} from '../events'
 import utils from '../utils'
 import i18n from '../i18n'
 import widgets from '../widgets'
+import makeRichPromise from '../richPromise';
 
 
 function getGoodDefaultModel(models) {
@@ -42,7 +43,7 @@ class AddAttachmentPage extends RecordComponent {
   }
 
   syncDialog() {
-    utils.loadData('/newattachment', {path: this.getRecordPath()})
+    utils.loadData('/newattachment', {path: this.getRecordPath()}, null, makeRichPromise)
       .then((resp) => {
         this.setState({
           newAttachmentInfo: resp

--- a/lektor/admin/static/js/views/AddChildPage.jsx
+++ b/lektor/admin/static/js/views/AddChildPage.jsx
@@ -113,7 +113,7 @@ class AddChildPage extends RecordComponent {
       data[primaryField.name] = this.state.primary;
     }
 
-    utils.apiRequest('/newrecord', {json: params, method: 'POST'})
+    utils.apiRequest('/newrecord', {json: params, method: 'POST'}, makeRichPromise)
       .then((resp) => {
         if (resp.exists) {
           errMsg(i18n.trans('ERROR_PAGE_ID_DUPLICATE').replace('%s', id));

--- a/lektor/admin/static/js/views/AddChildPage.jsx
+++ b/lektor/admin/static/js/views/AddChildPage.jsx
@@ -8,6 +8,7 @@ import i18n from '../i18n'
 import userLabel from '../userLabel'
 import utils from '../utils'
 import widgets from '../widgets'
+import makeRichPromise from '../richPromise';
 
 
 function getGoodDefaultModel(models) {
@@ -42,7 +43,7 @@ class AddChildPage extends RecordComponent {
   }
 
   syncDialog() {
-    utils.loadData('/newrecord', {path: this.getRecordPath()})
+    utils.loadData('/newrecord', {path: this.getRecordPath()}, null, makeRichPromise)
       .then((resp) => {
         let selectedModel = resp.implied_model;
         if (!selectedModel) {

--- a/lektor/admin/static/js/views/DeletePage.jsx
+++ b/lektor/admin/static/js/views/DeletePage.jsx
@@ -56,7 +56,7 @@ class DeletePage extends RecordComponent {
       path: path,
       alt: this.getRecordAlt(),
       delete_master: this.state.deleteMasterRecord ? '1' : '0'
-    }, method: 'POST'})
+    }, method: 'POST'}, makeRichPromise)
       .then((resp) => {
         if (this.state.recordInfo.is_attachment) {
           hub.emit(new AttachmentsChangedEvent({

--- a/lektor/admin/static/js/views/DeletePage.jsx
+++ b/lektor/admin/static/js/views/DeletePage.jsx
@@ -8,6 +8,7 @@ import utils from '../utils'
 import i18n from '../i18n'
 import hub from '../hub'
 import {AttachmentsChangedEvent} from '../events'
+import makeRichPromise from '../richPromise';
 
 
 class DeletePage extends RecordComponent {
@@ -32,7 +33,7 @@ class DeletePage extends RecordComponent {
   }
 
   syncDialog() {
-    utils.loadData('/recordinfo', {path: this.getRecordPath()})
+    utils.loadData('/recordinfo', {path: this.getRecordPath()}, null, makeRichPromise)
       .then((resp) => {
         this.setState({
           recordInfo: resp,

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -135,7 +135,7 @@ class EditPage extends RecordEditComponent {
     var alt = this.getRecordAlt();
     var newData = this.getValues();
     utils.apiRequest('/rawrecord', {json: {
-        data: newData, path: path, alt: alt}, method: 'PUT'})
+        data: newData, path: path, alt: alt}, method: 'PUT'}, makeRichPromise)
       .then((resp) => {
         this.setState({
           hasPendingChanges: false

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -7,6 +7,7 @@ import RecordEditComponent from '../components/RecordEditComponent'
 import utils from '../utils'
 import i18n from '../i18n'
 import widgets from '../widgets'
+import makeRichPromise from '../richPromise';
 
 
 class EditPage extends RecordEditComponent {
@@ -80,7 +81,7 @@ class EditPage extends RecordEditComponent {
     utils.loadData('/rawrecord', {
       path: this.getRecordPath(),
       alt: this.getRecordAlt()
-    })
+    }, null, makeRichPromise)
     .then((resp) => {
       this.setState({
         recordInitialData: resp.data,

--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Router from 'react-router'
 import utils from '../utils'
 import RecordComponent from '../components/RecordComponent'
+import makeRichPromise from '../richPromise';
 
 
 class PreviewPage extends RecordComponent {
@@ -39,7 +40,7 @@ class PreviewPage extends RecordComponent {
     }
 
     var recordUrl = this.getUrlRecordPathWithAlt();
-    utils.loadData('/previewinfo', {path: path, alt: alt})
+    utils.loadData('/previewinfo', {path: path, alt: alt}, null, makeRichPromise)
       .then((resp) => {
         this.setState({
           pageUrl: resp.url,
@@ -85,7 +86,7 @@ class PreviewPage extends RecordComponent {
     if (fsPath === null) {
       return;
     }
-    utils.loadData('/matchurl', {url_path: fsPath})
+    utils.loadData('/matchurl', {url_path: fsPath}, null, makeRichPromise)
       .then((resp) => {
         if (resp.exists) {
           var urlPath = this.getUrlRecordPathWithAlt(resp.path, resp.alt);

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -1,22 +1,20 @@
 'use strict'
 
-import React from 'react'
-import i18n from '../i18n'
-import metaformat from '../metaformat'
-import {BasicWidgetMixin} from './mixins'
-import userLabel from '../userLabel'
-
+import React from 'react';
+import i18n from '../i18n';
+import metaformat from '../metaformat';
+import {BasicWidgetMixin} from './mixins';
+import userLabel from '../userLabel';
+import widgets from '../widgets';;
 
 /* circular references require us to do this */
 function getWidgetComponent(type) {
-  var widgets = require('../widgets');
   return widgets.getWidgetComponent(type);
 }
 
 function getWidgets() {
-  return require('../widgets');
+  return widgets;
 }
-
 
 function parseFlowFormat(value) {
   var blocks = [];

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import i18n from '../i18n'
+import React from 'react';
+import i18n from '../i18n';
 
 function ValidationFailure (options) {
   this.message = options.message || i18n.trans('INVALID_INPUT')
@@ -33,7 +33,7 @@ const BasicWidgetMixin = {
 };
 
 
-export default {
-  ValidationFailure: ValidationFailure,
-  BasicWidgetMixin: BasicWidgetMixin
+export {
+  ValidationFailure,
+  BasicWidgetMixin
 }


### PR DESCRIPTION
- Fixes ES5 -> ES6 module import syntax.
- Fixes circular dependency issue for `richPromise.jsx`.
- Fixes issue with the Publish dialog when no servers are present in project file.
- Various syntax improvements.

I ran the JS tests locally, all passed. I tried running the Python tests, saw some errors, but they seemed all to originate from dependencies (My knowledge with python and it's tooling is still a bit rough)? I also ran through some manual testing, everything seemed OK, but it would probably be good to get some other hands on it.

One question:

How do the production assets get built when Lektor is deployed to pip / installed from the shell script?

A few recommendations for tasks:
- Add eslint for JS linting.
- Add `prettier` for JS formatting.
