### PR TITLE
Add new options "alts_enabled" to fields

### DIFF
--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -187,7 +187,7 @@ class EditPage extends RecordEditComponent {
         placeholder={this.getPlaceholderForField(widget, field)}
         field={field}
         onChange={this.onValueChange.bind(this, field)}
-        disabled={!(field.alts_enabled==null || (field.alts_enabled ^ this.state.recordInfo.alt == '_primary'))}
+        disabled={!(field.alts_enabled == null || (field.alts_enabled ^ this.state.recordInfo.alt === '_primary'))}
       />
     )
   }

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -187,6 +187,7 @@ class EditPage extends RecordEditComponent {
         placeholder={this.getPlaceholderForField(widget, field)}
         field={field}
         onChange={this.onValueChange.bind(this, field)}
+        disabled={!(field.alts_enabled==null || (field.alts_enabled ^ this.state.recordInfo.alt == '_primary'))}
       />
     )
   }

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -44,7 +44,7 @@ const FallbackWidget = React.createClass({
 
 class FieldBox extends Component {
   render () {
-    const {field, value, onChange, placeholder} = this.props
+    const {field, value, onChange, placeholder, disabled} = this.props
     const className = 'col-md-' + getFieldColumns(field) + ' field-box'
     let innerClassName = 'field'
     let inner
@@ -73,6 +73,7 @@ class FieldBox extends Component {
             onChange={onChange}
             type={field.type}
             placeholder={placeholder}
+            disabled={disabled}
           /></dd>
         </dl>
       )

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -194,6 +194,8 @@ class Field(object):
             'description_i18n': self.description_i18n,
             'type': self.type.to_json(pad, record, alt),
             'default': self.default,
+            'alts_enabled': bool_from_string(self.options.get('alts_enabled'),
+                                             default=None),
         }
 
     def deserialize_value(self, value, pad=None):


### PR DESCRIPTION
Define a new option to control whether or not a field should be editable
only in the primary (content.lr) or only in the alternatives
(content_atl.lr). This option only affect the webui editor by disabling
or enabling the respecting fields.

See #391