### PR TITLE
Add additional markdown plugin hook

### DIFF
--- a/lektor/markdown.py
+++ b/lektor/markdown.py
@@ -59,6 +59,7 @@ def make_markdown(env):
     cfg = MarkdownConfig()
     env.plugin_controller.emit('markdown-config', config=cfg)
     renderer = cfg.make_renderer()
+    env.plugin_controller.emit('markdown-lexer-config', config=cfg, renderer=renderer)
     return mistune.Markdown(renderer, **cfg.options)
 
 


### PR DESCRIPTION
In order to instantiate additional mistune lexers, plugins require
access to the Renderer instance. This commit adds an additional plugin
hook after instantiating the Renderer, but prior to creating the
Markdown processor.

The new hook is of use to plugins like lektor-shortcodes, which seek to
add new lexing rules to the Markdown syntax. Currently, such plugins
have to resort to a workaround, requiring users to pipe Lektor fields
through Jinja filters within HTML templates in order to process the
augmented syntax. By adding an additional plugin hook, Markdown syntax
additions can be processed without changes to Jinja templates.