### PR TITLE
[WIP] Support s/e shortcuts to switch between edit / preview mode.

### DIFF
--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -54,7 +54,7 @@ class EditPage extends RecordEditComponent {
       console.log('_onKeyPress', event)
     if (
         (event.which === 83 && utils.isMetaKey(event)) // meta+s
-        || event.which === 83 // s
+        // || event.which === 83 // s
     ) {
       event.preventDefault()
       this.saveChanges()

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -51,8 +51,11 @@ class EditPage extends RecordEditComponent {
   }
 
   _onKeyPress (event) {
-    // meta+s is open find files
-    if (event.which === 83 && utils.isMetaKey(event)) {
+      console.log('_onKeyPress', event)
+    if (
+        (event.which === 83 && utils.isMetaKey(event)) // meta+s
+        || event.which === 83 // s
+    ) {
       event.preventDefault()
       this.saveChanges()
     }

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -51,10 +51,9 @@ class EditPage extends RecordEditComponent {
   }
 
   _onKeyPress (event) {
-      console.log('_onKeyPress', event)
     if (
-        (event.which === 83 && utils.isMetaKey(event)) // meta+s
-        // || event.which === 83 // s
+      (event.which === 83 && utils.isMetaKey(event)) // meta+s
+      // || event.which === 83 // s
     ) {
       event.preventDefault()
       this.saveChanges()

--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -12,6 +12,7 @@ class PreviewPage extends RecordComponent {
       pageUrl: null,
       pageUrlFor: null
     }
+    this._onStartEditing = this._onStartEditing.bind(this)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -22,6 +23,25 @@ class PreviewPage extends RecordComponent {
   componentDidMount () {
     super.componentDidMount()
     this.syncState()
+    window.addEventListener('keydown', this._onStartEditing)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('keydown', this._onStartEditing)
+  }
+
+  _onStartEditing (event) {
+      console.log('_onStartEditing', event)
+    if (
+        (event.which === 91 && utils.isMetaKey(event)) // meta+e
+        || event.which === 69 // e
+    ) {
+      event.preventDefault()
+      const path = this.getRecordPath()
+      this.transitionToAdminPage('.edit', {
+        path: this.getUrlRecordPathWithAlt(path)
+      })
+    }
   }
 
   shouldComponentUpdate () {

--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -34,7 +34,7 @@ class PreviewPage extends RecordComponent {
       console.log('_onStartEditing', event)
     if (
         (event.which === 91 && utils.isMetaKey(event)) // meta+e
-        || event.which === 69 // e
+        // || event.which === 69 // e
     ) {
       event.preventDefault()
       const path = this.getRecordPath()

--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -31,10 +31,9 @@ class PreviewPage extends RecordComponent {
   }
 
   _onStartEditing (event) {
-      console.log('_onStartEditing', event)
     if (
-        (event.which === 91 && utils.isMetaKey(event)) // meta+e
-        // || event.which === 69 // e
+      (event.which === 91 && utils.isMetaKey(event)) // meta+e
+      // || event.which === 69 // e
     ) {
       event.preventDefault()
       const path = this.getRecordPath()


### PR DESCRIPTION
Hi there,

I really liked the way it is possible to switch from the edit screen to the preview screen with `command-s`, however I also wanted to switch back to the edit screen from the preview.

Thus what I do in this pull request.

Some things that I would love some feedback:
* When switching between the views, sometimes the opposing key-event seems to be auto generated by the browser
* I tried using `command+…` shortcuts but those seem to work really strangely - do you happen to know why?
* I'd like to have tooltips on the menu buttons (edit/preview) on the left - but I don't know react very well - how would one do that?