### PR TITLE
Fixing arrow function errors ref #390

### DIFF
--- a/lektor/admin/static/js/bootstrap-extras.jsx
+++ b/lektor/admin/static/js/bootstrap-extras.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 
-$(document).ready(function() {
-  $('[data-toggle=offcanvas]').click(function() {
+$(document).ready(function () {
+  $('[data-toggle=offcanvas]').click(function () {
     const target = $($(this).attr('data-target') || '.block-offcanvas')
     const isActive = target.is('.active')
     target.toggleClass('active', !isActive)

--- a/lektor/admin/static/js/bootstrap-extras.jsx
+++ b/lektor/admin/static/js/bootstrap-extras.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 
-$(document).ready(() => {
-  $('[data-toggle=offcanvas]').click(() => {
+$(document).ready(function() {
+  $('[data-toggle=offcanvas]').click(function() {
     const target = $($(this).attr('data-target') || '.block-offcanvas')
     const isActive = target.is('.active')
     target.toggleClass('active', !isActive)

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -57,7 +57,7 @@ const parseFlowFormat = (value) => {
 
 const serializeFlowFormat = (blocks) => {
   let rv = []
-  blocks.forEach(block => {
+  blocks.forEach((block) => {
     const [blockName, lines] = block
     rv.push('#### ' + blockName + ' ####\n')
     lines.forEach((line) => {
@@ -81,7 +81,7 @@ const deserializeFlowBlock = (flowBlockModel, lines, localId) => {
   let data = {}
   let rawData = {}
 
-  metaformat.tokenize(lines).forEach(item => {
+  metaformat.tokenize(lines).forEach((item) => {
     const [key, lines] = item
     const value = lines.join('')
     rawData[key] = value
@@ -158,7 +158,7 @@ const FlowWidget = React.createClass({
 
   // XXX: the modification of props is questionable
 
-  moveBlock: (idx, offset, event) => {
+  moveBlock: function(idx, offset, event) {
     event.preventDefault()
 
     const newIndex = idx + offset
@@ -175,7 +175,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  removeBlock: (idx, event) => {
+  removeBlock: function(idx, event) {
     event.preventDefault()
 
     if (confirm(i18n.trans('REMOVE_FLOWBLOCK_PROMPT'))) {
@@ -186,7 +186,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  addNewBlock: (key, event) => {
+  addNewBlock: function(key, event) {
     event.preventDefault()
 
     const flowBlockModel = this.props.type.flowblocks[key]
@@ -199,7 +199,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  renderFormField: (blockInfo, field, idx) => {
+  renderFormField: function(blockInfo, field, idx) {
     const widgets = getWidgets()
     const value = blockInfo.data[field.name]
     let placeholder = field['default']

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -158,7 +158,7 @@ const FlowWidget = React.createClass({
 
   // XXX: the modification of props is questionable
 
-  moveBlock: function(idx, offset, event) {
+  moveBlock: function (idx, offset, event) {
     event.preventDefault()
 
     const newIndex = idx + offset
@@ -175,7 +175,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  removeBlock: function(idx, event) {
+  removeBlock: function (idx, event) {
     event.preventDefault()
 
     if (confirm(i18n.trans('REMOVE_FLOWBLOCK_PROMPT'))) {
@@ -186,7 +186,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  addNewBlock: function(key, event) {
+  addNewBlock: function (key, event) {
     event.preventDefault()
 
     const flowBlockModel = this.props.type.flowblocks[key]
@@ -199,7 +199,7 @@ const FlowWidget = React.createClass({
     }
   },
 
-  renderFormField: function(blockInfo, field, idx) {
+  renderFormField: function (blockInfo, field, idx) {
     const widgets = getWidgets()
     const value = blockInfo.data[field.name]
     let placeholder = field['default']

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import i18n from '../i18n'
 
-const ValidationFailure = (options) => {
+function ValidationFailure (options) {
   this.message = options.message || i18n.trans('INVALID_INPUT')
   this.type = options.type || 'error'
 }

--- a/lektor/admin/static/js/widgets/multiWidgets.jsx
+++ b/lektor/admin/static/js/widgets/multiWidgets.jsx
@@ -27,7 +27,7 @@ const CheckboxesInputWidget = React.createClass({
     }
   },
 
-  onChange: function(field, event) {
+  onChange: function (field, event) {
     const newValue = utils.flipSetValue(this.props.value,
                                       field, event.target.checked)
     if (this.props.onChange) {
@@ -35,7 +35,7 @@ const CheckboxesInputWidget = React.createClass({
     }
   },
 
-  isActive: function(field) {
+  isActive: function (field) {
     let value = this.props.value
     if (value == null) {
       value = this.props.placeholder
@@ -55,7 +55,7 @@ const CheckboxesInputWidget = React.createClass({
     let {className, value, placeholder, type, ...otherProps} = this.props  // eslint-disable-line no-unused-vars
     className = (className || '') + ' checkbox'
 
-    const choices = this.props.type.choices.map(function(item) {
+    const choices = this.props.type.choices.map(function (item) {
       return (
         <div className={className} key={item[0]}>
           <label>

--- a/lektor/admin/static/js/widgets/multiWidgets.jsx
+++ b/lektor/admin/static/js/widgets/multiWidgets.jsx
@@ -27,7 +27,7 @@ const CheckboxesInputWidget = React.createClass({
     }
   },
 
-  onChange: (field, event) => {
+  onChange: function(field, event) {
     const newValue = utils.flipSetValue(this.props.value,
                                       field, event.target.checked)
     if (this.props.onChange) {
@@ -35,7 +35,7 @@ const CheckboxesInputWidget = React.createClass({
     }
   },
 
-  isActive: (field) => {
+  isActive: function(field) {
     let value = this.props.value
     if (value == null) {
       value = this.props.placeholder
@@ -55,7 +55,7 @@ const CheckboxesInputWidget = React.createClass({
     let {className, value, placeholder, type, ...otherProps} = this.props  // eslint-disable-line no-unused-vars
     className = (className || '') + ' checkbox'
 
-    const choices = this.props.type.choices.map((item) => {
+    const choices = this.props.type.choices.map(function(item) {
       return (
         <div className={className} key={item[0]}>
           <label>


### PR DESCRIPTION
Removing problematic arrow functions added in commit 33972ed (see https://github.com/lektor/lektor/issues/390#issuecomment-325061735). Also added in a few missing parens around arrow function params of arity 1. They aren't strictly required, but that is the norm in this project, and a common rule.

Many arrow functions already existed in the project and were untouched by 33972ed, and are untouched here. It turns out most arrow functions in 33972ed are also fine, just that most that used `this` inside of them were bad. Those are reverted here. I also manually tested this with the lektor-website repo, and while there are still unrelated warnings in the console, I didn't see any related exceptions. I also grepped through the app.js and vendor.js and did not see any suspicious looking `undefined`s anywhere.

Edit after failed tests / fix: The reverted functions didn't conform to the new linting rules. Now they do.

Ref #390 