### PR TITLE
JS warning fixes

### DIFF
--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -31,7 +31,6 @@
     "prop-types": "^15.5.10",
     "querystring": "^0.2.0",
     "react": "^15.3.0",
-    "react-addons-test-utils": "^15.3.0",
     "react-addons-update": "^15.3.0",
     "react-dom": "^15.3.0",
     "react-router": "^2.6.0",

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -28,6 +28,7 @@
     "mocha": "^3.1.2",
     "native-promise-only": "^0.7.6-a",
     "nyc": "^8.4.0",
+    "prop-types": "^15.5.10",
     "querystring": "^0.2.0",
     "react": "^15.3.0",
     "react-addons-test-utils": "^15.3.0",

--- a/lektor/admin/static/js/components/Link.jsx
+++ b/lektor/admin/static/js/components/Link.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Link } from 'react-router'
 import Component from './Component'
@@ -19,7 +20,7 @@ class LektorLink extends Component {
 }
 
 LektorLink.propTypes = {
-  to: React.PropTypes.string
+  to: PropTypes.string
 }
 
 module.exports = LektorLink

--- a/lektor/admin/static/js/components/SlideDialog.jsx
+++ b/lektor/admin/static/js/components/SlideDialog.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Component from '../components/Component'
 import dialogSystem from '../dialogSystem'
@@ -60,9 +61,9 @@ class SlideDialog extends Component {
 }
 
 SlideDialog.propTypes = {
-  title: React.PropTypes.string,
-  hasCloseButton: React.PropTypes.bool,
-  closeOnEscape: React.PropTypes.bool
+  title: PropTypes.string,
+  hasCloseButton: PropTypes.bool,
+  closeOnEscape: PropTypes.bool
 }
 
 export default SlideDialog

--- a/lektor/admin/static/js/components/ToggleGroup.jsx
+++ b/lektor/admin/static/js/components/ToggleGroup.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Component from './Component'
 
@@ -42,8 +43,8 @@ class ToggleGroup extends Component {
 }
 
 ToggleGroup.propTypes = {
-  groupTitle: React.PropTypes.string,
-  defaultVisibility: React.PropTypes.bool
+  groupTitle: PropTypes.string,
+  defaultVisibility: PropTypes.bool
 }
 
 export default ToggleGroup

--- a/lektor/admin/static/js/components/ToggleGroup.jsx
+++ b/lektor/admin/static/js/components/ToggleGroup.jsx
@@ -20,7 +20,7 @@ class ToggleGroup extends Component {
   }
 
   render () {
-    let {className, groupTitle, children, ...otherProps} = this.props
+    let {className, groupTitle, children, defaultVisibility, ...otherProps} = this.props
     className = (className || '') + ' toggle-group'
     if (this.state.isVisible) {
       className += ' toggle-group-open'

--- a/lektor/admin/static/js/components/ToggleGroup.test.js
+++ b/lektor/admin/static/js/components/ToggleGroup.test.js
@@ -9,7 +9,7 @@ describe('ToggleGroup', () => {
     jsdomify.create('<!DOCTYPE html><html><head></head><body><div id="container"></div></body></html>')
     React = require('react')
     ReactDOM = require('react-dom')
-    ReactTestUtils = require('react-addons-test-utils')
+    ReactTestUtils = require('react-dom/test-utils')
   })
 
   afterEach(() => {

--- a/lektor/admin/static/js/dialogs/errorDialog.jsx
+++ b/lektor/admin/static/js/dialogs/errorDialog.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import RecordComponent from '../components/RecordComponent'
 import SlideDialog from '../components/SlideDialog'
@@ -31,7 +32,7 @@ class ErrorDialog extends RecordComponent {
 }
 
 ErrorDialog.propTypes = {
-  error: React.PropTypes.object
+  error: PropTypes.object
 }
 
 export default ErrorDialog

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import primitiveWidgets from './widgets/primitiveWidgets'
 import multiWidgets from './widgets/multiWidgets'
@@ -88,10 +89,10 @@ class FieldBox extends Component {
 }
 
 FieldBox.propTypes = {
-  value: React.PropTypes.any,
-  onChange: React.PropTypes.func,
-  field: React.PropTypes.any,
-  placeholder: React.PropTypes.any
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  field: PropTypes.any,
+  placeholder: PropTypes.any
 }
 
 const getWidgetComponent = (type) => {

--- a/lektor/admin/static/js/widgets/fakeWidgets.jsx
+++ b/lektor/admin/static/js/widgets/fakeWidgets.jsx
@@ -1,5 +1,6 @@
 'use strict'
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import {BasicWidgetMixin} from './mixins'
 import i18n from '../i18n'
@@ -7,7 +8,7 @@ import i18n from '../i18n'
 const FakeWidgetMixin = {
   mixins: [BasicWidgetMixin],
   propTypes: {
-    field: React.PropTypes.any
+    field: PropTypes.any
   },
 
   statics: {

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import PropTypes from 'prop-types'
 import i18n from '../i18n'
 
 function ValidationFailure (options) {
@@ -8,10 +8,10 @@ function ValidationFailure (options) {
 
 const BasicWidgetMixin = {
   propTypes: {
-    value: React.PropTypes.any,
-    type: React.PropTypes.object,
-    placeholder: React.PropTypes.any,
-    onChange: React.PropTypes.func
+    value: PropTypes.any,
+    type: PropTypes.object,
+    placeholder: PropTypes.any,
+    onChange: PropTypes.func
   },
 
   getInputClass () {


### PR DESCRIPTION
I did some things to fix trivial JS warnings. This properly fixes the test suite warnings (`make test-js` and fixes everything Lektor is responsible when it comes to PropTypes usage (#431).

Lektor does however depend on `react-router` 2.8.1 which does use `React.PropTypes`. There may be other dependencies that use `PropTypes` in a deprecated way too.