### PR TITLE
Support `|url(alt='es')` on paginated pages

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1526,7 +1526,7 @@ class Pad(object):
 
         if pieces[0].isdigit():
             if len(pieces) == 1:
-                return self.get(record['_path'], page_num=int(pieces[0]))
+                return self.get(record['_path'], alt=record.alt, page_num=int(pieces[0]))
             return None
 
         resolver = self.env.virtual_sources.get(pieces[0])


### PR DESCRIPTION
See Issue #572. Using `url` filter on paginated pages lost the `alt`
parameter always returning the primary alt.