### PR TITLE
Added tests for the `lektor dev new-plugin` command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.egg-info
 *.pex
 .cache
+#*
 build
 dist
 venv
@@ -14,6 +15,7 @@ coverage/
 coverage.xml
 coverage.lcov
 .nyc_output
+.pytest_cache
 
 node_modules
 gui/build

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ pex:
 
 test-python:
 	@echo "---> running python tests"
-	py.test . --tb=short -v --cov=lektor
+	py.test . --tb=long -svv --cov=lektor
 
 coverage-python: test-python
 	coverage xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,3 +68,6 @@ test_script:
   - npm list
   - npm run lint
   - npm test
+
+on_failure:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ test_script:
   # Run Python tests
   - "%PYTHON%\\python.exe --version"
   - "%PYTHON%\\python.exe -m pip list"
-  - "%PYTHON%\\Scripts\\pytest.exe . --tb=short -v --cov=lektor"
+  - "%PYTHON%\\Scripts\\pytest.exe . --tb=long -svv --cov=lektor"
   # Run JS tests
   - cd lektor\admin
   - node --version
@@ -69,5 +69,5 @@ test_script:
   - npm run lint
   - npm test
 
-on_failure:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# on_failure:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -34,7 +34,8 @@ class Generator(object):
             comment_end_string='**/',
         )
         self.options = {}
-        self.term_width = min(click.get_terminal_size()[0], 78)
+        # term width in [1, 78]
+        self.term_width = min(max(click.get_terminal_size()[0], 1), 78)
         self.e = click.secho
         self.w = partial(click.wrap_text, width=self.term_width)
 
@@ -47,7 +48,7 @@ class Generator(object):
         self.e('')
         self.e('Step %d:' % self.question, fg='yellow')
         if info is not None:
-            self.e(click.wrap_text(info, self.term_width - 2, '| ', '| '))
+            self.e(click.wrap_text(info, self.term_width, '| ', '| '))
         text = '> ' + click.style(text, fg='green')
 
         if default is True or default is False:

