### PR TITLE
PR: Fix encoding error

### DIFF
--- a/lektor/i18n.py
+++ b/lektor/i18n.py
@@ -1,5 +1,6 @@
 import os
 import json
+from io import open
 
 from lektor._compat import iteritems
 from lektor.uilink import UI_LANG
@@ -13,7 +14,8 @@ KNOWN_LANGUAGES = list(x[:-5] for x in os.listdir(translations_path)
 
 translations = {}
 for _lang in KNOWN_LANGUAGES:
-    with open(os.path.join(translations_path, _lang + '.json')) as f:
+    with open(os.path.join(translations_path, _lang + '.json'),
+              encoding="utf8") as f:
         translations[_lang] = json.load(f)
 
 

--- a/lektor/i18n.py
+++ b/lektor/i18n.py
@@ -1,6 +1,6 @@
 import os
 import json
-from io import open
+import io
 
 from lektor._compat import iteritems
 from lektor.uilink import UI_LANG
@@ -14,7 +14,10 @@ KNOWN_LANGUAGES = list(x[:-5] for x in os.listdir(translations_path)
 
 translations = {}
 for _lang in KNOWN_LANGUAGES:
-    with open(os.path.join(translations_path, _lang + '.json'),
+    # Using standard open cause an error in python 2.7
+    # (because the encoding can't de selected)
+    # See https://github.com/lektor/lektor/issues/378
+    with io.open(os.path.join(translations_path, _lang + '.json'),
               encoding="utf8") as f:
         translations[_lang] = json.load(f)
 

--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -127,7 +127,10 @@ def get_default_author():
     import getpass
 
     if os.name == 'nt':
-        return getpass.getuser().decode('mbcs')
+        user = getpass.getuser()
+        if isinstance(user, text_type):
+            return user
+        return user.decode('mbcs')
 
     import pwd
     ent = pwd.getpwuid(os.getuid())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import pwd
 import shutil
 import subprocess
 import textwrap
@@ -139,6 +138,12 @@ def reporter(request, env):
 
 @pytest.fixture(scope='function')
 def os_user(monkeypatch):
+    if os.name == 'nt':
+        import getpass
+        monkeypatch.setattr('getpass.getuser', lambda: 'Lektor Test')
+        return "lektortest"
+
+    import pwd
     struct = pwd.struct_passwd((
         'lektortest',  # pw_name
         'lektorpass',  # pw_passwd

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -35,7 +35,7 @@ def test_unicode_attachment_filename(tmpdir):
         assert len(failures) == 0
 
         with prog.artifacts[0].open('rb') as f:
-            assert f.read() == b'attachment\n'
+            assert f.read().rstrip() == b'attachment'
 
 
 def test_bad_file_ignored(tmpdir):


### PR DESCRIPTION
Fixes: #378

I tested locally in a virtualbox with python3.6 and python2.7 using conda, and I was able to run `lektor quickstart --path example-project`

I also fix other errors in windows, but there are still errors when running `py.test . --tb=short -v --cov=lektor` (5 tests failed), but fix them looks a little difficult 😞 