### PR TITLE
run with "python -m lektor"

### DIFF
--- a/lektor/__main__.py
+++ b/lektor/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == '__main__':
+    from .cli import main
+    main(as_module=True)

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -616,4 +616,16 @@ from .devcli import cli as devcli  # pylint: disable=wrong-import-position
 cli.add_command(devcli, 'dev')
 
 
-main = cli
+def main(as_module=False):
+    args = sys.argv[1:]
+    name = None
+
+    if as_module:
+        name = 'python -m lektor'
+        sys.argv = ['-m', 'lektor'] + args
+
+    cli.main(args=args, prog_name=name)
+
+
+if __name__ == '__main__':
+    main(as_module=True)


### PR DESCRIPTION
closes #523 

Adds a `__main__.py` file so that `python -m lektor` works. Instead of aliasing `main = cli`, main is now a function that passes the correct args and name to the cli when running as a module. This is all taken directly from Flask.

I made this against the 3.x-maintenance branch, but I'm not sure about that since it doesn't seem to be synced with the 3.1 release. I can resubmit this against master if you're not using the maintenance branches.