### PR TITLE
Take absolute path of self.output_path in Watcher.is_interesting.

### DIFF
--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -70,7 +70,7 @@ class Watcher(BasicWatcher):
             return False
         if path.startswith(self.cache_dir):
             return False
-        if self.output_path is not None and path.startswith(self.output_path):
+        if self.output_path is not None and path.startswith(os.path.abspath(self.output_path)):
             return False
         return True
 


### PR DESCRIPTION
This fixes bug in issue #298 where the command 'lektor server -O <relative_path>'
can cause an infinite pruning/build loop. Previously, it was comparing
the absolute watch path to the relative server output_path, causing the
is_interesting to return 'True' when it shouldn't.  

The test suite passes for 'test_watcher/test_is_interesting.py'