### PR TITLE
Fix #588 - modified utils.py

### DIFF
--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -537,6 +537,13 @@ def make_relative_url(base, target):
     else:
         depth = ('/' + base.strip('/')).count('/')
         prefix = ''
+        # If the last part of the base path contains a dot, the page will 
+        # render into, for example "404.html" instead of "404/index.html".
+        # Any relative links from it therefore need one less level of depth.
+        if '.' in base.strip('/').split('/')[-1]:
+            depth -= 1
+            if depth == 0:
+                prefix = './'
 
     ends_in_slash = target[-1:] == '/'
     target = posixpath.normpath(posixpath.join(base, target))

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -537,7 +537,7 @@ def make_relative_url(base, target):
     else:
         depth = ('/' + base.strip('/')).count('/')
         prefix = ''
-        # If the last part of the base path contains a dot, the page will 
+        # If the last part of the base path contains a dot, the page will
         # render into, for example "404.html" instead of "404/index.html".
         # Any relative links from it therefore need one less level of depth.
         if '.' in base.strip('/').split('/')[-1]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,16 +66,12 @@ def test_parse_path():
 
 import pytest
 @pytest.mark.parametrize("base, target, expected", [
-    # A few different edge cases goes here, one testcase per line
     ("/", "./a/", "./a/"),
     ("/", "./a", "./a"),
     ("/fr/blog/2015/11/a/","/fr/blog/2015/11/a/a.jpg","../../../../../fr/blog/2015/11/a/a.jpg"),
     ("/fr/blog/2015/11/a/","/fr/blog/","../../../../../fr/blog/"),
     ("/fr/blog/2015/12/a/","/fr/b.php","../../../../fr/b.php"),
     ("/fr/blog/2016/1/a/","/images/b.svg","../../../../../images/b.svg"),
-    # ...
-    # Add as many test cases as you see fit. You definitely want one test case for the
-    # new behavior.
 ])
 def test_make_relative_url(base, target, expected):
     from lektor.utils import make_relative_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_join_path():
     from lektor.utils import join_path
 
@@ -64,7 +66,7 @@ def test_parse_path():
     assert parse_path('/foo/bar/') == ['foo', 'bar']
     assert parse_path('/foo/bar/../stuff') == ['foo', 'bar', 'stuff']
 
-import pytest
+    
 @pytest.mark.parametrize("base, target, expected", [
     ("/", "./a/", "./a/"),
     ("/", "./a", "./a"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,10 +68,10 @@ import pytest
 @pytest.mark.parametrize("base, target, expected", [
     ("/", "./a/", "./a/"),
     ("/", "./a", "./a"),
-    ("/fr/blog/2015/11/a/","/fr/blog/2015/11/a/a.jpg","../../../../../fr/blog/2015/11/a/a.jpg"),
-    ("/fr/blog/2015/11/a/","/fr/blog/","../../../../../fr/blog/"),
-    ("/fr/blog/2015/11/a.php","/fr/blog/","../../../../fr/blog/"),
-    ("/fr/blog/2015/11/a/","/images/b.svg","../../../../../images/b.svg"),
+    ("/fr/blog/2015/11/a/", "/fr/blog/2015/11/a/a.jpg", "../../../../../fr/blog/2015/11/a/a.jpg"),
+    ("/fr/blog/2015/11/a/", "/fr/blog/", "../../../../../fr/blog/"),
+    ("/fr/blog/2015/11/a.php", "/fr/blog/", "../../../../fr/blog/"),
+    ("/fr/blog/2015/11/a/", "/images/b.svg", "../../../../../images/b.svg"),
 ])
 def test_make_relative_url(base, target, expected):
     from lektor.utils import make_relative_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,3 +63,20 @@ def test_parse_path():
     assert parse_path('/foo/bar') == ['foo', 'bar']
     assert parse_path('/foo/bar/') == ['foo', 'bar']
     assert parse_path('/foo/bar/../stuff') == ['foo', 'bar', 'stuff']
+
+import pytest
+@pytest.mark.parametrize("base, target, expected", [
+    # A few different edge cases goes here, one testcase per line
+    ("/", "./a/", "./a/"),
+    ("/", "./a", "./a"),
+    ("/fr/blog/2015/11/a/","/fr/blog/2015/11/a/a.jpg","../../../../../fr/blog/2015/11/a/a.jpg"),
+    ("/fr/blog/2015/11/a/","/fr/blog/","../../../../../fr/blog/"),
+    ("/fr/blog/2015/12/a/","/fr/b.php","../../../../fr/b.php"),
+    ("/fr/blog/2016/1/a/","/images/b.svg","../../../../../images/b.svg"),
+    # ...
+    # Add as many test cases as you see fit. You definitely want one test case for the
+    # new behavior.
+])
+def test_make_relative_url(base, target, expected):
+    from lektor.utils import make_relative_url
+    assert make_relative_url(base, target) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,8 +70,8 @@ import pytest
     ("/", "./a", "./a"),
     ("/fr/blog/2015/11/a/","/fr/blog/2015/11/a/a.jpg","../../../../../fr/blog/2015/11/a/a.jpg"),
     ("/fr/blog/2015/11/a/","/fr/blog/","../../../../../fr/blog/"),
-    ("/fr/blog/2015/12/a/","/fr/b.php","../../../../fr/b.php"),
-    ("/fr/blog/2016/1/a/","/images/b.svg","../../../../../images/b.svg"),
+    ("/fr/blog/2015/11/a.php","/fr/blog/","../../../../fr/blog/"),
+    ("/fr/blog/2015/11/a/","/images/b.svg","../../../../../images/b.svg"),
 ])
 def test_make_relative_url(base, target, expected):
     from lektor.utils import make_relative_url


### PR DESCRIPTION
Modified def make_relative_url(base, target): so it checks whether the base path belongs to a dotted slug. If so, the depth is reduced by one to point to the target at the right level.

Addresses issue #588 in Github.