### PR TITLE
Be more robust when getting SVG info

### DIFF
--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -281,7 +281,8 @@ def get_image_info(fp):
     if len(head) < 24:
         return 'unknown', None, None
 
-    if head.strip().startswith(b'<?xml '):
+    magic_bytes = b'<?xml', b'<svg'
+    if any(map(head.strip().startswith, magic_bytes)):
         return get_svg_info(fp)
 
     fmt = imghdr.what(None, head)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,11 +1,40 @@
+import io
 import os
 from datetime import datetime
 
+import pytest
+
 from lektor._compat import iteritems
+from lektor.imagetools import get_image_info
 
 
 def almost_equal(a, b, e=0.00001):
     return abs(a - b) < e
+
+
+@pytest.fixture(scope='function')
+def make_svg():
+
+    def _make_svg(size_unit=None, with_declaration=True, w=100, h=100):
+        emotional_face = """<svg xmlns="http://www.w3.org/2000/svg" \
+height="{h}{unit}" width="{w}{unit}">
+    <circle cx="50" cy="50" r="50" fill="lightgrey"/>
+    <circle cx="30" cy="30" r="10" fill="black"/>
+    <circle cx="60" cy="30" r="10" fill="black"/>
+    <path stroke="black" d="M30 70 l30 0" stroke-width="5"/>
+ </svg>""" \
+        .format(unit=size_unit or '', w=w, h=h) \
+        .encode('utf-8')
+
+        if with_declaration:
+            xml_declaration = b'<?xml version="1.0" standalone="yes"?>'
+            svg = xml_declaration + emotional_face
+        else:
+            svg = emotional_face
+
+        return io.BytesIO(svg)
+
+    return _make_svg
 
 
 def test_exif(pad):
@@ -59,6 +88,18 @@ def test_image_attributes(pad):
         assert image.width == 512
         assert image.height == 384
         assert image.format == 'jpeg'
+
+
+def test_image_info_svg_declaration(make_svg):
+    w, h = 100, 100
+    svg_with_xml_decl = make_svg(with_declaration=True, h=h, w=w)
+    svg_no_xml_decl = make_svg(with_declaration=False, h=h, w=w)
+    info_svg_no_xml_decl = get_image_info(svg_no_xml_decl)
+    info_svg_with_xml_decl = get_image_info(svg_with_xml_decl)
+
+    expected = 'svg', w, h
+    assert info_svg_with_xml_decl == expected
+    assert info_svg_no_xml_decl == expected
 
 
 def test_thumbnail_height(builder):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -102,6 +102,18 @@ def test_image_info_svg_declaration(make_svg):
     assert info_svg_no_xml_decl == expected
 
 
+def test_image_info_svg_length(make_svg):
+    w, h = 100, 100
+    svg_with_unit_px = make_svg(size_unit='px', w=w, h=h)
+    svg_no_unit = make_svg(size_unit=None, w=w, h=h)
+    info_with_unit_px = get_image_info(svg_with_unit_px)
+    info_no_unit = get_image_info(svg_no_unit)
+
+    expected = 'svg', 100, 100
+    assert info_with_unit_px == expected
+    assert info_no_unit == expected
+
+
 def test_thumbnail_height(builder):
     builder.build_all()
     with open(os.path.join(builder.destination_path, 'index.html')) as f:


### PR DESCRIPTION
SVGs in the wild don’t always include an XML declaration, and as per [1], they
don’t necessarily have to. Additionally, height and width declarations may include more
than just an integer.

[1]: https://www.w3.org/TR/xml/#sec-prolog-dtd