### PR TITLE
pip/zsh doesn't like -e without quotes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ If you want to run the test suite instead:
 ```
 $ virtualenv venv
 $ . venv/bin/activate
-$ pip install --editable .[test]
+$ pip install --editable ".[test]"
 $ make test
 ```


### PR DESCRIPTION
This is true for at least OSX.

```
(lektor) --- Projects/lektor ‹master» uname -a                                                                                                                                               1 ↵
Darwin mbp 16.5.0 Darwin Kernel Version 16.5.0: Fri Mar  3 16:52:33 PST 2017; root:xnu-3789.51.2~3/RELEASE_X86_64 x86_64
(lektor) --- Projects/lektor ‹master» python --version                                                                                                                                       2 ↵
Python 2.7.13
(lektor) --- Projects/lektor ‹master» pip install --editable .[test]
zsh: no matches found: .[test]
(lektor) --- Projects/lektor ‹master» pip install --editable ".[test]"                                                                                                                       1 ↵
Obtaining file:///Users/anemitz/Projects/lektor
^CRequirement already satisfied: Jinja2>=2.4 in /Users/anemitz/.virtualenvs/lektor/lib/python2.7/site-packages (from Lektor==3.0)
Requirement already satisfied: click>=6.0 in /Users/anemitz/.virtualenvs/lektor/lib/python2.7/site-packages (from Lektor==3.0)
Requirement already satisfied: watchdog in /Users/anemitz/.virtualenvs/lektor/lib/python2.7/site-packages (from Lektor==3.0)
Requirement already satisfied: mistune>=0.7.0 in /Users/anemitz/.virtualenvs/lek
...
```