### PR TITLE
Protect against building in existing nonempty dir

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -6,6 +6,7 @@ import shutil
 import sqlite3
 import hashlib
 import tempfile
+import click
 
 from contextlib import contextmanager
 from itertools import chain
@@ -964,6 +965,15 @@ class Builder(object):
 
         try:
             os.makedirs(self.meta_path)
+            if os.listdir(self.destination_path) != ['.lektor']:
+                if not click.confirm(click.style(
+                        "The build dir %s hasn't been used before, and other "
+                        "files or folders already exist there. If you prune "
+                        "(which normally follows the build step), "
+                        "they will be deleted. Proceed with building?"
+                        % self.destination_path, fg='yellow')):
+                    os.rmdir(self.meta_path)
+                    raise click.Abort()
         except OSError:
             pass
 

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -6,12 +6,12 @@ import shutil
 import sqlite3
 import hashlib
 import tempfile
-import click
 
 from contextlib import contextmanager
 from itertools import chain
 from collections import deque, namedtuple
 
+import click
 from werkzeug.posixemulation import rename
 
 from lektor._compat import PY2, iteritems, text_type

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,13 +5,19 @@ import os
 from lektor.cli import cli
 
 def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["build", "-O", os.getcwd()], input='n\n')
+    os.mkdir('build_dir')
+    with open('build_dir/test', 'w'):
+        pass
+    result = project_cli_runner.invoke(cli, ["build", "-O", "build_dir"], input='n\n')
     assert "Aborted!" in result.output
     assert result.exit_code == 1
 
 
 def test_build_continue_in_existing_nonempty_dir(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["build", "-O", os.getcwd()], input='y\n')
+    os.mkdir('build_dir')
+    with open('build_dir/test', 'w'):
+        pass
+    result = project_cli_runner.invoke(cli, ["build", "-O", "build_dir"], input='y\n')
     assert "Finished prune" in result.output
     assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,18 @@
 import re
 import warnings
+import os
+
 from lektor.cli import cli
 
+def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["build", "-O", os.getcwd()], input='n\n')
+    assert "Aborted!" in result.output
+    assert result.exit_code == 1
+
+def test_build_continue_in_existing_nonempty_dir(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["build", "-O", os.getcwd()], input='y\n')
+    assert "Finished prune" in result.output
+    assert result.exit_code == 0
 
 def test_build_no_project(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["build"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,10 +9,12 @@ def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
     assert "Aborted!" in result.output
     assert result.exit_code == 1
 
+
 def test_build_continue_in_existing_nonempty_dir(project_cli_runner):
     result = project_cli_runner.invoke(cli, ["build", "-O", os.getcwd()], input='y\n')
     assert "Finished prune" in result.output
     assert result.exit_code == 0
+
 
 def test_build_no_project(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["build"])
@@ -22,11 +24,17 @@ def test_build_no_project(isolated_cli_runner):
 
 def test_build(project_cli_runner):
     result = project_cli_runner.invoke(cli, ["build"])
+    assert "files or folders already exist" not in result.output # No warning on fresh build
     assert result.exit_code == 0
     start_matches = re.findall(r"Started build", result.output)
     assert len(start_matches) == 1
     finish_matches = re.findall(r"Finished build in \d+\.\d{2} sec", result.output)
     assert len(finish_matches) == 1
+
+    # rebuild
+    result = project_cli_runner.invoke(cli, ["build"])
+    assert "files or folders already exist" not in result.output # No warning on repeat build
+    assert result.exit_code == 0
 
 
 def test_build_extra_flag(project_cli_runner, mocker):


### PR DESCRIPTION
Fixes #513 

I decided to put the warning before the build even happens, as it can be potentially problematic by itself. I also think it's so unlikely to be the case someone really wants to do this that I didn't feel the need to add in an ability to bypass the check with a flag. It would mainly be clutter in the cli.

The prompt is tripped when `.lektor` needs to be made (i.e. this dir hasn't been used before as a build dir) and is nonempty.

With tests.