### PR TITLE
enabled do extension in jinja environment

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -428,7 +428,9 @@ class Environment(object):
 
         self.jinja_env = CustomJinjaEnvironment(
             autoescape=self.select_jinja_autoescape,
-            extensions=['jinja2.ext.autoescape', 'jinja2.ext.with_'],
+            extensions=['jinja2.ext.autoescape',
+                        'jinja2.ext.with_',
+                        'jinja2.ext.do'],
             loader=jinja2.FileSystemLoader(
                 template_paths)
         )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,6 @@
+def test_jinja2_extensions(env):
+    extensions = env.jinja_env.extensions
+
+    assert 'jinja2.ext.AutoEscapeExtension' in extensions.keys()
+    assert 'jinja2.ext.WithExtension' in extensions.keys()
+    assert 'jinja2.ext.ExprStmtExtension' in extensions.keys()


### PR DESCRIPTION
@nixjdm @singingwolfboy My apologies, as this is an unsolicited PR, but I genuinely think that the `do` extension is a useful thing to have as part of the default Jinja2 environment that Lektor uses.

Please let me know if this is something you'd like or not; as this is my first PR into Lektor, I wasn't quite sure if I needed to add tests and the likes. Please do let me know, I am more than happy to continue adding things if needed.