### PR TITLE
GUI markdown widget

### DIFF
--- a/lektor/admin/package-lock.json
+++ b/lektor/admin/package-lock.json
@@ -4,6 +4,267 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+      "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+      "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@types/codemirror": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.71.tgz",
+      "integrity": "sha512-b2oEEnno1LIGKMR7uBEsr40al1UijF1HEpRn0+Yf1xOLl24iQgB7DBpZVMM7y54G5wCNoclDrRO65E6KHPNO2w==",
+      "dev": true,
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.3.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.29.tgz",
+      "integrity": "sha512-FhJvBninYD36v3k6c+bVk1DSZwh7B5Dpb/Pyk3HKVsiohn0nhbefZZ+3JXbWQhFyt0MxSl2jRDdGQPHeOHFXrQ==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/linkify-it": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-2.1.0.tgz",
+      "integrity": "sha512-Q7DYAOi9O/+cLLhdaSvKdaumWyHbm7HAk/bFwwyTuU0arR5yyCeW5GOoqt4tJTpDRxhpx9Q8kQL6vMpuw9hDSw==",
+      "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.7.tgz",
+      "integrity": "sha512-WyL6pa76ollQFQNEaLVa41ZUUvDvPY+qAUmlsphnrpL6I9p1m868b26FyeoOmo7X3/Ta/S9WKXcEYXUSHnxoVQ==",
+      "dev": true,
+      "requires": {
+        "@types/linkify-it": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
+    },
+    "@types/tern": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.0.tgz",
+      "integrity": "sha512-klmHtUmX+in4DA8l+Hj/zFO8M3g+otgQ9n7AfiEJ3Er9xjxjEsidKVyifLV4klwVu/X7qh8oIFY4d+GNgZiR7Q==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -70,6 +331,12 @@
         "json-schema-traverse": "^0.3.0",
         "json-stable-stringify": "^1.0.1"
       }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -302,6 +569,20 @@
         "private": "^0.1.7",
         "slash": "^1.0.0",
         "source-map": "^0.5.6"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "babel-generator": {
@@ -804,6 +1085,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
@@ -1269,6 +1569,27 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codemirror": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.45.0.tgz",
+      "integrity": "sha512-c19j644usCE8gQaXa0jqn2B/HN9MnB2u6qPIrrhrMkB+QAP42y8G4QnTwuwbVSoUS1jEl7JU9HZMGhCDL0nsAw==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1725,6 +2046,12 @@
         "tapable": "^0.2.7"
       }
     },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
@@ -2070,6 +2397,22 @@
       "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
       "dev": true
     },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "espree": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
@@ -2123,6 +2466,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "eve": {
+      "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+      "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
       "dev": true
     },
     "event-emitter": {
@@ -2233,6 +2581,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2420,7 +2774,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2835,7 +3190,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2891,6 +3247,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2934,12 +3291,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3157,6 +3516,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
       "dev": true
     },
     "history": {
@@ -3805,6 +4170,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "0.9.x"
           }
@@ -3882,7 +4248,8 @@
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
           "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "0.10.1",
@@ -4013,6 +4380,15 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "linkify-it": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
+      "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
@@ -4169,6 +4545,19 @@
         "pify": "^2.3.0"
       }
     },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -4190,6 +4579,12 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -4504,6 +4899,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5248,7 +5644,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.0",
@@ -6172,6 +6569,24 @@
         }
       }
     },
+    "plantuml-encoder": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.5.tgz",
+      "integrity": "sha512-viV7Sz+BJNX/sC3iyebh2VfLyAZKuu3+JuBs2ISms8+zoTGwPqwk3/WEDw/zROmGAJ/xD4sNd8zsBw/YmTo7ng==",
+      "dev": true,
+      "requires": {
+        "pako": "1.0.3",
+        "utf8-bytes": "0.0.1"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+          "integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8=",
+          "dev": true
+        }
+      }
+    },
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -6339,6 +6754,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "raphael": {
+      "version": "git+https://github.com/nhnent/raphael.git#78a6ed3ec269f33b6457b0ec66f8c3d1f2ed70e0",
+      "from": "git+https://github.com/nhnent/raphael.git#2.2.0-c",
+      "dev": true,
+      "requires": {
+        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
       }
     },
     "react": {
@@ -6657,6 +7080,12 @@
         "resolve-from": "^1.0.0"
       }
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
@@ -6884,6 +7313,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "squire-rte": {
+      "version": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
+      "from": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
       "dev": true
     },
     "sshpk": {
@@ -7176,6 +7610,12 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-mark": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/to-mark/-/to-mark-1.1.4.tgz",
+      "integrity": "sha512-w6NdBzrbqwxIikVUcQeb+qVyAOdwnOkOnWCTk3GwCFmeo8utAZbivY4wzX0jU25Noi/zaTO3NTrHudEB9OCjyw==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
@@ -7208,6 +7648,62 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
+    },
+    "tui-chart": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/tui-chart/-/tui-chart-3.6.1.tgz",
+      "integrity": "sha512-Z9DU52LffSt0pdg0vrTxR73dnVD1pqKKMV3cWEFZ7TH/G2CU+2CpVdXJ6N9NpEM+CoczeQLT5mOhnpt2/gRL2g==",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "^6.26.0",
+        "raphael": "git+https://github.com/nhnent/raphael.git#2.2.0-c",
+        "tui-code-snippet": "^1.5.0"
+      }
+    },
+    "tui-code-snippet": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/tui-code-snippet/-/tui-code-snippet-1.5.0.tgz",
+      "integrity": "sha512-grVv/lrHDXp9sRWypmMe76fHDlpdSfVYLiVmy8f765mWEBk+2JtiKgH+ACuipNtPZbUAy2pYgIWRQfDcg0zdCw==",
+      "dev": true
+    },
+    "tui-color-picker": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tui-color-picker/-/tui-color-picker-2.2.2.tgz",
+      "integrity": "sha512-uad1DJ+xQsBUxRYXGm9SM2l+wE8H8ZXZrNBrx42LXjOr23PpdjCdBaLXuHyhK65h9sM6ZLJU9A8lnKt+rO5T7Q==",
+      "dev": true,
+      "requires": {
+        "tui-code-snippet": "^1.5.0"
+      }
+    },
+    "tui-editor": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tui-editor/-/tui-editor-1.3.3.tgz",
+      "integrity": "sha512-AKck+bPC+4ZOeD7rNLeKvLF3zLITlU0QLxVesT0o66R1X7YowIKbWeBlVvSqcWv2eB/ZGJ9Qi6/1lFU2yYOuVA==",
+      "dev": true,
+      "requires": {
+        "@types/codemirror": "0.0.71",
+        "@types/jquery": "^3.3.29",
+        "@types/markdown-it": "0.0.7",
+        "codemirror": "^5.33.0",
+        "highlight.js": "^9.12.0",
+        "jquery": "^3.3.1",
+        "markdown-it": "^8.4.0",
+        "plantuml-encoder": "^1.2.5",
+        "resize-observer-polyfill": "^1.5.0",
+        "squire-rte": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
+        "to-mark": "^1.1.4",
+        "tui-chart": "^3.0.1",
+        "tui-code-snippet": "^1.5.0",
+        "tui-color-picker": "^2.2.1"
+      },
+      "dependencies": {
+        "jquery": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+          "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+          "dev": true
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -7250,6 +7746,12 @@
       "version": "0.7.14",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
       "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "uglify-js": {
@@ -7301,6 +7803,23 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -7319,6 +7838,66 @@
         }
       }
     },
+    "url-loader": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
+      "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "mime": "^2.0.3",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+          "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -7327,6 +7906,12 @@
       "requires": {
         "os-homedir": "^1.0.0"
       }
+    },
+    "utf8-bytes": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+      "integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30=",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",

--- a/lektor/admin/package-lock.json
+++ b/lektor/admin/package-lock.json
@@ -257,9 +257,9 @@
       "dev": true
     },
     "@types/tern": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.0.tgz",
-      "integrity": "sha512-klmHtUmX+in4DA8l+Hj/zFO8M3g+otgQ9n7AfiEJ3Er9xjxjEsidKVyifLV4klwVu/X7qh8oIFY4d+GNgZiR7Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.2.tgz",
+      "integrity": "sha512-OtEnzdjKJqQ5URz4DKvVkHDiPcjXKXc+NbqXsFb3rughaN4R7JVtoSRAvuoiDIA4Ev4mxX3u56WvPBpEac5ULA==",
       "dev": true,
       "requires": {
         "@types/estree": "*"
@@ -1570,9 +1570,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.45.0.tgz",
-      "integrity": "sha512-c19j644usCE8gQaXa0jqn2B/HN9MnB2u6qPIrrhrMkB+QAP42y8G4QnTwuwbVSoUS1jEl7JU9HZMGhCDL0nsAw==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.46.0.tgz",
+      "integrity": "sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w==",
       "dev": true
     },
     "color-convert": {
@@ -6757,8 +6757,8 @@
       }
     },
     "raphael": {
-      "version": "git+https://github.com/nhnent/raphael.git#78a6ed3ec269f33b6457b0ec66f8c3d1f2ed70e0",
-      "from": "git+https://github.com/nhnent/raphael.git#2.2.0-c",
+      "version": "git+https://github.com/nhn/raphael.git#78a6ed3ec269f33b6457b0ec66f8c3d1f2ed70e0",
+      "from": "git+https://github.com/nhn/raphael.git#2.2.0-c",
       "dev": true,
       "requires": {
         "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
@@ -7316,8 +7316,8 @@
       "dev": true
     },
     "squire-rte": {
-      "version": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
-      "from": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
+      "version": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
+      "from": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
       "dev": true
     },
     "sshpk": {
@@ -7611,9 +7611,9 @@
       "dev": true
     },
     "to-mark": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/to-mark/-/to-mark-1.1.4.tgz",
-      "integrity": "sha512-w6NdBzrbqwxIikVUcQeb+qVyAOdwnOkOnWCTk3GwCFmeo8utAZbivY4wzX0jU25Noi/zaTO3NTrHudEB9OCjyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/to-mark/-/to-mark-1.1.5.tgz",
+      "integrity": "sha512-LLaUpBSGHQb2rleUXW7oF6vKYUALb1A1YOVIP+Yk1+seAQFQoTpI53GKY8fNBB0BKOuN57Otk9tvOi8j2N1CZg==",
       "dev": true
     },
     "tough-cookie": {
@@ -7650,35 +7650,35 @@
       "dev": true
     },
     "tui-chart": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/tui-chart/-/tui-chart-3.6.1.tgz",
