### PR TITLE
[lektor-618] Adding babel-eslint to standard to fix ES6 parsing.

### DIFF
--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -5,6 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.26.0",
+    "babel-eslint": "^10.0.1",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -68,6 +69,7 @@
     ]
   },
   "standard": {
+    "parser": "babel-eslint",
     "ignore": [
       "static/gen/"
     ],


### PR DESCRIPTION
Fixes #618 