### PR TITLE
test added under tests/test_urls.py about SourceObject.url_to()

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -27,26 +27,51 @@ def test_basic_url_to_with_alts(pad):
     assert slave_de.url_to(slave_en) == '../../../projects/slave/'
 
 
-@pytest.mark.parametrize("alt, absolute, external, base_url, expected", [
-    ("de", None, None, None, '../../de/projects/sklave/'),
-    ("de", True, None, None, '/de/projects/sklave/'),
-    ("de", True, True, None, '/de/projects/sklave/'), #
-    ("de", True, True, '/content/', '/de/projects/sklave/'),#
-    ("de", None, True, None, '/projects/slave1/de/projects/sklave/'),
-    ("de", None, True, '/content/', '/projects/slave1/de/projects/sklave/'),#
-    ("de", None, None, '/content/', '../de/projects/sklave/'),
-    (None, True, None, None, '/projects/slave/'),
-    (None, True, True, None, '/projects/slave/'),#
-    (None, True, True, '/content/', '/projects/slave/'),
-    (None, True, None, '/content/', '/projects/slave/'),
-    (None, None, True, None, '/projects/slave1/projects/slave/'),
-    (None, None, True, '/content/', '/projects/slave1/projects/slave/'),
-    (None, None, None, '/content/', '../projects/slave/'),
+@pytest.mark.parametrize('path, alt, absolute, external, base_url, expected', [
+    ('/projects/slave', '', None, None, None, '../../projects/slave/'),
+    ('/projects/slave', 'de', None, None, None, '../../de/projects/sklave/'),
+    ('/projects/slave', 'de', True, None, None, '/de/projects/sklave/'),
+    ('/projects/slave', 'de', True, True, None, '/de/projects/sklave/'),
+    ('/projects/slave', 'de', True, True, '/content/', '/de/projects/sklave/'),
+    ('/projects/slave', 'de', None, True, None, '/projects/slave1/de/projects/sklave/'),
+    ('/projects/slave', 'de', None, True, '/content/', '/projects/slave1/de/projects/sklave/'),
+    ('/projects/slave', 'de', None, None, '/content/', '../de/projects/sklave/'),
+    ('', 'de', None, None, None, '../../de/projects/wolf/'),
+    ('!', 'de', None, None, None, '../../projects/wolf/'),
+    ('!/projects/slave', 'de', None, None, None, '../../projects/slave'),
+    ('!/projects/slave', None, None, None, None, '../../projects/slave'),
+    ('!', None, None, None, None, '../../projects/wolf/'),
+    ('', None, None, None, None, '../../projects/wolf/'),
+    ('/projects/slave', None, True, None, None, '/projects/slave/'),
+    ('/projects/slave', None, True, True, None, '/projects/slave/'),
+    ('/projects/slave', None, True, True, '/content/', '/projects/slave/'),
+    ('/projects/slave', None, True, None, '/content/', '/projects/slave/'),
+    ('/projects/slave', None, None, True, None, '/projects/slave1/projects/slave/'),
+    ('/projects/slave', None, None, True, '/content/', '/projects/slave1/projects/slave/'),
+    ('/projects/slave', None, None, None, '/content/', '../projects/slave/'),
+    ('/projects/slave', None, None, None, None, '../../projects/slave/'),
+
 ])
-def test_url_to_all_params(pad, alt, absolute, external, base_url, expected):
-    if external:
-        pad.db.config.base_url = "/projects/slave1/"
+def test_url_to_all_params(pad, path, alt, absolute, external, base_url, expected):
+
+    if external and not absolute:
+        pad.db.config.base_url = '/projects/slave1/'
 
     wolf_en = pad.get('/projects/wolf')
 
-    assert wolf_en.url_to("/projects/slave/", alt, absolute, external, base_url) == expected
+    assert wolf_en.url_to(path, alt, absolute, external, base_url) == expected
+
+
+@pytest.mark.parametrize('path, alt, absolute, external, base_url', [
+    ('/projects/slave', 'de', None, True, None),
+    ('/projects/slave', 'de', None, True, '/content/'),
+    ('/projects/slave', None, None, True, None),
+    ('/projects/slave', None, None, True, '/content/'),
+
+])
+def test_url_to_all_params_error_cases(pad, path, alt, absolute, external, base_url):
+
+    wolf_en = pad.get('/projects/wolf')
+
+    with pytest.raises(RuntimeError):
+        wolf_en.url_to(path, alt, absolute, external, base_url)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -27,26 +27,26 @@ def test_basic_url_to_with_alts(pad):
     assert slave_de.url_to(slave_en) == '../../../projects/slave/'
 
 
-@pytest.mark.parametrize("path, alt, absolute, external, base_url, expected", [
-    ("/projects/slave/", "de", None, None, None, '../../de/projects/sklave/'),
-    ("/projects/slave/", "de", True, None, None, '/de/projects/sklave/'),
-    ("/projects/slave/", "de", True, True, None, '/de/projects/sklave/'), #
-    ("/projects/slave/", "de", True, True, '/content/', '/de/projects/sklave/'),#
-    ("/projects/slave/", "de", None, True, None, '/projects/slave1/de/projects/sklave/'),
-    ("/projects/slave/", "de", None, True, '/content/', '/projects/slave1/de/projects/sklave/'),#
-    ("/projects/slave/", "de", None, None, '/content/', '../de/projects/sklave/'),
-    ("/projects/slave/", None, True, None, None, '/projects/slave/'),
-    ("/projects/slave/", None, True, True, None, '/projects/slave/'),#
-    ("/projects/slave/", None, True, True, '/content/', '/projects/slave/'),
-    ("/projects/slave/", None, True, None, '/content/', '/projects/slave/'),
-    ("/projects/slave/", None, None, True, None, '/projects/slave1/projects/slave/'),
-    ("/projects/slave/", None, None, True, '/content/', '/projects/slave1/projects/slave/'),
-    ("/projects/slave/", None, None, None, '/content/', '../projects/slave/'),
+@pytest.mark.parametrize("alt, absolute, external, base_url, expected", [
+    ("de", None, None, None, '../../de/projects/sklave/'),
+    ("de", True, None, None, '/de/projects/sklave/'),
+    ("de", True, True, None, '/de/projects/sklave/'), #
+    ("de", True, True, '/content/', '/de/projects/sklave/'),#
+    ("de", None, True, None, '/projects/slave1/de/projects/sklave/'),
+    ("de", None, True, '/content/', '/projects/slave1/de/projects/sklave/'),#
+    ("de", None, None, '/content/', '../de/projects/sklave/'),
+    (None, True, None, None, '/projects/slave/'),
+    (None, True, True, None, '/projects/slave/'),#
+    (None, True, True, '/content/', '/projects/slave/'),
+    (None, True, None, '/content/', '/projects/slave/'),
+    (None, None, True, None, '/projects/slave1/projects/slave/'),
+    (None, None, True, '/content/', '/projects/slave1/projects/slave/'),
+    (None, None, None, '/content/', '../projects/slave/'),
 ])
-def test_param(pad, path, alt, absolute, external, base_url, expected):
+def test_url_to_all_params(pad, alt, absolute, external, base_url, expected):
     if external:
         pad.db.config.base_url = "/projects/slave1/"
 
     wolf_en = pad.get('/projects/wolf')
 
-    assert wolf_en.url_to(path, alt, absolute, external, base_url) == expected
+    assert wolf_en.url_to("/projects/slave/", alt, absolute, external, base_url) == expected

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_cleanup_path():
     from lektor.utils import cleanup_path
 
@@ -13,6 +15,7 @@ def test_cleanup_path():
 
 
 def test_basic_url_to_with_alts(pad):
+
     wolf_en = pad.get('/projects/wolf', alt='en')
     slave_en = pad.get('/projects/slave', alt='en')
     wolf_de = pad.get('/projects/wolf', alt='de')
@@ -20,6 +23,30 @@ def test_basic_url_to_with_alts(pad):
 
     assert wolf_en.url_to(slave_en) == '../../projects/slave/'
     assert wolf_de.url_to(slave_de) == '../../../de/projects/sklave/'
-
     assert slave_en.url_to(slave_de) == '../../de/projects/sklave/'
     assert slave_de.url_to(slave_en) == '../../../projects/slave/'
+
+
+@pytest.mark.parametrize("path, alt, absolute, external, base_url, expected", [
+    ("/projects/slave/", "de", None, None, None, '../../de/projects/sklave/'),
+    ("/projects/slave/", "de", True, None, None,'/de/projects/sklave/'),
+    ("/projects/slave/", "de", True, True, None,  '/de/projects/sklave/'), #
+    ("/projects/slave/", "de", True, True, '/content/',  '/de/projects/sklave/'),#
+    ("/projects/slave/", "de", None, True, None,  '/projects/slave1/de/projects/sklave/'),
+    ("/projects/slave/", "de", None, True, '/content/',  '/projects/slave1/de/projects/sklave/'),#
+    ("/projects/slave/", "de", None, None, '/content/',  '../de/projects/sklave/'),
+    ("/projects/slave/", None, True, None, None,  '/projects/slave/'),
+    ("/projects/slave/", None, True, True, None,  '/projects/slave/'),#
+    ("/projects/slave/", None, True, True, '/content/',  '/projects/slave/'),
+    ("/projects/slave/", None, True, None, '/content/',  '/projects/slave/'),
+    ("/projects/slave/", None, None, True, None, '/projects/slave1/projects/slave/'),
+    ("/projects/slave/", None, None, True, '/content/',  '/projects/slave1/projects/slave/'),
+    ("/projects/slave/", None, None, None, '/content/',  '../projects/slave/'),
+])
+def test_param(pad,path,alt,absolute, external, base_url, expected):
+    if external :
+        pad.db.config.base_url = "/projects/slave1/"
+
+    wolf_en = pad.get('/projects/wolf')
+
+    assert wolf_en.url_to(path,alt,absolute, external, base_url) == expected

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -29,24 +29,24 @@ def test_basic_url_to_with_alts(pad):
 
 @pytest.mark.parametrize("path, alt, absolute, external, base_url, expected", [
     ("/projects/slave/", "de", None, None, None, '../../de/projects/sklave/'),
-    ("/projects/slave/", "de", True, None, None,'/de/projects/sklave/'),
-    ("/projects/slave/", "de", True, True, None,  '/de/projects/sklave/'), #
-    ("/projects/slave/", "de", True, True, '/content/',  '/de/projects/sklave/'),#
-    ("/projects/slave/", "de", None, True, None,  '/projects/slave1/de/projects/sklave/'),
-    ("/projects/slave/", "de", None, True, '/content/',  '/projects/slave1/de/projects/sklave/'),#
-    ("/projects/slave/", "de", None, None, '/content/',  '../de/projects/sklave/'),
-    ("/projects/slave/", None, True, None, None,  '/projects/slave/'),
-    ("/projects/slave/", None, True, True, None,  '/projects/slave/'),#
-    ("/projects/slave/", None, True, True, '/content/',  '/projects/slave/'),
-    ("/projects/slave/", None, True, None, '/content/',  '/projects/slave/'),
+    ("/projects/slave/", "de", True, None, None, '/de/projects/sklave/'),
+    ("/projects/slave/", "de", True, True, None, '/de/projects/sklave/'), #
+    ("/projects/slave/", "de", True, True, '/content/', '/de/projects/sklave/'),#
+    ("/projects/slave/", "de", None, True, None, '/projects/slave1/de/projects/sklave/'),
+    ("/projects/slave/", "de", None, True, '/content/', '/projects/slave1/de/projects/sklave/'),#
+    ("/projects/slave/", "de", None, None, '/content/', '../de/projects/sklave/'),
+    ("/projects/slave/", None, True, None, None, '/projects/slave/'),
+    ("/projects/slave/", None, True, True, None, '/projects/slave/'),#
+    ("/projects/slave/", None, True, True, '/content/', '/projects/slave/'),
+    ("/projects/slave/", None, True, None, '/content/', '/projects/slave/'),
     ("/projects/slave/", None, None, True, None, '/projects/slave1/projects/slave/'),
-    ("/projects/slave/", None, None, True, '/content/',  '/projects/slave1/projects/slave/'),
-    ("/projects/slave/", None, None, None, '/content/',  '../projects/slave/'),
+    ("/projects/slave/", None, None, True, '/content/', '/projects/slave1/projects/slave/'),
+    ("/projects/slave/", None, None, None, '/content/', '../projects/slave/'),
 ])
-def test_param(pad,path,alt,absolute, external, base_url, expected):
-    if external :
+def test_param(pad, path, alt, absolute, external, base_url, expected):
+    if external:
         pad.db.config.base_url = "/projects/slave1/"
 
     wolf_en = pad.get('/projects/wolf')
 
-    assert wolf_en.url_to(path,alt,absolute, external, base_url) == expected
+    assert wolf_en.url_to(path, alt, absolute, external, base_url) == expected


### PR DESCRIPTION
Issue #526 

Hello,

adding tests for all `url_to()` parameters.

Can you confirm that `expected` parameter is always good.
I have a doubt for some tests with `absolute = True`, as `external` and `base_url` are not took into account. (see below)
```
@pytest.mark.parametrize("path, alt, absolute, external, base_url, expected", [
("/projects/slave/", "de", True, True, None,  '/de/projects/sklave/'),
("/projects/slave/", "de", True, True, '/content/',  '/de/projects/sklave/'),
("/projects/slave/", "de", None, True, '/content/',  '/projects/slave1/de/projects/sklave/'),
("/projects/slave/", None, True, True, None,  '/projects/slave/'),
("/projects/slave/", None, True, True, '/content/',  '/projects/slave/'),
("/projects/slave/", None, True, None, '/content/',  '/projects/slave/')
])
```
It's clearly written under `url_to()` to return `path` before `absolute` or `base_url` are processed: 
        ```if absolute:
            return path```

Also I have to set `pad.db.config.base_url` when `external = True`, is that an expected behavior ?
```
    if external :
        pad.db.config.base_url = "/projects/slave1/"
```
Regards.