--- a/tests/test_dev_cli.py
+++ b/tests/test_dev_cli.py
@@ -1,0 +1,178 @@
+import textwrap
+import os
+
+from lektor.cli import cli
+from lektor.quickstart import get_default_author, get_default_author_email
+
+def test_new_plugin(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
+                                       input='Plugin Name\n'
+                                       '\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert "Create Plugin?" in result.output
+    assert os.listdir(os.path.join('packages', 'plugin-name')
+    ) == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert result.exit_code == 0
+
+    # gitignore
+    gitignore_expected = textwrap.dedent("""
+        dist
+        build
+        *.pyc
+        *.pyo
+        *.egg-info
+    """).strip()
+    with open(os.path.join('packages', 'plugin-name', '.gitignore')) as f:
+        gitignore_contents = f.read().strip()
+    assert gitignore_contents == gitignore_expected
+
+    # setup.py
+    setup_expected = textwrap.dedent("""
+        from setuptools import setup
+
+        setup(
+            name='lektor-plugin-name',
+            version='0.1',
+            author='Author Name',
+            author_email='author@email.com',
+            license='MIT',
+            py_modules=['lektor_plugin_name'],
+            entry_points={
+                'lektor.plugins': [
+                    'plugin-name = lektor_plugin_name:PluginNamePlugin',
+                ]
+            }
+        )
+    """).strip()
+    with open(os.path.join('packages', 'plugin-name', 'setup.py')) as f:
+        setup_contents = f.read().strip()
+    assert setup_contents == setup_expected
+
+    # plugin.py
+    plugin_expected = textwrap.dedent("""
+        # -*- coding: utf-8 -*-
+        from lektor.pluginsystem import Plugin
+
+
+        class PluginNamePlugin(Plugin):
+            name = 'Plugin Name'
+            description = u'Add your description here.'
+
+            def on_process_template_context(self, context, **extra):
+                def test_function():
+                    return 'Value from plugin %s' % self.name
+                context['test_function'] = test_function
+    """).strip()
+    with open(os.path.join('packages', 'plugin-name', 'lektor_plugin_name.py')) as f:
+        plugin_contents = f.read().strip()
+    assert plugin_contents == plugin_expected
+
+
+def test_new_plugin_abort_plugin_exists(project_cli_runner):
+    os.mkdir('packages')
+    os.mkdir(os.path.join('packages', 'plugin-name'))
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
+                                       input='Plugin Name\n'
+                                       '\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert "Aborted!" in result.output
+    assert result.exit_code == 1
+
+
+def test_new_plugin_abort_cancel(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
+                                       input='Plugin Name\n'
+                                       '\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'n\n'
+    )
+    assert "Aborted!" in result.output
+    assert result.exit_code == 1
+
+
+def test_new_plugin_name_only(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
+                                       input='Plugin Name\n'
+                                       '\n'
+                                       '\n'
+                                       '\n'
+                                       'y\n'
+    )
+    assert os.listdir(os.path.join('packages', 'plugin-name')
+    ) == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert result.exit_code == 0
+
+    # setup.py
+    author = get_default_author()
+    author_email = get_default_author_email()
+    setup_expected = textwrap.dedent("""
+        from setuptools import setup
+
+        setup(
+            name='lektor-plugin-name',
+            version='0.1',
+            author='{}',
+            author_email='{}',
+            license='MIT',
+            py_modules=['lektor_plugin_name'],
+            entry_points={{
+                'lektor.plugins': [
+                    'plugin-name = lektor_plugin_name:PluginNamePlugin',
+                ]
+            }}
+        )
+    """).format(author, author_email).strip()
+    with open(os.path.join('packages', 'plugin-name', 'setup.py')) as f:
+        setup_contents = f.read().strip()
+    assert setup_contents == setup_expected
+
+
+def test_new_plugin_name_param(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "plugin-name"],
+                                       input='\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert os.listdir('packages') == ['plugin-name']
+    assert result.exit_code == 0
+
+
+def test_new_plugin_path(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
+                                       input='Plugin Name\n'
+                                       'path\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert result.exit_code == 0
+
+
+def test_new_plugin_path_param(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "--path", "path"],
+                                       input='Plugin Name\n'
+                                       'Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert result.exit_code == 0
+
+
+def test_new_plugin_path_and_name_params(project_cli_runner):
+    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "plugin-name", "--path", "path"],
+                                       input='Author Name\n'
+                                       'author@email.com\n'
+                                       'y\n'
+    )
+    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert result.exit_code == 0

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -38,7 +38,7 @@ def test_new_plugin(project_cli_runner):
             name='lektor-plugin-name',
             version='0.1',
             author={}'Author Name',
-            author_email={}'author@email.com',
+            author_email='author@email.com',
             license='MIT',
             py_modules=['lektor_plugin_name'],
             entry_points={{
@@ -49,9 +49,9 @@ def test_new_plugin(project_cli_runner):
         )
     """).strip()
     if PY2:
-        setup_expected = setup_expected.format("u", "u")
+        setup_expected = setup_expected.format("u")
     else:
-        setup_expected = setup_expected.format("", "")
+        setup_expected = setup_expected.format("")
     with open(os.path.join(path, 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected
@@ -125,7 +125,7 @@ def test_new_plugin_name_only(project_cli_runner):
             name='lektor-plugin-name',
             version='0.1',
             author={}'{}',
-            author_email={}'{}',
+            author_email='{}',
             license='MIT',
             py_modules=['lektor_plugin_name'],
             entry_points={{
@@ -136,9 +136,9 @@ def test_new_plugin_name_only(project_cli_runner):
         )
     """).strip()
     if PY2:
-        setup_expected = setup_expected.format("u", author, "u", author_email)
+        setup_expected = setup_expected.format("u", author, author_email)
     else:
