### PR TITLE
cmd aliases

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -50,6 +50,21 @@ def buildflag(cli):
         callback=buildflag_deprecated)(cli)
 
 
+class AliasedGroup(click.Group):
+
+    def get_command(self, ctx, cmd_name):
+        rv = click.Group.get_command(self, ctx, cmd_name)
+        if rv is not None:
+            return rv
+        matches = [x for x in self.list_commands(ctx)
+                   if x.startswith(cmd_name)]
+        if not matches:
+            return None
+        elif len(matches) == 1:
+            return click.Group.get_command(self, ctx, matches[0])
+        ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
+
+
 class Context(object):
 
     def __init__(self):
@@ -124,7 +139,7 @@ def validate_language(ctx, param, value):
     return value
 
 
-@click.group()
+@click.group(cls=AliasedGroup)
 @click.option('--project', type=click.Path(),
               help='The path to the lektor project to work with.')
 @click.option('--language', default=None, callback=validate_language,

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -52,6 +52,7 @@ def buildflag(cli):
 
 class AliasedGroup(click.Group):
 
+    # pylint: disable=inconsistent-return-statements
     def get_command(self, ctx, cmd_name):
         rv = click.Group.get_command(self, ctx, cmd_name)
         if rv is not None:

--- a/lektor/devcli.py
+++ b/lektor/devcli.py
@@ -9,7 +9,7 @@ except ImportError:
     pass # fallback to normal Python InteractiveConsole
 
 from .packages import get_package_info, register_package, publish_package
-from .cli import pass_context
+from .cli import pass_context, AliasedGroup
 
 
 def ensure_plugin():
@@ -24,7 +24,7 @@ def ensure_plugin():
     return info
 
 
-@click.group(short_help='Development commands.')
+@click.group(cls=AliasedGroup, short_help='Development commands.')
 def cli():
     """Development commands for Lektor.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,12 @@ def test_alias_multiple_matches(project_cli_runner):
     assert "Error: Too many matches" in result.output
 
 
+def test_alias_no_matches(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["z"])
+    assert result.exit_code == 2
+    assert "Error: No such command" in result.output
+
+
 def test_build_no_project(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["build"])
     assert result.exit_code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,18 @@ import warnings
 from lektor.cli import cli
 
 
+def test_alias(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["pr"])
+    assert result.exit_code == 0
+    assert "Name: Demo Project" in result.output
+
+
+def test_alias_multiple_matches(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["p"])
+    assert result.exit_code == 2
+    assert "Error: Too many matches" in result.output
+
+
 def test_build_no_project(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["build"])
     assert result.exit_code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,19 +4,19 @@ from lektor.cli import cli
 
 
 def test_alias(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["pr"])
+    result = project_cli_runner.invoke(cli, ["pr"]) # short for 'project-info'
     assert result.exit_code == 0
     assert "Name: Demo Project" in result.output
 
 
 def test_dev_cmd_alias(isolated_cli_runner):
-    result = isolated_cli_runner.invoke(cli, ["dev", "p"])
+    result = isolated_cli_runner.invoke(cli, ["dev", "p"]) # short for 'publish-plugin'
     assert result.exit_code == 2
     assert "Error: This command must be run in a Lektor plugin folder" in result.output
 
 
 def test_alias_multiple_matches(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["p"])
+    result = project_cli_runner.invoke(cli, ["p"]) # short for 'project-info' & 'plugins'
     assert result.exit_code == 2
     assert "Error: Too many matches" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,12 @@ def test_alias(project_cli_runner):
     assert "Name: Demo Project" in result.output
 
 
+def test_dev_cmd_alias(isolated_cli_runner):
+    result = isolated_cli_runner.invoke(cli, ["dev", "p"])
+    assert result.exit_code == 2
+    assert "Error: This command must be run in a Lektor plugin folder" in result.output
+
+
 def test_alias_multiple_matches(project_cli_runner):
     result = project_cli_runner.invoke(cli, ["p"])
     assert result.exit_code == 2


### PR DESCRIPTION
Fixes #516, and then some. This enables any shortened cmd that will resolve. So `lektor s` will work the same as `lektor server`, but `lektor p` will fail as that alias cannot resolve, since it is short for both `plugins` and `project-info`, but `lektor pl` will work. This also enables cmd shortening of the devcli.

The fancy code snippet for `class AliasedGroup` is copied straight from http://click.pocoo.org/5/advanced/#command-aliases.

Tests included.