-      "integrity": "sha512-Z9DU52LffSt0pdg0vrTxR73dnVD1pqKKMV3cWEFZ7TH/G2CU+2CpVdXJ6N9NpEM+CoczeQLT5mOhnpt2/gRL2g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/tui-chart/-/tui-chart-3.7.0.tgz",
+      "integrity": "sha512-twrXxK1oqYvcvmPnULPjLdVRyvza3Ab8078HWR0UbTxuXnS8RIliRZY7FbUC1L8Ii9yvWeX3US4OGCSd0iBuJQ==",
       "dev": true,
       "requires": {
         "babel-polyfill": "^6.26.0",
-        "raphael": "git+https://github.com/nhnent/raphael.git#2.2.0-c",
+        "raphael": "git+https://github.com/nhn/raphael.git#2.2.0-c",
         "tui-code-snippet": "^1.5.0"
       }
     },
     "tui-code-snippet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/tui-code-snippet/-/tui-code-snippet-1.5.0.tgz",
-      "integrity": "sha512-grVv/lrHDXp9sRWypmMe76fHDlpdSfVYLiVmy8f765mWEBk+2JtiKgH+ACuipNtPZbUAy2pYgIWRQfDcg0zdCw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/tui-code-snippet/-/tui-code-snippet-1.5.1.tgz",
+      "integrity": "sha512-a3udDRNFAJBKz7B/004ew4uyokObOrKpR8o0eq/33qap4i0xCah6SQ3eHDatZ+kdezJxSGEjW0FwewfX0d6PrQ==",
       "dev": true
     },
     "tui-color-picker": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tui-color-picker/-/tui-color-picker-2.2.2.tgz",
-      "integrity": "sha512-uad1DJ+xQsBUxRYXGm9SM2l+wE8H8ZXZrNBrx42LXjOr23PpdjCdBaLXuHyhK65h9sM6ZLJU9A8lnKt+rO5T7Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/tui-color-picker/-/tui-color-picker-2.2.3.tgz",
+      "integrity": "sha512-TI93kidjl9NMFIJV2RZvHtR093PdvJxNgwnC2L7mWe/SwFAv4rfVOSIYgkYR9hs7+cvUETGmBHvW2Kz60Nzd1g==",
       "dev": true,
       "requires": {
         "tui-code-snippet": "^1.5.0"
       }
     },
     "tui-editor": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tui-editor/-/tui-editor-1.3.3.tgz",
-      "integrity": "sha512-AKck+bPC+4ZOeD7rNLeKvLF3zLITlU0QLxVesT0o66R1X7YowIKbWeBlVvSqcWv2eB/ZGJ9Qi6/1lFU2yYOuVA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tui-editor/-/tui-editor-1.4.0.tgz",
+      "integrity": "sha512-VUHteAkJmRAOBQ/DwJXTeaBxjWoFqfVvCfb7QkVSOy+sE4ru0J5O+LcgD9uKzKZwYnnDndCl006fn6vAnpM8tw==",
       "dev": true,
       "requires": {
         "@types/codemirror": "0.0.71",
@@ -7690,17 +7690,17 @@
         "markdown-it": "^8.4.0",
         "plantuml-encoder": "^1.2.5",
         "resize-observer-polyfill": "^1.5.0",
-        "squire-rte": "github:sohee-lee7/Squire#b1e0e1031fa18912d233c204cbe7c7fae4a42621",
-        "to-mark": "^1.1.4",
+        "squire-rte": "github:sohee-lee7/Squire#e35304de663568a458a75f0d3c206fbddb8c0699",
+        "to-mark": "^1.1.5",
         "tui-chart": "^3.0.1",
         "tui-code-snippet": "^1.5.0",
         "tui-color-picker": "^2.2.1"
       },
       "dependencies": {
         "jquery": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-          "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
           "dev": true
         }
       }

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -36,7 +36,7 @@
     "react-router": "^2.6.0",
     "standard": ">8.5.0",
     "style-loader": "^0.8.3",
-    "tui-editor": "^1.3.3",
+    "tui-editor": "^1.4.0",
     "url-loader": "^1.1.2",
     "webpack": "^3.6.0"
   },

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -36,6 +36,8 @@
     "react-router": "^2.6.0",
     "standard": ">8.5.0",
     "style-loader": "^0.8.3",
+    "tui-editor": "^1.3.3",
+    "url-loader": "^1.1.2",
     "webpack": "^3.6.0"
   },
   "scripts": {

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -189,6 +189,7 @@ class EditPage extends RecordEditComponent {
         field={field}
         onChange={this.onValueChange.bind(this, field)}
         disabled={!(field.alts_enabled == null || (field.alts_enabled ^ this.state.recordInfo.alt === '_primary'))}
+        {...this.getRoutingProps()}
       />
     )
   }

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -77,6 +77,7 @@ class FieldBox extends Component {
             type={field.type}
             placeholder={placeholder}
             disabled={disabled}
+            {...this.getRoutingProps()}
           /></dd>
         </dl>
       )

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -9,11 +9,13 @@ import fakeWidgets from './widgets/fakeWidgets'
 import { BasicWidgetMixin } from './widgets/mixins'
 import Component from './components/Component'
 import ToggleGroup from './components/ToggleGroup'
