### PR TITLE
Fix minor deployment issues

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -175,6 +175,7 @@ class Command(object):
                         if not line:
                             if stream in streams:
                                 streams.remove(stream)
+                                stream.close()
                             break
                         yield line.rstrip().decode('utf-8', 'replace')
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -94,6 +94,7 @@ def _temporary_folder(env):
     finally:
         try:
             shutil.rmtree(folder)
+            os.rmdir(base)
         except (IOError, OSError):
             pass
 


### PR DESCRIPTION
This PR fixes the warning about unclosed file objects during deploy (#455) and also removes the temporary -empty- directory. This PR is a duplicate of the incorrect one I've opened and closed before (#615).