### PR TITLE
Add simple bash script for pre commit js linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ coverage: coverage-python coverage-js
 
 osx-dmg:
 	$(MAKE) -C gui osx-dmg
+
+install-git-hooks:
+	ln -sT $(PWD)/bin/pre-commit .git/hooks/pre-commit

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ virtualenv venv
 $ . venv/bin/activate
 $ pip install --editable .
 $ make build-js
+$ make install-git-hooks
 $ export LEKTOR_DEV=1
 $ lektor quickstart --path example-project
 $ lektor --project example-project server

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+touched_js_admin_files=`git diff --cached --name-only | egrep '\.jsx?$' || true`
+
+if [ -n "$touched_js_admin_files" ]; then
+    cd lektor/admin/ && npm run lint
+fi


### PR DESCRIPTION
Also updated Makefile with task for install hooks
Ref #428.

This is a very simple and naive implementation of lint before commit, but while scripting I've done some research of tools:
1. for [pre-commit](http://pre-commit.com/) from yelp we need to create plugins for standard linter.
2. there are various soltuions based for npm, like this [one](https://github.com/okonet/lint-staged#working-from-a-subdirectory), but after local testing they are not working well in sub-directories (although with gitDir proposed in docs).