-        setup_expected = setup_expected.format("", author, "", author_email)
+        setup_expected = setup_expected.format("", author, author_email)
     with open(os.path.join(path, 'plugin-name', 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -6,17 +6,19 @@ from lektor.cli import cli
 from lektor.quickstart import get_default_author, get_default_author_email
 
 def test_new_plugin(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
-                                       input='Plugin Name\n'
-                                       '\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin"],
+        input='Plugin Name\n'
+        '\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
     assert "Create Plugin?" in result.output
-    path = os.path.join(os.path.abspath('packages'), 'plugin-name')
-    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
+    path = os.path.join('packages', 'plugin-name')
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+
 
     # gitignore
     gitignore_expected = textwrap.dedent("""
@@ -81,43 +83,48 @@ def test_new_plugin(project_cli_runner):
 
 
 def test_new_plugin_abort_plugin_exists(project_cli_runner):
-    path = os.path.abspath('packages')
+    path = 'packages'
     os.mkdir(path)
     os.mkdir(os.path.join(path, 'plugin-name'))
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
-                                       input='Plugin Name\n'
-                                       '\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    input = 'Plugin Name\n\nAuthor Name\nauthor@email.com\ny\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin"],
+        input='Plugin Name\n'
+        '\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
     assert "Aborted!" in result.output
     assert result.exit_code == 1
 
 
 def test_new_plugin_abort_cancel(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
-                                       input='Plugin Name\n'
-                                       '\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'n\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin"],
+        input='Plugin Name\n'
+        '\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'n\n',
     )
     assert "Aborted!" in result.output
     assert result.exit_code == 1
 
 
 def test_new_plugin_name_only(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
-                                       input='Plugin Name\n'
-                                       '\n'
-                                       '\n'
-                                       '\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin"],
+        input='Plugin Name\n'
+        '\n'
+        '\n'
+        '\n'
+        'y\n',
     )
-    path = os.path.abspath('packages')
-    assert os.listdir(path) == ['plugin-name']
+    assert "Create Plugin?" in result.output
     assert result.exit_code == 0
+    path = 'packages'
+    assert os.listdir(path) == ['plugin-name']
 
     # setup.py
     author = get_default_author()
@@ -149,48 +156,56 @@ def test_new_plugin_name_only(project_cli_runner):
 
 
 def test_new_plugin_name_param(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "plugin-name"],
-                                       input='\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin", "plugin-name"],
+        input='\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
-    path = os.path.abspath('packages')
-    assert os.listdir(path) == ['plugin-name']
+    assert "Create Plugin?" in result.output
     assert result.exit_code == 0
+    path = 'packages'
+    assert os.listdir(path) == ['plugin-name']
 
 
 def test_new_plugin_path(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
-                                       input='Plugin Name\n'
-                                       'path\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin"],
+        input='Plugin Name\n'
+        'path\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
-    path = os.path.abspath('path')
-    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+    assert "Create Plugin?" in result.output
     assert result.exit_code == 0
+    path = 'path'
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
 
 
 def test_new_plugin_path_param(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "--path", "path"],
-                                       input='Plugin Name\n'
-                                       'Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin", "--path", "path"],
+        input='Plugin Name\n'
+        'Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
-    path = os.path.abspath('path')
-    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+    assert "Create Plugin?" in result.output
     assert result.exit_code == 0
+    path = 'path'
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
 
 
 def test_new_plugin_path_and_name_params(project_cli_runner):
-    result = project_cli_runner.invoke(cli, ["dev", "new-plugin", "plugin-name", "--path", "path"],
-                                       input='Author Name\n'
-                                       'author@email.com\n'
-                                       'y\n'
+    result = project_cli_runner.invoke(
+        cli, ["dev", "new-plugin", "plugin-name", "--path", "path"],
+        input='Author Name\n'
+        'author@email.com\n'
+        'y\n',
     )
-    path = os.path.abspath('path')
-    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+    assert "Create Plugin?" in result.output
     assert result.exit_code == 0
+    path = 'path'
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -13,8 +13,8 @@ def test_new_plugin(project_cli_runner):
                                        'y\n'
     )
     assert "Create Plugin?" in result.output
-    assert set(os.listdir(os.path.join('packages', 'plugin-name')
-    )) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+    path = os.path.join(os.path.abspath('packages'), 'plugin-name')
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
 
     # gitignore
@@ -25,7 +25,7 @@ def test_new_plugin(project_cli_runner):
         *.pyo
         *.egg-info
     """).strip()
-    with open(os.path.join('packages', 'plugin-name', '.gitignore')) as f:
+    with open(os.path.join(path, '.gitignore')) as f:
         gitignore_contents = f.read().strip()
     assert gitignore_contents == gitignore_expected
 
@@ -47,7 +47,7 @@ def test_new_plugin(project_cli_runner):
             }
         )
     """).strip()
-    with open(os.path.join('packages', 'plugin-name', 'setup.py')) as f:
+    with open(os.path.join(path, 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected
 
@@ -66,14 +66,15 @@ def test_new_plugin(project_cli_runner):
                     return 'Value from plugin %s' % self.name
                 context['test_function'] = test_function
     """).strip()