+import ToastEditor from './widgets/ToastEditor'
 import i18n from './i18n'
 
 const widgetComponents = {
   'singleline-text': primitiveWidgets.SingleLineTextInputWidget,
   'multiline-text': primitiveWidgets.MultiLineTextInputWidget,
+  'markdown-gui': ToastEditor,
   'datepicker': primitiveWidgets.DateInputWidget,
   'integer': primitiveWidgets.IntegerInputWidget,
   'float': primitiveWidgets.FloatInputWidget,

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -40,7 +40,6 @@ class ToastEditor extends Component {
     super(props)
 
     this.element = null
-    this.count = 0
     this.content = this.props.value
 
     this.onChange = this.onChange.bind(this)
@@ -115,10 +114,6 @@ class ToastEditor extends Component {
     }
 
     const markdown = this.state.editor.getMarkdown()
-    if (this.count === 0 && markdown === '') {
-      this.count++
-      return
-    }
 
     // recalculate height - delay is required to get most up to date height
     setTimeout(function () {

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -54,15 +54,6 @@ class ToastEditor extends Component {
     }
   }
 
-  // from http://youmightnotneedjquery.com/#outer_height_with_margin
-  outerHeight (el) {
-    var height = el.offsetHeight
-    var style = window.getComputedStyle(el)
-
-    height += parseInt(style.marginTop) + parseInt(style.marginBottom)
-    return height
-  }
-
   onLoad (editor) {
     // add in the mode switcher
     let toolbar = editor.getUI().getToolbar()
@@ -92,14 +83,14 @@ class ToastEditor extends Component {
     try {
       // markdown
       let editorEl = currentEditor.editorContainerEl.getElementsByClassName('CodeMirror-sizer')[0]
-      editorHeight = this.outerHeight(editorEl)
+      editorHeight = $(editorEl).outerHeight(true)
     } catch (e) {
       // wysiwyg
 
       // get height of all children in editor
       let editorEl = currentEditor.$editorContainerEl[0].firstChild
       let editorChildren = Array.from(editorEl.children)
-      let editorChildrenHeights = editorChildren.map(el => this.outerHeight(el))
+      let editorChildrenHeights = editorChildren.map(el => $(el).outerHeight(true))
       editorHeight = editorChildrenHeights.reduce((a, b) => a + b)
 
       // add on padding/border/margin of editor element
@@ -143,24 +134,10 @@ class ToastEditor extends Component {
 
   // focus and blur are used to implement the border-blur found on other widgets
   focus () {
-    this.setState({
-      style: {
-        borderColor: '#807177',
-        outline: 0,
-        boxShadow: 'inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(128, 113, 119, 0.6)',
-        transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
-      }
-    })
-    this.element.firstChild.style.transition = 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
-    this.element.firstChild.style.borderColor = '#807177'
+    this.element.classList.add('active')
   }
   blur () {
-    this.setState({
-      style: {
-        transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
-      }
-    })
-    this.element.firstChild.style.borderColor = '#e5e5e5'
+    this.element.classList.remove('active')
   }
 
   onRef (element) {
@@ -202,6 +179,7 @@ class ToastEditor extends Component {
         <div
           ref={this.onRef}
           style={this.state.style}
+          className="toast-editor-widget"
         />
         <LektorImageExtension editor={this.state.editor} {...this.getRoutingProps()} />
         <LektorLinkExtension editor={this.state.editor} {...this.getRoutingProps()} />

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -64,9 +64,20 @@ class ToastEditor extends Component {
   }
 
   onLoad (editor) {
-    // change label of 'WYSIWYG' to 'Rich Text'
-    editor.getUI().getModeSwitch().$el[0].getElementsByClassName('wysiwyg')[0].innerText = 'Rich Text'
+    // add in the mode switcher
+    let toolbar = editor.getUI().getToolbar()
+    toolbar.insertItem(0, {type: 'button', options: {name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab active'}})
+    toolbar.insertItem(1, {type: 'button', options: {name: 'markdown-tab', text: 'Markdown',  event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab'}})
+    toolbar.insertItem(2, {type: 'divider', options: {name: 'switch-divider', className: 'mode-tab-divider'}})
+    let richtextbtn = toolbar.getItem(0).$el
+    let markdownbtn = toolbar.getItem(1).$el
+    editor.eventManager.addEventType('mode-tab-richtext')
+    editor.eventManager.addEventType('mode-tab-markdown')
+    editor.eventManager.listen('mode-tab-richtext', () => { markdownbtn.removeClass('active'); richtextbtn.addClass('active'); editor.changeMode('wysiwyg', true) })
+    editor.eventManager.listen('mode-tab-markdown', () => { richtextbtn.removeClass('active'); markdownbtn.addClass('active'); editor.changeMode('markdown', true) })
+
     this.recalculateHeight(editor)
+
   }
 
   onImageUpload (file, cb, source) {
@@ -164,6 +175,7 @@ class ToastEditor extends Component {
       useCommandShortcut: true,
       usageStatistics: false,
       previewStyle: null,
+      hideModeSwitch: true,
       toolbarItems: toolbarItems,
       hooks: {
         addImageBlobHook: this.onImageUpload

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -1,0 +1,129 @@
+'use strict'
+
+import React, { Component } from 'react'
+import Editor from 'tui-editor'
+
+import 'codemirror/lib/codemirror.css'
+import 'tui-editor/dist/tui-editor.min.css'
+import 'tui-editor/dist/tui-editor-contents.min.css'
+
+const toolbarItems = [
+  'heading',
+  'bold',
+  'italic',
+  'strike',
+  'divider',
+  'hr',
+  'quote',
+  'divider',
+  'ul',
+  'ol',
+  // 'task',
+  'indent',
+  'outdent',
+  'divider',
+  'table',
+  // 'image',
+  // 'link',
+  'divider',
+  'code',
+  'codeblock'
+]
+
+class ToastEditor extends Component {
+  constructor () {
+    super()
+    this.editor = null
+    this.element = null
+    this.count = 0
+
+    this.onChange = this.onChange.bind(this)
+    this.onRef = this.onRef.bind(this)
+    this.blur = this.blur.bind(this)
+    this.focus = this.focus.bind(this)
+
+    this.state = {
+      style: {}
+    }
+  }
+
+  onLoad (editor) {
+    // change label of 'WYSIWYG' to 'Rich Text'
+    editor.getUI().getModeSwitch().$el[0].getElementsByClassName('wysiwyg')[0].innerText = 'Rich Text'
+  }
+
+  onImageUpload (file, cb, source) {
+    // do image upload of file here, call cb once done
+    cb(file.name) // leave second param null to use user-specified text
+  }
+
+  onChange () {
+    const markdown = this.editor.getMarkdown()
+    if (this.count === 0 && markdown === '') {
+      this.count++
+      return
+    }
+
+    if (this.props.onChange) {
+      this.props.onChange(markdown)
+    }
+  }
+
+  // focus and blur are used to implement the border-blur found on other widgets
+  focus () {
+    this.setState({
+      style: {
+        borderColor: '#807177',
+        outline: 0,
+        boxShadow: 'inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(128, 113, 119, 0.6)',
+        transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
+      }
+    })
+    this.element.firstChild.style.transition = 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
+    this.element.firstChild.style.borderColor = '#807177'
+  }
+  blur () {
+    this.setState({
+      style: {
+        transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s'
+      }
+    })
+    this.element.firstChild.style.borderColor = '#e5e5e5'
+  }
+
+  onRef (element) {
+    if (element === null) {
+      return
+    }
+    this.element = element
+    this.editor = new Editor({
+      el: element,
+      initialValue: this.props.value,
+      initialEditType: 'wysiwyg',
+      useCommandShortcut: true,
+      usageStatistics: false,
+      previewStyle: null,
+      toolbarItems: toolbarItems,
+      hooks: {
+        addImageBlobHook: this.onImageUpload
+      },
+      events: {
+        load: this.onLoad,
+        change: this.onChange,
+        focus: this.focus,
+        blur: this.blur
+      }
+    })
+  }
+
+  render () {
+    return (
+      <div
+        ref={this.onRef}
+        style={this.state.style}
+      />
+    )
+  }
+}
+
+export default ToastEditor

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -56,17 +56,17 @@ class ToastEditor extends Component {
 
   onLoad (editor) {
     // add in the mode switcher
-    let toolbar = editor.getUI().getToolbar()
+    const toolbar = editor.getUI().getToolbar()
     toolbar.insertItem(0, { type: 'button', options: { name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab' } })
     toolbar.insertItem(1, { type: 'button', options: { name: 'markdown-tab', text: 'Markdown', event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab' } })
     toolbar.insertItem(2, { type: 'divider', options: { name: 'switch-divider', className: 'mode-tab-divider' } })
-    let richtextbtn = toolbar.getItem(0).$el
-    let markdownbtn = toolbar.getItem(1).$el
+    const richtextbtn = toolbar.getItem(0).$el
+    const markdownbtn = toolbar.getItem(1).$el
     editor.eventManager.addEventType('mode-tab-richtext')
     editor.eventManager.addEventType('mode-tab-markdown')
     editor.eventManager.listen('mode-tab-richtext', () => { markdownbtn.removeClass('active'); richtextbtn.addClass('active'); editor.changeMode('wysiwyg', true) })
     editor.eventManager.listen('mode-tab-markdown', () => { richtextbtn.removeClass('active'); markdownbtn.addClass('active'); editor.changeMode('markdown', true) })
-    let activebtn = (this.props.type.default_view === 'richtext') ? richtextbtn : markdownbtn
+    const activebtn = (this.props.type.default_view === 'richtext') ? richtextbtn : markdownbtn
     activebtn.addClass('active')
 
     this.recalculateHeight(editor)
@@ -78,33 +78,33 @@ class ToastEditor extends Component {
   }
 
   recalculateHeight (editor) {
-    let currentEditor = editor.getCurrentModeEditor()
+    const currentEditor = editor.getCurrentModeEditor()
     let editorHeight
     try {
       // markdown
-      let editorEl = currentEditor.editorContainerEl.getElementsByClassName('CodeMirror-sizer')[0]
+      const editorEl = currentEditor.editorContainerEl.getElementsByClassName('CodeMirror-sizer')[0]
       editorHeight = $(editorEl).outerHeight(true)
     } catch (e) {
       // wysiwyg
 
       // get height of all children in editor
-      let editorEl = currentEditor.$editorContainerEl[0].firstChild
+      const editorEl = currentEditor.$editorContainerEl[0].firstChild
       let editorChildren = Array.from(editorEl.children)
-      let editorChildrenHeights = editorChildren.map(el => $(el).outerHeight(true))
+      const editorChildrenHeights = editorChildren.map(el => $(el).outerHeight(true))
       editorHeight = editorChildrenHeights.reduce((a, b) => a + b)
 
       // add on padding/border/margin of editor element
-      let marginTop = parseInt(window.getComputedStyle(editorEl).marginTop)
-      let marginBottom = parseInt(window.getComputedStyle(editorEl).marginBottom)
-      let paddingTop = parseInt(window.getComputedStyle(editorEl).paddingTop)
-      let paddingBottom = parseInt(window.getComputedStyle(editorEl).paddingBottom)
-      let borderTop = parseInt(window.getComputedStyle(editorEl).borderTopWidth)
-      let borderBottom = parseInt(window.getComputedStyle(editorEl).borderBottomWidth)
+      const marginTop = parseInt(window.getComputedStyle(editorEl).marginTop)
+      const marginBottom = parseInt(window.getComputedStyle(editorEl).marginBottom)
+      const paddingTop = parseInt(window.getComputedStyle(editorEl).paddingTop)
+      const paddingBottom = parseInt(window.getComputedStyle(editorEl).paddingBottom)
+      const borderTop = parseInt(window.getComputedStyle(editorEl).borderTopWidth)
+      const borderBottom = parseInt(window.getComputedStyle(editorEl).borderBottomWidth)
       editorHeight += (marginTop + marginBottom + paddingTop + paddingBottom + borderTop + borderBottom)
     }
 
-    let totalHeight = editorHeight + 31 + 31
-    let totalHeightStr = totalHeight + 'px'
+    const totalHeight = editorHeight + 31 + 31
+    const totalHeightStr = totalHeight + 'px'
     editor.height(totalHeightStr)
   }
 
@@ -121,7 +121,7 @@ class ToastEditor extends Component {
     }.bind(this), 10)
 
     // send markdown up
-    let contentChanged = markdown !== this.content
+    const contentChanged = markdown !== this.content
     if (this.props.onChange && this.content !== null && contentChanged) {
       this.content = markdown
       this.props.onChange(markdown)

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -83,14 +83,14 @@ class ToastEditor extends Component {
     try {
       // markdown
       const editorEl = currentEditor.editorContainerEl.getElementsByClassName('CodeMirror-sizer')[0]
-      editorHeight = $(editorEl).outerHeight(true)
+      editorHeight = window.$(editorEl).outerHeight(true)
     } catch (e) {
       // wysiwyg
 
       // get height of all children in editor
       const editorEl = currentEditor.$editorContainerEl[0].firstChild
       let editorChildren = Array.from(editorEl.children)
-      const editorChildrenHeights = editorChildren.map(el => $(el).outerHeight(true))
+      const editorChildrenHeights = editorChildren.map(el => window.$(el).outerHeight(true))
       editorHeight = editorChildrenHeights.reduce((a, b) => a + b)
 
       // add on padding/border/margin of editor element
@@ -177,7 +177,7 @@ class ToastEditor extends Component {
         <div
           ref={this.onRef}
           style={this.state.style}
-          className="toast-editor-widget"
+          className='toast-editor-widget'
         />
         <LektorImageExtension editor={this.state.editor} {...this.getRoutingProps()} />
         <LektorLinkExtension editor={this.state.editor} {...this.getRoutingProps()} />

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -67,7 +67,7 @@ class ToastEditor extends Component {
     // add in the mode switcher
     let toolbar = editor.getUI().getToolbar()
     toolbar.insertItem(0, {type: 'button', options: {name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab'}})
-    toolbar.insertItem(1, {type: 'button', options: {name: 'markdown-tab', text: 'Markdown',  event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab'}})
+    toolbar.insertItem(1, {type: 'button', options: {name: 'markdown-tab', text: 'Markdown', event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab'}})
     toolbar.insertItem(2, {type: 'divider', options: {name: 'switch-divider', className: 'mode-tab-divider'}})
     let richtextbtn = toolbar.getItem(0).$el
     let markdownbtn = toolbar.getItem(1).$el
@@ -79,7 +79,6 @@ class ToastEditor extends Component {
     activebtn.addClass('active')
 
     this.recalculateHeight(editor)
-
   }
 
   onImageUpload (file, cb, source) {

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -1,7 +1,9 @@
 'use strict'
 
-import React, { Component } from 'react'
+import React from 'react'
 import Editor from 'tui-editor'
+
+import Component from '../components/Component'
 
 import 'codemirror/lib/codemirror.css'
 import 'tui-editor/dist/tui-editor.min.css'

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -36,11 +36,12 @@ const toolbarItems = [
 ]
 
 class ToastEditor extends Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
+
     this.element = null
     this.count = 0
-    this.content = null
+    this.content = this.props.value
 
     this.onChange = this.onChange.bind(this)
     this.onLoad = this.onLoad.bind(this)
@@ -140,14 +141,9 @@ class ToastEditor extends Component {
     this.element.classList.remove('active')
   }
 
-  onRef (element) {
-    if (element === null) {
-      return
-    }
-    this.element = element
-    this.content = this.props.value
-    let editor = new Editor({
-      el: element,
+  componentDidMount () {
+    const editor = new Editor({
+      el: this.element,
       initialValue: this.props.value,
       initialEditType: (this.props.type.default_view === 'richtext') ? 'wysiwyg' : 'markdown',
       useCommandShortcut: true,
@@ -171,6 +167,13 @@ class ToastEditor extends Component {
     this.setState({
       editor: editor
     })
+  }
+
+  onRef (element) {
+    if (element === null) {
+      return
+    }
+    this.element = element
   }
 
   render () {

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -38,7 +38,6 @@ const toolbarItems = [
 class ToastEditor extends Component {
   constructor () {
     super()
-    this.editor = null
     this.element = null
     this.count = 0
     this.content = null
@@ -50,7 +49,8 @@ class ToastEditor extends Component {
     this.focus = this.focus.bind(this)
 
     this.state = {
-      style: {}
+      style: {},
+      editor: null
     }
   }
 
@@ -106,11 +106,11 @@ class ToastEditor extends Component {
   }
 
   onChange () {
-    if (!this.editor) {
+    if (!this.state.editor) {
       return
     }
 
-    const markdown = this.editor.getMarkdown()
+    const markdown = this.state.editor.getMarkdown()
     if (this.count === 0 && markdown === '') {
       this.count++
       return
@@ -118,7 +118,7 @@ class ToastEditor extends Component {
 
     // recalculate height - delay is required to get most up to date height
     setTimeout(function () {
-      this.recalculateHeight(this.editor)
+      this.recalculateHeight(this.state.editor)
     }.bind(this), 10)
 
     // send markdown up
@@ -157,7 +157,7 @@ class ToastEditor extends Component {
     }
     this.element = element
     this.content = this.props.value
-    this.editor = new Editor({
+    let editor = new Editor({
       el: element,
       initialValue: this.props.value,
       initialEditType: 'wysiwyg',
@@ -178,6 +178,9 @@ class ToastEditor extends Component {
       },
       exts: ['lektorImage', 'lektorLink']
     })
+    this.setState({
+      editor: editor
+    })
   }
 
   render () {
@@ -187,8 +190,8 @@ class ToastEditor extends Component {
           ref={this.onRef}
           style={this.state.style}
         />
-        <LektorImageExtension editor={this.editor} {...this.getRoutingProps()} />
-        <LektorLinkExtension editor={this.editor} {...this.getRoutingProps()} />
+        <LektorImageExtension editor={this.state.editor} {...this.getRoutingProps()} />
+        <LektorLinkExtension editor={this.state.editor} {...this.getRoutingProps()} />
       </div>
     )
   }

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -66,9 +66,9 @@ class ToastEditor extends Component {
   onLoad (editor) {
     // add in the mode switcher
     let toolbar = editor.getUI().getToolbar()
-    toolbar.insertItem(0, {type: 'button', options: {name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab'}})
-    toolbar.insertItem(1, {type: 'button', options: {name: 'markdown-tab', text: 'Markdown', event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab'}})
-    toolbar.insertItem(2, {type: 'divider', options: {name: 'switch-divider', className: 'mode-tab-divider'}})
+    toolbar.insertItem(0, { type: 'button', options: { name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab' } })
+    toolbar.insertItem(1, { type: 'button', options: { name: 'markdown-tab', text: 'Markdown', event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab' } })
+    toolbar.insertItem(2, { type: 'divider', options: { name: 'switch-divider', className: 'mode-tab-divider' } })
     let richtextbtn = toolbar.getItem(0).$el
     let markdownbtn = toolbar.getItem(1).$el
     editor.eventManager.addEventType('mode-tab-richtext')

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -41,6 +41,7 @@ class ToastEditor extends Component {
     this.editor = null
     this.element = null
     this.count = 0
+    this.content = null
 
     this.onChange = this.onChange.bind(this)
     this.onLoad = this.onLoad.bind(this)
@@ -121,7 +122,9 @@ class ToastEditor extends Component {
     }.bind(this), 10)
 
     // send markdown up
-    if (this.props.onChange) {
+    let contentChanged = markdown !== this.content
+    if (this.props.onChange && this.content !== null && contentChanged) {
+      this.content = markdown
       this.props.onChange(markdown)
     }
   }
@@ -153,6 +156,7 @@ class ToastEditor extends Component {
       return
     }
     this.element = element
+    this.content = this.props.value
     this.editor = new Editor({
       el: element,
       initialValue: this.props.value,

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -66,7 +66,7 @@ class ToastEditor extends Component {
   onLoad (editor) {
     // add in the mode switcher
     let toolbar = editor.getUI().getToolbar()
-    toolbar.insertItem(0, {type: 'button', options: {name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab active'}})
+    toolbar.insertItem(0, {type: 'button', options: {name: 'richtext-tab', text: 'Rich Text', event: 'mode-tab-richtext', tooltip: 'Use Rich Text Editor', className: 'mode-tab'}})
     toolbar.insertItem(1, {type: 'button', options: {name: 'markdown-tab', text: 'Markdown',  event: 'mode-tab-markdown', tooltip: 'Use Markdown Editor', className: 'mode-tab'}})
     toolbar.insertItem(2, {type: 'divider', options: {name: 'switch-divider', className: 'mode-tab-divider'}})
     let richtextbtn = toolbar.getItem(0).$el
@@ -75,6 +75,8 @@ class ToastEditor extends Component {
     editor.eventManager.addEventType('mode-tab-markdown')
     editor.eventManager.listen('mode-tab-richtext', () => { markdownbtn.removeClass('active'); richtextbtn.addClass('active'); editor.changeMode('wysiwyg', true) })
     editor.eventManager.listen('mode-tab-markdown', () => { richtextbtn.removeClass('active'); markdownbtn.addClass('active'); editor.changeMode('markdown', true) })
+    let activebtn = (this.props.type.default_view === 'richtext') ? richtextbtn : markdownbtn
+    activebtn.addClass('active')
 
     this.recalculateHeight(editor)
 
@@ -171,7 +173,7 @@ class ToastEditor extends Component {
     let editor = new Editor({
       el: element,
       initialValue: this.props.value,
-      initialEditType: 'wysiwyg',
+      initialEditType: (this.props.type.default_view === 'richtext') ? 'wysiwyg' : 'markdown',
       useCommandShortcut: true,
       usageStatistics: false,
       previewStyle: null,

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -100,6 +100,10 @@ class ToastEditor extends Component {
   }
 
   onChange () {
+    if (!this.editor) {
+      return
+    }
+
     const markdown = this.editor.getMarkdown()
     if (this.count === 0 && markdown === '') {
       this.count++
@@ -159,6 +163,7 @@ class ToastEditor extends Component {
         load: this.onLoad,
         change: this.onChange,
         stateChange: this.onChange,
+        contentChangedFromWysiwyg: () => {setTimeout(this.onChange, 100)},
         focus: this.focus,
         blur: this.blur
       }

--- a/lektor/admin/static/js/widgets/ToastEditor.jsx
+++ b/lektor/admin/static/js/widgets/ToastEditor.jsx
@@ -9,6 +9,9 @@ import 'codemirror/lib/codemirror.css'
 import 'tui-editor/dist/tui-editor.min.css'
 import 'tui-editor/dist/tui-editor-contents.min.css'
 
+import LektorLinkExtension from './tuiEditorLektorLinkExt.jsx'
+import LektorImageExtension from './tuiEditorLektorImageExt.jsx'
+
 const toolbarItems = [
   'heading',
   'bold',
@@ -165,19 +168,24 @@ class ToastEditor extends Component {
         load: this.onLoad,
         change: this.onChange,
         stateChange: this.onChange,
-        contentChangedFromWysiwyg: () => {setTimeout(this.onChange, 100)},
+        contentChangedFromWysiwyg: () => { setTimeout(this.onChange, 100) },
         focus: this.focus,
         blur: this.blur
-      }
+      },
+      exts: ['lektorImage', 'lektorLink']
     })
   }
 
   render () {
     return (
-      <div
-        ref={this.onRef}
-        style={this.state.style}
-      />
+      <div>
+        <div
+          ref={this.onRef}
+          style={this.state.style}
+        />
+        <LektorImageExtension editor={this.editor} {...this.getRoutingProps()} />
+        <LektorLinkExtension editor={this.editor} {...this.getRoutingProps()} />
+      </div>
     )
   }
 }

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -134,6 +134,17 @@ let lastBlockId = 0
 const FlowWidget = React.createClass({
   mixins: [BasicWidgetMixin],
 
+  getRoutingProps: function () {
+    return {
+      history: this.props.history,
+      location: this.props.location,
+      params: this.props.params,
+      route: this.props.route,
+      routeParams: this.props.routeParams,
+      routes: this.props.routes
+    }
+  },
+
   statics: {
     deserializeValue: (value, type) => {
       return parseFlowFormat(value).map((item) => {
@@ -220,6 +231,7 @@ const FlowWidget = React.createClass({
         placeholder={placeholder}
         field={field}
         onChange={onChange}
+        {...this.getRoutingProps()}
       />
     )
   },

--- a/lektor/admin/static/js/widgets/multiWidgets.jsx
+++ b/lektor/admin/static/js/widgets/multiWidgets.jsx
@@ -52,7 +52,7 @@ const CheckboxesInputWidget = React.createClass({
   },
 
   render () {
-    let { className, value, placeholder, type, ...otherProps } = this.props // eslint-disable-line no-unused-vars
+    let { history, location, params, route, routeParams, routes, className, value, placeholder, type, ...otherProps } = this.props // eslint-disable-line no-unused-vars
     className = (className || '') + ' checkbox'
 
     const choices = this.props.type.choices.map((item) => {
@@ -84,7 +84,7 @@ const SelectInputWidget = React.createClass({
   },
 
   render () {
-    let { className, type, value, placeholder, onChange, ...otherProps } = this.props // eslint-disable-line no-unused-vars
+    let { history, location, params, route, routeParams, routes, className, type, value, placeholder, onChange, ...otherProps } = this.props // eslint-disable-line no-unused-vars
     value = value || placeholder
 
     let choices = this.props.type.choices.map((item) => {

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -36,7 +36,7 @@ const InputWidgetMixin = {
   },
 
   render () {
-    let { type, onChange, className, ...otherProps } = this.props
+    let { history, location, params, route, routeParams, routes, type, onChange, className, ...otherProps } = this.props // eslint-disable-line no-unused-vars
     let help = null
     const failure = this.getValidationFailure()
     className = (className || '')
@@ -281,7 +281,7 @@ const MultiLineTextInputWidget = React.createClass({
   },
 
   render () {
-    let { className, type, onChange, style, ...otherProps } = this.props // eslint-disable-line no-unused-vars
+    let { history, location, params, route, routeParams, routes, className, type, onChange, style, ...otherProps } = this.props // eslint-disable-line no-unused-vars
     className = (className || '')
 
     style = style || {}
@@ -322,7 +322,7 @@ const BooleanInputWidget = React.createClass({
   },
 
   render () {
-    let { className, type, placeholder, onChange, value, ...otherProps } = this.props // eslint-disable-line no-unused-vars
+    let { history, location, params, route, routeParams, routes, className, type, placeholder, onChange, value, ...otherProps } = this.props // eslint-disable-line no-unused-vars
     className = (className || '') + ' checkbox'
 
     return (

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -214,7 +214,7 @@ class LektorImageExtension extends RecordComponent {
 
     // render popup
     return (
-      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left}}>
+      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left, minWidth: '295px'}}>
         <div id='tabs' className='popup'>
           <ul className='nav'>
             <li><a onClick={this.modeChange} data-mode='attachment' className={this.state.mode === 'attachment' ? 'active' : ''}>Attachment</a></li>

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -102,7 +102,7 @@ class LektorImageExtension extends RecordComponent {
       }
     })
     const lektorImageButtonIndex = toolbar.indexOfItem(EXT_NAME)
-    const {$el: $button} = toolbar.getItem(lektorImageButtonIndex)
+    const { $el: $button } = toolbar.getItem(lektorImageButtonIndex)
     this.button = $button
 
     // make the popup hide on editor focus, closeAllPopup, and close
@@ -122,29 +122,29 @@ class LektorImageExtension extends RecordComponent {
       utils.loadData('/recordinfo', {
         path: this.getRecordPath()
       }, null, makeRichPromise)
-      .then((data) => {
-        // filter out non-image files
-        let imageAttachments = data.attachments.filter((file) => {
-          return file.type === 'image'
-        })
+        .then((data) => {
+          // filter out non-image files
+          let imageAttachments = data.attachments.filter((file) => {
+            return file.type === 'image'
+          })
 
-        // add the attachments into state
-        this.setState({
-          files: imageAttachments
+          // add the attachments into state
+          this.setState({
+            files: imageAttachments
+          })
         })
-      })
-      .finally(() => {
-        // set popup location to be under the button
-        const { offsetTop, offsetLeft } = this.button.get(0)
-        this.setState({
-          top: offsetTop + this.button.outerHeight() + 18 + 4,
-          left: offsetLeft + 15
-        })
+        .finally(() => {
+          // set popup location to be under the button
+          const { offsetTop, offsetLeft } = this.button.get(0)
+          this.setState({
+            top: offsetTop + this.button.outerHeight() + 18 + 4,
+            left: offsetLeft + 15
+          })
 
-        // show the popup
-        this.editor.eventManager.emit('closeAllPopup')
-        this.show()
-      })
+          // show the popup
+          this.editor.eventManager.emit('closeAllPopup')
+          this.show()
+        })
     })
   }
 
@@ -214,7 +214,7 @@ class LektorImageExtension extends RecordComponent {
 
     // render popup
     return (
-      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left, minWidth: '295px'}}>
+      <div className='tui-popup-wrapper tui-popup-body' style={{ display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left, minWidth: '295px' }}>
         <div id='tabs' className='popup'>
           <ul className='nav'>
             <li><a onClick={this.modeChange} data-mode='attachment' className={this.state.mode === 'attachment' ? 'active' : ''}>Attachment</a></li>
@@ -222,7 +222,7 @@ class LektorImageExtension extends RecordComponent {
             <li><a onClick={this.modeChange} data-mode='external' className={this.state.mode === 'external' ? 'active' : ''}>External</a></li>
           </ul>
 
-          <div id='popup-tab-attachment' className='content attachment' style={{display: this.state.mode === 'attachment' ? 'block' : 'none'}}>
+          <div id='popup-tab-attachment' className='content attachment' style={{ display: this.state.mode === 'attachment' ? 'block' : 'none' }}>
             <dl className='field'>
               <dt>File</dt>
               <dd>
@@ -248,7 +248,7 @@ class LektorImageExtension extends RecordComponent {
             </dl>
           </div>
 
-          <div id='popup-tab-upload' className='content' style={{display: this.state.mode === 'upload' ? 'block' : 'none'}}>
+          <div id='popup-tab-upload' className='content' style={{ display: this.state.mode === 'upload' ? 'block' : 'none' }}>
             <dl className='field'>
               <dt>Image File</dt>
               <dd>
@@ -271,7 +271,7 @@ class LektorImageExtension extends RecordComponent {
             </dl>
           </div>
 
-          <div id='popup-tab-external' className='content' style={{display: this.state.mode === 'external' ? 'block' : 'none'}}>
+          <div id='popup-tab-external' className='content' style={{ display: this.state.mode === 'external' ? 'block' : 'none' }}>
             <dl className='field'>
               <dt>Image URL</dt>
               <dd>

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -1,0 +1,302 @@
+/*
+ * Insert Image extension for TUI editor
+ * Based on popupAddImage.js and colorSyntax.js
+ *
+ * Integrates with Lektor's attachment system to enable selecting an existing
+ * attachment, and uploading a new image attachment.
+ */
+
+import React from 'react'
+
+import hub from '../hub'
+import utils from '../utils'
+import { AttachmentsChangedEvent } from '../events'
+import RecordComponent from '../components/RecordComponent'
+import makeRichPromise from '../richPromise'
+
+// name of the extension
+const EXT_NAME = 'lektorLink'
+
+class LektorImageExtension extends RecordComponent {
+  constructor (props) {
+    super(props)
+
+    this.editor = null
+    this.button = null
+
+    this.initForm = {
+      attachmentPath: '----',
+      attachmentAltText: '',
+      uploadFile: null,
+      uploadAltText: '',
+      externalPath: '',
+      externalAltText: ''
+    }
+
+    this.state = {
+      show: false,
+      top: '',
+      left: '',
+      mode: 'attachment',
+      files: [],
+      form: this.initForm
+    }
+
+    this.modeChange = this.modeChange.bind(this)
+    this.formChange = this.formChange.bind(this)
+    this.canAddImage = this.canAddImage.bind(this)
+    this.addImage = this.addImage.bind(this)
+    this.init = this.init.bind(this)
+    this.hide = this.hide.bind(this)
+    this.show = this.show.bind(this)
+  }
+
+  // called when we switch tabs
+  modeChange (e) {
+    this.setState({
+      mode: e.target.getAttribute('data-mode')
+    })
+  }
+
+  // called whenever one of the controlled form elements is updated
+  formChange (e) {
+    const key = e.target.getAttribute('data-key')
+    const val = e.target.type === 'file' ? e.target.files[0] : e.target.value
+
+    this.setState(prevState => {
+      return {
+        form: {
+          ...prevState.form,
+          [key]: val
+        }
+      }
+    })
+  }
+
+  hide () {
+    this.setState({
+      show: false
+    })
+  }
+
+  show () {
+    this.setState({
+      form: this.initForm,
+      show: true
+    })
+  }
+
+  init () {
+    // add the event for when the toolbar button is clicked
+    this.editor.eventManager.addEventType('lektorImageButtonClicked')
+
+    // add the button to the toolbar
+    const toolbar = this.editor.getUI().getToolbar()
+    toolbar.insertItem(14, {
+      type: 'button',
+      options: {
+        name: EXT_NAME,
+        className: 'tui-image',
+        event: 'lektorImageButtonClicked',
+        tooltip: 'Add Image'
+      }
+    })
+    const lektorImageButtonIndex = toolbar.indexOfItem(EXT_NAME)
+    const {$el: $button} = toolbar.getItem(lektorImageButtonIndex)
+    this.button = $button
+
+    // make the popup hide on editor focus, closeAllPopup, and close
+    this.editor.eventManager.listen('focus', () => { this.hide() })
+    this.editor.eventManager.listen('closeAllPopup', () => { this.hide() })
+    this.editor.eventManager.listen('removeEditor', () => { this.hide() })
+
+    // add event handler for when the toolbar button is clicked
+    this.editor.eventManager.listen('lektorImageButtonClicked', () => {
+      // if the popup is open, close it
+      if (this.state.show) {
+        this.hide()
+        return
+      }
+
+      // get the current attachments of this page by calling the API
+      utils.loadData('/recordinfo', {
+        path: this.getRecordPath()
+      }, null, makeRichPromise)
+      .then((data) => {
+        // add the attachments into state
+        this.setState({
+          files: data.attachments
+        })
+      })
+      .finally(() => {
+        // set popup location to be under the button
+        const { offsetTop, offsetLeft } = this.button.get(0)
+        this.setState({
+          top: offsetTop + this.button.outerHeight() + 18 + 4,
+          left: offsetLeft + 15
+        })
+
+        // show the popup
+        this.editor.eventManager.emit('closeAllPopup')
+        this.show()
+      })
+    })
+  }
+
+  // called when the add button on the popup is clicked
+  addImage () {
+    // what mode are we in?
+    switch (this.state.mode) {
+      case 'upload':
+        // create new form object to send to the API to upload the image
+        const formData = new window.FormData()
+        formData.append('path', this.getRecordPath())
+        formData.append('file', this.state.form.uploadFile, this.state.form.uploadFile.name)
+        const xhr = new window.XMLHttpRequest()
+        xhr.open('POST', utils.getApiUrl('/newattachment'))
+
+        // upload finished event
+        xhr.onload = (event) => {
+          const data = JSON.parse(xhr.responseText)
+          hub.emit(new AttachmentsChangedEvent({
+            recordPath: this.getRecordPath(),
+            attachmentsAdded: data.buckets.map((bucket) => {
+              return bucket.stored_filename
+            })
+          }))
+          // emit add image event to the editor to add the image in
+          this.editor.eventManager.emit('command', 'AddImage', {
+            imageUrl: data.path + '/' + data.buckets[0].stored_filename,
+            altText: this.state.form.uploadAltText
+          })
+          this.hide()
+        }
+        xhr.send(formData)
+        break
+
+      case 'attachment':
+      case 'external':
+        // emit add image event to the editor to add the image in
+        this.editor.eventManager.emit('command', 'AddImage', {
+          imageUrl: this.state.mode === 'attachment' ? this.state.form.attachmentPath : this.state.form.externalPath,
+          altText: this.state.mode === 'attachment' ? this.state.form.attachmentAltText : this.state.form.externalAltText
+        })
+
+        // close the popup
+        this.hide()
+        break
+    }
+  }
+
+  // return true if all the required info on the current tab is filled out
+  canAddImage () {
+    switch (this.state.mode) {
+      case 'attachment':
+        return this.state.form.attachmentPath !== '----'
+      case 'upload':
+        return this.state.form.uploadFile !== null
+      case 'external':
+        return this.state.form.externalPath !== ''
+    }
+  }
+
+  render () {
+    // call init once we have the editor
+    if (this.editor === null && this.props.editor !== null) {
+      this.editor = this.props.editor
+      this.init()
+    }
+
+    // render popup
+    return (
+      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left}}>
+        <div id='tabs' className='popup'>
+          <ul className='nav'>
+            <li><a onClick={this.modeChange} data-mode='attachment' className={this.state.mode === 'attachment' ? 'active' : ''}>Attachment</a></li>
+            <li><a onClick={this.modeChange} data-mode='upload' className={this.state.mode === 'upload' ? 'active' : ''}>Upload</a></li>
+            <li><a onClick={this.modeChange} data-mode='external' className={this.state.mode === 'external' ? 'active' : ''}>External</a></li>
+          </ul>
+
+          <div id='popup-tab-attachment' className='content attachment' style={{display: this.state.mode === 'attachment' ? 'block' : 'none'}}>
+            <dl className='field'>
+              <dt>File</dt>
+              <dd>
+                <div className='form-group'>
+                  <div>
+                    <select id='attachment-path' className='form-control' data-key='attachmentPath' onChange={this.formChange} value={this.state.form.attachmentPath}>
+                      <option value='----'>----</option>
+                      {this.state.files.map(file => <option key={file.id} value={file.path}>{file.id}</option>)}
+                    </select>
+                  </div>
+                </div>
+              </dd>
+            </dl>
+            <dl className='field'>
+              <dt>Alt Text</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='attachment-alt-text' type='text' className='form-control' data-key='attachmentAltText' onChange={this.formChange} value={this.state.form.attachmentAltText} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+          </div>
+
+          <div id='popup-tab-upload' className='content' style={{display: this.state.mode === 'upload' ? 'block' : 'none'}}>
+            <dl className='field'>
+              <dt>Image File</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='upload-file' type='file' className='form-control' accept='image/*' data-key='uploadFile' onChange={this.formChange} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+            <dl className='field'>
+              <dt>Alt Text</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='upload-alt-text' type='text' className='form-control' data-key='uploadAltText' onChange={this.formChange} value={this.state.form.uploadAltText} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+          </div>
+
+          <div id='popup-tab-external' className='content' style={{display: this.state.mode === 'external' ? 'block' : 'none'}}>
+            <dl className='field'>
+              <dt>Image URL</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='external-path' type='text' className='form-control' data-key='externalPath' onChange={this.formChange} value={this.state.form.externalPath} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+            <dl className='field'>
+              <dt>Alt Text</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='external-alt-text' type='text' className='form-control' data-key='externalAltText' onChange={this.formChange} value={this.state.form.externalAltText} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+          </div>
+
+          <div className='actions'>
+            <div onClick={this.addImage} className={'btn btn-primary ' + (!this.canAddImage() ? 'disabled' : '')}>Add</div>
+            <div onClick={this.hide} className='btn btn-default'>Cancel</div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default LektorImageExtension

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -124,7 +124,7 @@ class LektorImageExtension extends RecordComponent {
       }, null, makeRichPromise)
         .then((data) => {
           // filter out non-image files
-          let imageAttachments = data.attachments.filter((file) => {
+          const imageAttachments = data.attachments.filter((file) => {
             return file.type === 'image'
           })
 

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -123,9 +123,14 @@ class LektorImageExtension extends RecordComponent {
         path: this.getRecordPath()
       }, null, makeRichPromise)
       .then((data) => {
+        // filter out non-image files
+        let imageAttachments = data.attachments.filter((file) => {
+          return file.type === 'image'
+        })
+
         // add the attachments into state
         this.setState({
-          files: data.attachments
+          files: imageAttachments
         })
       })
       .finally(() => {

--- a/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorImageExt.jsx
@@ -43,7 +43,7 @@ class LektorImageExtension extends RecordComponent {
     }
 
     this.modeChange = this.modeChange.bind(this)
-    this.formChange = this.formChange.bind(this)
+    this.onChange = this.onChange.bind(this)
     this.canAddImage = this.canAddImage.bind(this)
     this.addImage = this.addImage.bind(this)
     this.init = this.init.bind(this)
@@ -59,7 +59,7 @@ class LektorImageExtension extends RecordComponent {
   }
 
   // called whenever one of the controlled form elements is updated
-  formChange (e) {
+  onChange (e) {
     const key = e.target.getAttribute('data-key')
     const val = e.target.type === 'file' ? e.target.files[0] : e.target.value
 
@@ -228,7 +228,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div>
-                    <select id='attachment-path' className='form-control' data-key='attachmentPath' onChange={this.formChange} value={this.state.form.attachmentPath}>
+                    <select id='attachment-path' className='form-control' data-key='attachmentPath' onChange={this.onChange} value={this.state.form.attachmentPath}>
                       <option value='----'>----</option>
                       {this.state.files.map(file => <option key={file.id} value={file.path}>{file.id}</option>)}
                     </select>
@@ -241,7 +241,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <input id='attachment-alt-text' type='text' className='form-control' data-key='attachmentAltText' onChange={this.formChange} value={this.state.form.attachmentAltText} />
+                    <input id='attachment-alt-text' type='text' className='form-control' data-key='attachmentAltText' onChange={this.onChange} value={this.state.form.attachmentAltText} />
                   </div>
                 </div>
               </dd>
@@ -254,7 +254,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <input id='upload-file' type='file' className='form-control' accept='image/*' data-key='uploadFile' onChange={this.formChange} />
+                    <input id='upload-file' type='file' className='form-control' accept='image/*' data-key='uploadFile' onChange={this.onChange} />
                   </div>
                 </div>
               </dd>
@@ -264,7 +264,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <input id='upload-alt-text' type='text' className='form-control' data-key='uploadAltText' onChange={this.formChange} value={this.state.form.uploadAltText} />
+                    <input id='upload-alt-text' type='text' className='form-control' data-key='uploadAltText' onChange={this.onChange} value={this.state.form.uploadAltText} />
                   </div>
                 </div>
               </dd>
@@ -277,7 +277,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <input id='external-path' type='text' className='form-control' data-key='externalPath' onChange={this.formChange} value={this.state.form.externalPath} />
+                    <input id='external-path' type='text' className='form-control' data-key='externalPath' onChange={this.onChange} value={this.state.form.externalPath} />
                   </div>
                 </div>
               </dd>
@@ -287,7 +287,7 @@ class LektorImageExtension extends RecordComponent {
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <input id='external-alt-text' type='text' className='form-control' data-key='externalAltText' onChange={this.formChange} value={this.state.form.externalAltText} />
+                    <input id='external-alt-text' type='text' className='form-control' data-key='externalAltText' onChange={this.onChange} value={this.state.form.externalAltText} />
                   </div>
                 </div>
               </dd>

--- a/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
@@ -180,8 +180,8 @@ class LektorLinkExtension extends FindFiles {
   // called when the add button on the popup is clicked
   addLink () {
     // get the link text and url, depending on what mode we're in
-    var linkText = this.state.form.pageLinkText
-    var url = this.state.form.pagePath + '/'
+    let linkText = this.state.form.pageLinkText
+    let url = this.state.form.pagePath + '/'
     if (this.state.mode === 'external') {
       linkText = this.state.form.externalLinkText
       url = this.state.form.externalPath

--- a/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
@@ -1,0 +1,295 @@
+/*
+ * Insert Link extension for TUI editor
+ * Based on popupAddLink.js and colorSyntax.js
+ *
+ * Integrates with Lektor's search system to provide suggestions of pages to
+ * link to.
+ */
+
+import React from 'react'
+
+import i18n from '../i18n'
+import FindFiles from '../dialogs/findFiles'
+
+// name of the extension
+const EXT_NAME = 'lektorImage'
+
+// regex expression to use to match against URLs
+const URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(\/([^\s]*))?$/
+
+class LektorLinkExtension extends FindFiles {
+  constructor (props) {
+    super(props)
+
+    this.editor = null
+    this.button = null
+
+    this.initForm = {
+      pagePath: '',
+      pageLinkText: '',
+      externalPath: '',
+      externalLinkText: ''
+    }
+
+    this.state = {
+      show: false,
+      top: '',
+      left: '',
+      mode: 'page',
+      form: this.initForm,
+      newOpen: true,
+      query: '',
+      currentSelection: -1,
+      results: []
+    }
+
+    this.init = this.init.bind(this)
+    this.hide = this.hide.bind(this)
+    this.show = this.show.bind(this)
+    this.modeChange = this.modeChange.bind(this)
+    this.formChange = this.formChange.bind(this)
+    this.updateFormState = this.updateFormState.bind(this)
+    this.addLink = this.addLink.bind(this)
+  }
+
+  // overrides from FindFiles, called when a page search dropdown is selected
+  onActiveItem (index) {
+    const item = this.state.results[index]
+    if (item !== undefined) {
+      // set the query (text in the field) to the title
+      this.setState({
+        results: [],
+        query: item.title
+      })
+      // update the form object with the page path
+      this.updateFormState('pagePath', item.path)
+    }
+  }
+
+  // called on change of the page search
+  onPreInputChange (e) {
+    // update the form object page path to nothing, as we are still searching
+    this.updateFormState('pagePath', '')
+    this.onInputChange.bind(this)(e)
+  }
+
+  hide () {
+    this.setState({
+      show: false
+    })
+  }
+
+  show () {
+    // on show, set the selected text to current text selection
+    const selectedText = this.editor.getSelectedText()
+    // if a url is selected, go to the external tab, and set the url to it
+    const externalPath = URL_REGEX.exec(selectedText) ? selectedText : ''
+    const mode = URL_REGEX.exec(selectedText) ? 'external' : 'page'
+
+    // reset the state
+    this.setState({
+      mode: mode,
+      show: true,
+      newOpen: true,
+      query: '',
+      currentSelection: -1,
+      results: [],
+      form: {
+        ...this.initForm,
+        pageLinkText: selectedText,
+        externalLinkText: selectedText,
+        externalPath: externalPath
+      }
+    })
+  }
+
+  // called when we switch tabs
+  modeChange (event) {
+    this.setState({
+      mode: event.target.getAttribute('data-mode')
+    })
+  }
+
+  init () {
+    // add the event for when the toolbar button is clicked
+    this.editor.eventManager.addEventType('lektorLinkButtonClicked')
+
+    // add the button to the toolbar
+    const toolbar = this.editor.getUI().getToolbar()
+    toolbar.insertItem(14, {
+      type: 'button',
+      options: {
+        name: EXT_NAME,
+        className: 'tui-link',
+        event: 'lektorLinkButtonClicked',
+        tooltip: 'Add Link'
+      }
+    })
+    const lektorImageButtonIndex = toolbar.indexOfItem(EXT_NAME)
+    const {$el: $button} = toolbar.getItem(lektorImageButtonIndex)
+    this.button = $button
+
+    // make the popup hide on editor focus, closeAllPopup, and close
+    this.editor.eventManager.listen('focus', () => { this.hide() })
+    this.editor.eventManager.listen('closeAllPopup', () => { this.hide() })
+    this.editor.eventManager.listen('removeEditor', () => { this.hide() })
+
+    // add event handler for when the toolbar button is clicked
+    this.editor.eventManager.listen('lektorLinkButtonClicked', () => {
+      // if the popup is open, close it
+      if (this.state.show) {
+        this.hide()
+        return
+      }
+
+      // set popup location to be under the button
+      const { offsetTop, offsetLeft } = this.button.get(0)
+      this.setState({
+        top: offsetTop + this.button.outerHeight() + 18 + 4,
+        left: offsetLeft + 15
+      })
+
+      // show the popup
+      this.editor.eventManager.emit('closeAllPopup')
+      this.show()
+    })
+  }
+
+  // return true if all the required info on the current tab is filled out
+  canAddLink () {
+    switch (this.state.mode) {
+      case 'page':
+        return this.state.form.pagePath !== ''
+      case 'external':
+        return this.state.form.externalPath !== ''
+    }
+  }
+
+  // helper function for updating a value for a key in the form state object
+  updateFormState (key, val) {
+    this.setState(prevState => {
+      return {
+        form: {
+          ...prevState.form,
+          [key]: val
+        }
+      }
+    })
+  }
+
+  // called when the add button on the popup is clicked
+  addLink () {
+    // get the link text and url, depending on what mode we're in
+    var linkText = this.state.form.pageLinkText
+    var url = this.state.form.pagePath + '/'
+    if (this.state.mode === 'external') {
+      linkText = this.state.form.externalLinkText
+      url = this.state.form.externalPath
+    }
+
+    // send the command to the editor
+    this.editor.eventManager.emit('command', 'AddLink', {
+      linkText,
+      url
+    })
+
+    // close the popup
+    this.hide()
+  }
+
+  // called whenever one of the controlled form elements is updated
+  formChange (event) {
+    const key = event.target.getAttribute('data-key')
+    const val = event.target.type = event.target.value
+    this.updateFormState(key, val)
+  }
+
+  render () {
+    // call init once we have the editor
+    if (this.editor === null && this.props.editor !== null) {
+      this.editor = this.props.editor
+      this.init()
+    }
+
+    // render popup
+    return (
+      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left}}>
+        <div id='tabs' className='popup'>
+          <ul className='nav'>
+            <li><a onClick={this.modeChange} data-mode='page' className={this.state.mode === 'page' ? 'active' : ''}>Page</a></li>
+            <li><a onClick={this.modeChange} data-mode='external' className={this.state.mode === 'external' ? 'active' : ''}>URL</a></li>
+          </ul>
+
+          <div id='popup-tab-attachment' className='content attachment' style={{display: this.state.mode === 'page' ? 'block' : 'none'}}>
+            <dl className='field'>
+              <dt>Page Search</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <div style={{position: 'initial'}} className='dialog-slot'>
+                      <div style={{width: '260px', position: 'initial', padding: 'initial'}} className='sliding-panel container'>
+                        <div style={{boxShadow: 'initial', padding: 'initial'}}>
+                          <div className='form-group'>
+                            <input type='text'
+                              ref='q'
+                              className='form-control'
+                              value={this.state.query}
+                              onChange={this.onPreInputChange.bind(this)}
+                              onKeyDown={this.onInputKey.bind(this)}
+                              placeholder={i18n.trans('FIND_FILES_PLACEHOLDER')}
+                            />
+                          </div>
+                          {this.renderResults()}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </dd>
+            </dl>
+            <dl className='field'>
+              <dt>Link Text</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='page-link-text' type='text' className='form-control' data-key='pageLinkText' onChange={this.formChange} value={this.state.form.pageLinkText} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+          </div>
+
+          <div id='popup-tab-upload' className='content' style={{display: this.state.mode === 'external' ? 'block' : 'none'}}>
+            <dl className='field'>
+              <dt>URL</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='external-path' type='text' className='form-control' data-key='externalPath' onChange={this.formChange} value={this.state.form.externalPath} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+            <dl className='field'>
+              <dt>Link Text</dt>
+              <dd>
+                <div className='form-group'>
+                  <div className='input-group'>
+                    <input id='external-link-text' type='text' className='form-control' data-key='externalLinkText' onChange={this.formChange} value={this.state.form.externalLinkText} />
+                  </div>
+                </div>
+              </dd>
+            </dl>
+          </div>
+
+          <div className='actions'>
+            <div onClick={this.addLink} className={'btn btn-primary ' + (!this.canAddLink() ? 'disabled' : '')}>Add</div>
+            <div onClick={this.hide} className='btn btn-default'>Cancel</div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default LektorLinkExtension

--- a/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
+++ b/lektor/admin/static/js/widgets/tuiEditorLektorLinkExt.jsx
@@ -126,7 +126,7 @@ class LektorLinkExtension extends FindFiles {
       }
     })
     const lektorImageButtonIndex = toolbar.indexOfItem(EXT_NAME)
-    const {$el: $button} = toolbar.getItem(lektorImageButtonIndex)
+    const { $el: $button } = toolbar.getItem(lektorImageButtonIndex)
     this.button = $button
 
     // make the popup hide on editor focus, closeAllPopup, and close
@@ -213,22 +213,22 @@ class LektorLinkExtension extends FindFiles {
 
     // render popup
     return (
-      <div className='tui-popup-wrapper tui-popup-body' style={{display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left}}>
+      <div className='tui-popup-wrapper tui-popup-body' style={{ display: this.state.show ? 'block' : 'none', width: 'auto', position: 'absolute', top: this.state.top, left: this.state.left }}>
         <div id='tabs' className='popup'>
           <ul className='nav'>
             <li><a onClick={this.modeChange} data-mode='page' className={this.state.mode === 'page' ? 'active' : ''}>Page</a></li>
             <li><a onClick={this.modeChange} data-mode='external' className={this.state.mode === 'external' ? 'active' : ''}>URL</a></li>
           </ul>
 
-          <div id='popup-tab-attachment' className='content attachment' style={{display: this.state.mode === 'page' ? 'block' : 'none'}}>
+          <div id='popup-tab-attachment' className='content attachment' style={{ display: this.state.mode === 'page' ? 'block' : 'none' }}>
             <dl className='field'>
               <dt>Page Search</dt>
               <dd>
                 <div className='form-group'>
                   <div className='input-group'>
-                    <div style={{position: 'initial'}} className='dialog-slot'>
-                      <div style={{width: '260px', position: 'initial', padding: 'initial'}} className='sliding-panel container'>
-                        <div style={{boxShadow: 'initial', padding: 'initial'}}>
+                    <div style={{ position: 'initial' }} className='dialog-slot'>
+                      <div style={{ width: '260px', position: 'initial', padding: 'initial' }} className='sliding-panel container'>
+                        <div style={{ boxShadow: 'initial', padding: 'initial' }}>
                           <div className='form-group'>
                             <input type='text'
                               ref='q'
@@ -259,7 +259,7 @@ class LektorLinkExtension extends FindFiles {
             </dl>
           </div>
 
-          <div id='popup-tab-upload' className='content' style={{display: this.state.mode === 'external' ? 'block' : 'none'}}>
+          <div id='popup-tab-upload' className='content' style={{ display: this.state.mode === 'external' ? 'block' : 'none' }}>
             <dl className='field'>
               <dt>URL</dt>
               <dd>

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -621,3 +621,11 @@ pre.traceback {
     }
   }
 }
+
+.te-preview {
+  display: none;
+}
+
+.CodeMirror pre {
+  font-family: "Roboto Slab", Georgia, "Times New Roman", serif !important;
+}

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -555,3 +555,69 @@ pre.traceback {
   color: white;
   padding: 10px 15px;
 }
+
+.popup {
+  > .nav {
+    margin-top: 0px;
+
+    > li {
+      float: left;
+
+      > a {
+        font-family: 'Roboto Slab', 'Georgia', 'Times New Roman', serif;
+        font-size: 14px;
+        display: inline-block;
+        padding: 5px 10px;
+        background: @block-item-background;
+        color: @block-item-color;
+        cursor: pointer;
+        &:not(.active):hover {
+          background: @block-item-hover-background;
+          color: @block-item-hover-color;
+        }
+        &.active {
+          font-weight: 500;
+          background: @block-item-active-background;
+          color: @block-item-active-color;
+          outline: none;
+        }
+      }
+    }
+
+    > li:not(:first-child) {
+      margin-left: 5px;margin-left: 5px;
+    }
+
+    > li:not(:last-child) {
+      margin-right: 5px;
+    }
+  }
+
+  > .content {
+    border: 2px solid @block-item-active-background;
+    padding: 10px;
+
+    > .field:not(:last-child) {
+      margin-bottom: 10px;
+    }
+
+    .form-control {
+      max-width: 260px;
+    }
+
+    .input-group {
+      width: 100%;
+    }
+  }
+
+  > .actions {
+    background: initial;
+    padding: 0;
+    margin: 0;
+
+    > .btn {
+      margin-top: 5px;
+      margin-right: 5px;
+    }
+  }
+}

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -656,3 +656,20 @@ pre.traceback {
     color: white;
   }
 }
+
+.toast-editor-widget {
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+
+  :first-child {
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  }
+
+  &.active {
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(128, 113, 119, 0.6);
+
+    :first-child {
+      border-color: @input-border-focus;
+    }
+  }
+}

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -596,6 +596,7 @@ pre.traceback {
   > .content {
     border: 2px solid @block-item-active-background;
     padding: 10px;
+    min-width: 284px;
 
     > .field:not(:last-child) {
       margin-bottom: 10px;
@@ -607,6 +608,11 @@ pre.traceback {
 
     .input-group {
       width: 100%;
+
+      input[type="file"] {
+        width: 100%;
+        height: 100%;
+      }
     }
   }
 

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -629,3 +629,24 @@ pre.traceback {
 .CodeMirror pre {
   font-family: "Roboto Slab", Georgia, "Times New Roman", serif !important;
 }
+
+.tui-editor-defaultUI .tui-editor-defaultUI-toolbar .mode-tab {
+  width: initial;
+  color: #77304c;
+  margin-bottom: 0px;
+  font-family: 'Roboto Slab', 'Georgia', 'Times New Roman', serif;
+  border: 0px;
+  padding: 0px 8px 0px 8px;
+  height: calc(100% - 5px);
+  background-color: #eeeeee;
+  background-image: none;
+
+  &:not(.active):hover {
+    background-color: #cccccc
+  }
+
+  &.active {
+    background-color: #6c5f65;
+    color: white;
+  }
+}

--- a/lektor/admin/static/webpack.config.js
+++ b/lektor/admin/static/webpack.config.js
@@ -49,10 +49,16 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract({
-          use: 'css-loader?sourceMap',
-          fallback: 'style-loader?sourceMap'
-        })
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true
+            }
+          }
+        ]
       },
       {
         test: /\.json$/,
@@ -61,6 +67,10 @@ module.exports = {
       {
         test: /\.(ttf|eot|svg|woff2?)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader'
+      },
+      {
+        test: /\.(jpe?g|png|gif)(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'url-loader'
       }
     ]
   },

--- a/lektor/types/__init__.py
+++ b/lektor/types/__init__.py
@@ -96,7 +96,7 @@ from lektor.types.primitives import \
      FloatType, BooleanType, DateType, DateTimeType
 from lektor.types.multi import CheckboxesType, SelectType
 from lektor.types.special import SortKeyType, SlugType, UrlType
-from lektor.types.formats import MarkdownType
+from lektor.types.formats import MarkdownType, MarkdownGUIType
 from lektor.types.flow import FlowType
 from lektor.types.fake import LineType, SpacingType, InfoType, HeadingType
 
@@ -124,6 +124,7 @@ builtin_types = {
 
     # Formats
     'markdown': MarkdownType,
+    'markdown-gui': MarkdownGUIType,
 
     # Flow
     'flow': FlowType,

--- a/lektor/types/formats.py
+++ b/lektor/types/formats.py
@@ -1,5 +1,6 @@
 from lektor.types import Type
 from lektor.markdown import Markdown
+from lektor.environment import PRIMARY_ALT
 
 
 class MarkdownDescriptor(object):
@@ -18,3 +19,14 @@ class MarkdownType(Type):
 
     def value_from_raw(self, raw):
         return MarkdownDescriptor(raw.value or u'')
+
+class MarkdownGUIType(MarkdownType):
+    widget = 'markdown-gui'
+
+    def to_json(self, pad, record=None, alt=PRIMARY_ALT):
+        rv = MarkdownType.to_json(self, pad, record, alt)
+        default_view = self.options.get('default_view') or 'richtext'
+        if default_view not in ('richtext', 'markdown'):
+            default_view = 'richtext'
+        rv['default_view'] = default_view
+        return rv

--- a/lektor/types/formats.py
+++ b/lektor/types/formats.py
@@ -14,7 +14,7 @@ class MarkdownDescriptor(object):
 
 
 class MarkdownType(Type):
-    widget = 'markdown-gui'
+    widget = 'multiline-text'
 
     def value_from_raw(self, raw):
         return MarkdownDescriptor(raw.value or u'')

--- a/lektor/types/formats.py
+++ b/lektor/types/formats.py
@@ -14,7 +14,7 @@ class MarkdownDescriptor(object):
 
 
 class MarkdownType(Type):
-    widget = 'multiline-text'
+    widget = 'markdown-gui'
 
     def value_from_raw(self, raw):
         return MarkdownDescriptor(raw.value or u'')


### PR DESCRIPTION
Implement GUI markdown widget which has the ability to edit in rich text, or markdown mode. Uses [Toast UI Editor](https://github.com/nhn/tui.editor) for the editor, along with two custom widgets to provide image and link functionality with Lektor.

Fixes #7, where more comments on this can be found.