### PR TITLE
Fix some problems with FTP in Python 3.6

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -7,10 +7,10 @@ import shutil
 import subprocess
 import tempfile
 import threading
-from contextlib import contextmanager
 
-from werkzeug import urls
+from contextlib import contextmanager
 from ftplib import Error as FTPError
+from werkzeug import urls
 
 from lektor._compat import (iteritems, iterkeys, range_type, string_types,
     text_type, queue, BytesIO, StringIO, PY2)
@@ -357,8 +357,7 @@ class FtpConnection(object):
         if getvalue:
             if PY2:
                 return out.getvalue()
-            else:
-                return out.getvalue().decode('utf-8')
+            return out.getvalue().decode('utf-8')
         return out
 
     def upload_file(self, filename, src, mkdir=False):


### PR DESCRIPTION
I was able to do some digging in the FTP upload of lektor. It now works for me when I do FTP uploads. FTP-TLS is still broken, though.

The API of pythons `ftplib` has changed slightly with Python 3. Most of the errors where caused by ftplib expecting `str` instead of `bytes` and vice versa.

Furthermore, `ftplib` uses exceptions for a lot of things. There were lots of instances where I found code like this:

     try:
          ...
     except Exception as e:
          ...

This made it a lot harder to find the root-cause of many errors. I changed that to only catch ftplib's own `Error` class (which is renamed to `FTPError` during import).

I would not know how to write unit tests for this … sorry.

Hope this helps. The corresponding issue is #554 .