### PR TITLE
PR: Use primary alternative in markdown image links

### DIFF
--- a/lektor/markdown.py
+++ b/lektor/markdown.py
@@ -27,10 +27,12 @@ class ImprovedRenderer(mistune.Renderer):
         return '<a href="%s" title="%s">%s</a>' % (link, title, text)
 
     def image(self, src, title, text):
+        from lektor.environment import PRIMARY_ALT
         if self.record is not None:
             url = url_parse(src)
             if not url.scheme:
-                src = self.record.url_to('!' + src,
+                # PRIMARY_ALT is used because images aren't generated for  each alt
+                src = self.record.url_to(src, alt=PRIMARY_ALT,
                                          base_url=get_ctx().base_url)
         src = escape(src)
         text = escape(text)


### PR DESCRIPTION
Hi, this PR tries to fix  #313 

Personally I don't like the import in the function, but putting it at the top of the file cause a circular import, this could be fixed moving the constants out on `environment.py` to another file (maybe `config.py`), is that ok?

https://github.com/lektor/lektor/blob/master/lektor/environment.py#L27-L75

This is also missing a test

EDIT: Resolving the url doesn't seem like the right solution, I'll further investigate this issue