### PR TITLE
Fix minor deployment issues

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -24,7 +24,7 @@ def rewrite_html_for_editing(fp, edit_url):
         position: fixed;
         z-index: 9999999;
         right: 10px;
-        top: 10px;
+        top: 100px;
         position: fixed;
         margin: 0;
         font-family: 'Verdana', sans-serif;

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -175,6 +175,7 @@ class Command(object):
                         if not line:
                             if stream in streams:
                                 streams.remove(stream)
+                                stream.close()
                             break
                         yield line.rstrip().decode('utf-8', 'replace')
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -94,6 +94,7 @@ def _temporary_folder(env):
     finally:
         try:
             shutil.rmtree(folder)
+            os.rmdir(base)
         except (IOError, OSError):
             pass
 


### PR DESCRIPTION
This PR fixes the warning about unclosed file objects during deploy (#455) and also removes the temporary -empty- directory.