### PR TITLE
Disable pylint errors, because false-positive

### DIFF
--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -132,8 +132,10 @@ def get_default_author():
             return user
         return user.decode('mbcs')
 
-    import pwd
-    ent = pwd.getpwuid(os.getuid())
+    # we disable pylint, because there is no such
+    # modules on windows & it's false positive
+    import pwd  # pylint: disable=import-error
+    ent = pwd.getpwuid(os.getuid())  # pylint: disable=no-member
     if ent and ent.pw_gecos:
         name = ent.pw_gecos
         if isinstance(name, text_type):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,9 @@ def os_user(monkeypatch):
         monkeypatch.setattr('getpass.getuser', lambda: 'Lektor Test')
         return "lektortest"
 
-    import pwd
+    # we disable pylint, because there is no such
+    # modules on windows & it's false positive
+    import pwd  # pylint: disable=import-error
     struct = pwd.struct_passwd((
         'lektortest',  # pw_name
         'lektorpass',  # pw_passwd


### PR DESCRIPTION
It's false positive on windows, because pylint don't go in bracnh for os.name == 'nt'.