### PR TITLE
Enable publishing from different filesystem

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -597,7 +597,10 @@ class GithubPagesPublisher(Publisher):
                     os.makedirs(os.path.dirname(dst))
                 except (OSError, IOError):
                     pass
-                link(full_path, dst)
+                try:
+                    link(full_path, dst)
+                except OSError:
+                    shutil.copy(full_path, dst)
 
     def write_cname(self, path, target_url):
         params = target_url.decode_query()

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -599,7 +599,7 @@ class GithubPagesPublisher(Publisher):
                     pass
                 try:
                     link(full_path, dst)
-                except OSError:
+                except OSError: # Different Filesystems
                     shutil.copy(full_path, dst)
 
     def write_cname(self, path, target_url):


### PR DESCRIPTION
os.link() fails if files are on different filesystems. This change enables fallback to shutil.copy() in this case.