-    with open(os.path.join('packages', 'plugin-name', 'lektor_plugin_name.py')) as f:
+    with open(os.path.join(path, 'lektor_plugin_name.py')) as f:
         plugin_contents = f.read().strip()
     assert plugin_contents == plugin_expected
 
 
 def test_new_plugin_abort_plugin_exists(project_cli_runner):
-    os.mkdir('packages')
-    os.mkdir(os.path.join('packages', 'plugin-name'))
+    path = os.path.abspath('packages')
+    os.mkdir(path)
+    os.mkdir(os.path.join(path, 'plugin-name'))
     result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
                                        input='Plugin Name\n'
                                        '\n'
@@ -105,8 +106,8 @@ def test_new_plugin_name_only(project_cli_runner):
                                        '\n'
                                        'y\n'
     )
-    assert set(os.listdir(os.path.join('packages', 'plugin-name')
-    )) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
+    path = os.path.abspath('packages')
+    assert os.listdir(path) == ['plugin-name']
     assert result.exit_code == 0
 
     # setup.py
@@ -129,7 +130,7 @@ def test_new_plugin_name_only(project_cli_runner):
             }}
         )
     """).format(author, author_email).strip()
-    with open(os.path.join('packages', 'plugin-name', 'setup.py')) as f:
+    with open(os.path.join(path, 'plugin-name', 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected
 
@@ -141,7 +142,8 @@ def test_new_plugin_name_param(project_cli_runner):
                                        'author@email.com\n'
                                        'y\n'
     )
-    assert os.listdir('packages') == ['plugin-name']
+    path = os.path.abspath('packages')
+    assert os.listdir(path) == ['plugin-name']
     assert result.exit_code == 0
 
 

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -1,6 +1,7 @@
 import textwrap
 import os
 
+from lektor._compat import PY2
 from lektor.cli import cli
 from lektor.quickstart import get_default_author, get_default_author_email
 
@@ -36,17 +37,21 @@ def test_new_plugin(project_cli_runner):
         setup(
             name='lektor-plugin-name',
             version='0.1',
-            author='Author Name',
-            author_email='author@email.com',
+            author={}'Author Name',
+            author_email={}'author@email.com',
             license='MIT',
             py_modules=['lektor_plugin_name'],
-            entry_points={
+            entry_points={{
                 'lektor.plugins': [
                     'plugin-name = lektor_plugin_name:PluginNamePlugin',
                 ]
-            }
+            }}
         )
     """).strip()
+    if PY2:
+        setup_expected = setup_expected.format("u", "u")
+    else:
+        setup_expected = setup_expected.format("", "")
     with open(os.path.join(path, 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected
@@ -119,8 +124,8 @@ def test_new_plugin_name_only(project_cli_runner):
         setup(
             name='lektor-plugin-name',
             version='0.1',
-            author='{}',
-            author_email='{}',
+            author={}'{}',
+            author_email={}'{}',
             license='MIT',
             py_modules=['lektor_plugin_name'],
             entry_points={{
@@ -129,7 +134,11 @@ def test_new_plugin_name_only(project_cli_runner):
                 ]
             }}
         )
-    """).format(author, author_email).strip()
+    """).strip()
+    if PY2:
+        setup_expected = setup_expected.format("u", author, "u", author_email)
+    else:
+        setup_expected = setup_expected.format("", author, "", author_email)
     with open(os.path.join(path, 'plugin-name', 'setup.py')) as f:
         setup_contents = f.read().strip()
     assert setup_contents == setup_expected

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -13,8 +13,8 @@ def test_new_plugin(project_cli_runner):
                                        'y\n'
     )
     assert "Create Plugin?" in result.output
-    assert os.listdir(os.path.join('packages', 'plugin-name')
-    ) == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert set(os.listdir(os.path.join('packages', 'plugin-name')
+    )) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
 
     # gitignore
@@ -105,8 +105,8 @@ def test_new_plugin_name_only(project_cli_runner):
                                        '\n'
                                        'y\n'
     )
-    assert os.listdir(os.path.join('packages', 'plugin-name')
-    ) == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    assert set(os.listdir(os.path.join('packages', 'plugin-name')
+    )) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
 
     # setup.py
