### PR TITLE
lektor dev shell use IPython if available

### DIFF
--- a/lektor/devcli.py
+++ b/lektor/devcli.py
@@ -2,6 +2,12 @@ import os
 import sys
 import click
 
+try:
+    from IPython import embed
+    from traitlets.config.loader import Config
+except ImportError:
+    pass # fallback to normal Python InteractiveConsole
+
 from .packages import get_package_info, register_package, publish_package
 from .cli import pass_context
 
@@ -69,7 +75,12 @@ def shell_cmd(ctx):
                                      ctx.get_default_output_path()),
         F=F
     )
-    code.interact(banner=banner, local=ns)
+    try:
+        c = Config()
+        c.TerminalInteractiveShell.banner2 = banner
+        embed(config=c, user_ns=ns)
+    except NameError: # No IPython
+        code.interact(banner=banner, local=ns)
 
 
 @cli.command('publish-plugin', short_help='Publish a plugin to PyPI.')

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
         'requests[security]',
     ],
     tests_require=tests_require,
-    extras_require={'test': tests_require},
+    extras_require={
+        'test': tests_require,
+        'ipython': ['ipython'],
+    },
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
If IPython isn't installed, then this falls back to running with the standard Python InteractiveConsole. This will make development easier IMO.