@@ -153,7 +153,8 @@ def test_new_plugin_path(project_cli_runner):
                                        'author@email.com\n'
                                        'y\n'
     )
-    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    path = os.path.abspath('path')
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
 
 
@@ -164,7 +165,8 @@ def test_new_plugin_path_param(project_cli_runner):
                                        'author@email.com\n'
                                        'y\n'
     )
-    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    path = os.path.abspath('path')
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0
 
 
@@ -174,5 +176,6 @@ def test_new_plugin_path_and_name_params(project_cli_runner):
                                        'author@email.com\n'
                                        'y\n'
     )
-    assert os.listdir('path') == ['lektor_plugin_name.py', 'setup.py', '.gitignore']
+    path = os.path.abspath('path')
+    assert set(os.listdir(path)) == set(['lektor_plugin_name.py', 'setup.py', '.gitignore'])
     assert result.exit_code == 0

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -63,7 +63,7 @@ def test_new_plugin(project_cli_runner):
 
 
         class PluginNamePlugin(Plugin):
-            name = 'Plugin Name'
+            name = {}'Plugin Name'
             description = u'Add your description here.'
 
             def on_process_template_context(self, context, **extra):
@@ -71,6 +71,10 @@ def test_new_plugin(project_cli_runner):
                     return 'Value from plugin %s' % self.name
                 context['test_function'] = test_function
     """).strip()
+    if PY2:
+        plugin_expected = plugin_expected.format("u")
+    else:
+        plugin_expected = plugin_expected.format("")
     with open(os.path.join(path, 'lektor_plugin_name.py')) as f:
         plugin_contents = f.read().strip()
     assert plugin_contents == plugin_expected


### PR DESCRIPTION
Here are some new tests for the CLI command `lektor dev new-plugin`.

These tests pass locally, but I've keep running into the same errors on Appveyor with Python 2, and Travis with Python 3. Appveyor with Python 3 passes, as does Travis with Python 2. I don't know what the cause is of the errors on those platforms or how to prevent them yet.

Easily see the difference: [Travis](https://travis-ci.org/lektor/lektor/builds/373597166), and [Appveyor](https://ci.appveyor.com/project/Lektor/lektor/build/1.0.238).

I have tried to reproduce the errors locally with Python2 and Python3, and with live debugging on both Appveyor (rdp + powershell) and Travis (ssh), and haven't succeeded.

For some reason, the part of each test that runs 
```python
result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
                                   input='Plugin Name\n\nAuthor Name\nauthor@email.com\ny\n'
)
```
does not execute as expected, giving `result.output` equal to
```
Step 1:

```
instead of the larger, complete output, which varies a bit per test, but in general looks like
```
Step 1:
| This is the human readable name for this plugin
> Plugin Name: Plugin Name

Step 2:
| The place where you want to initialize the plugin
> Plugin Path [/tmp/tmp6xn_rxhh/packages/plugin-name]: 

Step 3:
| Your name as it will be embedded in the plugin metadata.
> Author Name [joe,,,]: Author Name

Step 4:
| Your e-mail address for the plugin info.
> Author E-Mail [nixjdm@terminallabs.com]: author@email.com

Create Plugin? [Y/n] y
```

I'll keep poking around, but I don't want to pull these tests if they only work locally. Any help is appreciated. I'm running out of ideas atm.

--
The simplest test that ought to fail would be:
```python
import os

from lektor.cli import cli

def test_new_plugin(project_cli_runner):
    result = project_cli_runner.invoke(cli, ["dev", "new-plugin"],
                                       input='Plugin Name\n\nAuthor Name\nauthor@email.com\ny\n'
    )
    assert "Create Plugin?" in result.output
    assert result.exit_code == 0
```

-----
**Update:**

Thanks to @anlutro's help on freenode, we I now know what's causing this to some extant. [Lektor was subtracting 2 from the terminal width](https://github.com/lektor/lektor/blob/1e4b8b2b8ed8f1c5a436ad0b243f6eaae7ec2c75/lektor/quickstart.py#L50), and Click was erring on a width of -2 since the detected width was 0. This was again the case on Py3 Travis and Py2 Appveyor, and not Py2 Travis and Py3 Appveyor, for reasons I have not dug into. Where the error exists though, that's what's going on. I'll update the PR later to fix that as well.
