### PR TITLE
Lektor 613 - Passing extra_flags to all plugin events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ pex:
 
 test-python:
 	@echo "---> running python tests"
-	py.test . --tb=long -svv --cov=lektor
+	py.test . --tb=long -vv --cov=lektor
 
 coverage-python: test-python
 	coverage xml

--- a/lektor/devcli.py
+++ b/lektor/devcli.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import sys
 import click
@@ -10,7 +9,7 @@ except ImportError:
     pass  # fallback to normal Python InteractiveConsole
 
 from .packages import get_package_info, register_package, publish_package
-from .cli import pass_context, AliasedGroup, extraflag, buildflag
+from .cli import pass_context, AliasedGroup, extraflag
 
 
 def ensure_plugin():
@@ -38,9 +37,8 @@ def cli():
 
 @cli.command('shell', short_help='Starts a python shell.')
 @extraflag
-@buildflag
 @pass_context
-def shell_cmd(ctx, extra_flags, build_flags):
+def shell_cmd(ctx, extra_flags):
     """Starts a Python shell in the context of a Lektor project.
 
     This is particularly useful for debugging plugins and to explore the
@@ -53,7 +51,6 @@ def shell_cmd(ctx, extra_flags, build_flags):
     - `pad`: a database pad initialized for the project and environment
       that is ready to use.
     """
-    extra_flags = tuple(itertools.chain(extra_flags or (), build_flags or ()))
     ctx.load_plugins(extra_flags=extra_flags)
     import code
     from lektor.db import F, Tree

--- a/lektor/devcli.py
+++ b/lektor/devcli.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import sys
 import click
@@ -9,7 +10,7 @@ except ImportError:
     pass  # fallback to normal Python InteractiveConsole
 
 from .packages import get_package_info, register_package, publish_package
-from .cli import pass_context, AliasedGroup
+from .cli import pass_context, AliasedGroup, extraflag, buildflag
 
 
 def ensure_plugin():
@@ -36,8 +37,10 @@ def cli():
 
 
 @cli.command('shell', short_help='Starts a python shell.')
+@extraflag
+@buildflag
 @pass_context
-def shell_cmd(ctx):
+def shell_cmd(ctx, extra_flags, build_flags):
     """Starts a Python shell in the context of a Lektor project.
 
     This is particularly useful for debugging plugins and to explore the
@@ -50,7 +53,8 @@ def shell_cmd(ctx):
     - `pad`: a database pad initialized for the project and environment
       that is ready to use.
     """
-    ctx.load_plugins()
+    extra_flags = tuple(itertools.chain(extra_flags or (), build_flags or ()))
+    ctx.load_plugins(extra_flags=extra_flags)
     import code
     from lektor.db import F, Tree
     from lektor.builder import Builder

--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -406,7 +406,7 @@ def lookup_from_bag(*args):
 
 class Environment(object):
 
-    def __init__(self, project, load_plugins=True):
+    def __init__(self, project, load_plugins=True, extra_flags=None):
         self.project = project
         self.root_path = os.path.abspath(project.tree)
 
@@ -475,7 +475,7 @@ class Environment(object):
         # The plugins that are loaded for this environment.  This is
         # modified by the plugin controller and registry methods on the
         # environment.
-        self.plugin_controller = PluginController(self)
+        self.plugin_controller = PluginController(self, extra_flags)
         self.plugins = {}
         self.plugin_ids_by_class = {}
         self.build_programs = []

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -117,12 +117,12 @@ def load_plugins():
     return rv
 
 
-def initialize_plugins(env):
+def initialize_plugins(env, extra_flags=None):
     """Initializes the plugins for the environment."""
     plugins = load_plugins()
     for plugin_id, plugin_cls in iteritems(plugins):
         env.plugin_controller.instanciate_plugin(plugin_id, plugin_cls)
-    env.plugin_controller.emit('setup-env')
+    env.plugin_controller.emit('setup-env', extra_flags=extra_flags)
 
 
 class PluginController(object):
@@ -130,8 +130,9 @@ class PluginController(object):
     the environment.
     """
 
-    def __init__(self, env):
+    def __init__(self, env, extra_flags=None):
         self._env = weakref(env)
+        self.extra_flags = extra_flags
 
     @property
     def env(self):
@@ -153,7 +154,9 @@ class PluginController(object):
         return itervalues(self.env.plugins)
 
     def emit(self, event, **kwargs):
+        from lektor.builder import process_extra_flags
         rv = {}
+        kwargs['extra_flags'] = process_extra_flags(self.extra_flags)
         funcname = 'on_' + event.replace('-', '_')
         for plugin in self.iter_plugins():
             handler = getattr(plugin, funcname, None)

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -117,12 +117,12 @@ def load_plugins():
     return rv
 
 
-def initialize_plugins(env, extra_flags=None):
+def initialize_plugins(env):
     """Initializes the plugins for the environment."""
     plugins = load_plugins()
     for plugin_id, plugin_cls in iteritems(plugins):
         env.plugin_controller.instanciate_plugin(plugin_id, plugin_cls)
-    env.plugin_controller.emit('setup-env', extra_flags=extra_flags)
+    env.plugin_controller.emit('setup-env')
 
 
 class PluginController(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def project():
 
 
 @pytest.fixture(scope='function')
-def scratch_project(tmpdir):
+def scratch_project_data(tmpdir):
     base = tmpdir.mkdir("scratch-proj")
     lektorfile_text = textwrap.dedent(u"""
         [project]
@@ -32,7 +32,7 @@ def scratch_project(tmpdir):
         ---
         title: Index
         ---
-        body: Hello World!
+        body: *Hello World!*
     """)
     base.join("content", "contents.lr").write_text(content_text, "utf8", ensure=True)
     template_text = textwrap.dedent(u"""
@@ -51,7 +51,13 @@ def scratch_project(tmpdir):
     """)
     base.join("models", "page.ini").write_text(model_text, "utf8", ensure=True)
 
+    return base
+
+
+@pytest.fixture(scope='function')
+def scratch_project(scratch_project_data):
     from lektor.project import Project
+    base = scratch_project_data
     return Project.from_path(str(base))
 
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -7,7 +7,7 @@ def test_basic_editor(scratch_tree):
 
     assert sess['_model'] == 'page'
     assert sess['title'] == 'Index'
-    assert sess['body'] == 'Hello World!'
+    assert sess['body'] == '*Hello World!*'
 
     sess['body'] = 'A new body'
     sess.commit()
@@ -33,7 +33,7 @@ def test_create_alt(scratch_tree, scratch_pad):
 
     assert sess['_model'] == 'page'
     assert sess['title'] == 'Index'
-    assert sess['body'] == 'Hello World!'
+    assert sess['body'] == '*Hello World!*'
 
     sess['body'] = 'Hallo Welt!'
     sess.commit()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -78,14 +78,6 @@ def scratch_project_with_plugin(scratch_project_data, request, isolated_cli_runn
         "lektor_event_test{}.py".format(request.param_index),
     ).write_text(plugin_text, "utf8", ensure=True)
 
-    template_text = textwrap.dedent(
-        u"""
-        <h1>{{ "**Title**"|markdown }}</h1>
-        {{ this.body }}
-    """
-    )
-    base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
-
     # Move into isolated path.
     for entry in os.listdir(str(base)):
         entry_path = os.path.join(str(base), entry)
@@ -118,8 +110,8 @@ def test_plugin_build_events_via_cli(scratch_project_with_plugin):
     # these previous plugins are never removed. So while this does test what it says it
     # does, it also hooks previously generated plugins. Avoiding this with a succint
     # teardown is currently not possible AFAICT, since setuptools provides no clear way
-    # of removing entry_points. I choose this comment over what would be a convoluted and
-    # very hacky teardown function. The extra computation time is negligible.
+    # of removing entry_points. I choose this comment over what would be a convoluted
+    # and very hacky teardown function. The extra computation time is negligible.
     # See https://github.com/pypa/setuptools/issues/1759
 
     hits = [r for r in output_lines if "event on_{}".format(event) in r]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -67,9 +67,9 @@ def scratch_project_with_plugin(scratch_project_data, request, isolated_cli_runn
             name = 'Event Test'
             description = u'Non-empty string'
 
-            def on_{}(self, **extra):
-                print("event on_{}", extra['extra_flags'])
-                return extra
+            def on_{}(self, extra_flags, **extra):
+                print("event on_{}", extra_flags)
+                return extra_flags
     """
     ).format(request.param_index, request.param, request.param)
     base.join(
@@ -160,8 +160,9 @@ def test_env_extra_flag_passthrough(scratch_project_with_plugin):
     extra = {"extra": "extra"}
     env = Environment(proj, extra_flags=extra)
     plugin_return = env.plugin_controller.emit(event)
+
     for plugin in plugin_return:
-        assert plugin_return[plugin]["extra_flags"] == extra
+        assert plugin_return[plugin] == extra
 
 
 @pytest.mark.parametrize("scratch_project_with_plugin", ["setup_env"], indirect=True)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,142 @@
+import textwrap
+import os
+
+import pytest
+
+from lektor.cli import cli
+
+
+build_events = [
+    "before_build",
+    "before_build_all",
+    "after_build",
+    "after_build_all",
+    "before_prune",
+    "after_prune",
+    "markdown_meta_init",
+    "markdown_meta_postprocess",
+    "process_template_context",
+    "setup_env",
+]
+
+all_events = build_events + [
+    # Only during creation of markdown threadlocal object. I.e. only emitted on build
+    # on the first render of the *entire* test suite, or else a lot of lib load hacking.
+    "markdown_config",
+    "markdown_lexer_config",
+    # Only during `lektor server` command, never on build or other commands.
+    "server_spawn",
+    "server_stop",
+]
+
+
+@pytest.fixture(scope="function")
+def scratch_project_with_plugin(scratch_project_data, request):
+    """Create a scratch project and add a plugin that has the named event listener.
+
+    Return project and current event.
+    """
+    base = scratch_project_data
+
+    # Minimum viable setup.py
+    current_test_index = (request.param_index,) * 4
+    setup_text = textwrap.dedent(
+        u"""
+        from setuptools import setup
+
+        setup(
+            name='lektor-event-test{}',
+            entry_points={{
+                'lektor.plugins': [
+                    'event-test{} = lektor_event_test{}:EventTestPlugin{}',
+                ]
+            }}
+        )
+    """
+    ).format(*current_test_index)
+    base.join(
+        "packages", "event-test{}".format(request.param_index), "setup.py"
+    ).write_text(setup_text, "utf8", ensure=True)
+
+    # Minimum plugin code
+    plugin_text = textwrap.dedent(
+        u"""
+        from lektor.pluginsystem import Plugin
+        import os
+
+        class EventTestPlugin{}(Plugin):
+            name = 'Event Test'
+            description = u'Non-empty string'
+
+            def on_{}(self, **extra):
+                print("event on_{}", extra['extra_flags'])
+                return extra
+    """
+    ).format(request.param_index, request.param, request.param)
+    base.join(
+        "packages",
+        "event-test{}".format(request.param_index),
+        "lektor_event_test{}.py".format(request.param_index),
+    ).write_text(plugin_text, "utf8", ensure=True)
+
+    template_text = textwrap.dedent(
+        u"""
+        <h1>{{ "**Title**"|markdown }}</h1>
+        {{ this.body }}
+    """
+    )
+    base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
+
+    from lektor.project import Project
+
+    yield (Project.from_path(str(base)), request.param)
+
+
+@pytest.mark.parametrize("scratch_project_with_plugin", build_events, indirect=True)
+def test_plugin_build_events_via_cli(scratch_project_with_plugin, isolated_cli_runner):
+    """Test whether a plugin with a given event can successfully use an extra flag.
+    """
+    proj, event = scratch_project_with_plugin
+    os.chdir(proj.tree)
+
+    result = isolated_cli_runner.invoke(cli, ["build", "-f", "EXTRA"])
+    assert result.exit_code == 0
+
+    # Test that the event was triggered and the current extra flag was passed.
+    output_lines = result.output.split("\n")
+
+    # XXX - take a closer look at result.output
+    # The setuptools working_set that keeps track of plugin installations is initialized
+    # at the first import of pkg_resources, and then plugins are added to the
+    # working_set as they are loaded into Lektor. Since pytest runs a single process,
+    # these previous plugins are never removed. So while this does test what it says it
+    # does, it also hooks previously generated plugins. Avoiding this with a succint
+    # teardown is currently not possible AFAICT, since setuptools provides no clear way
+    # of removing entry_points. I choose this comment over what would be a convoluted and
+    # very hacky teardown function. The extra computation time is negligible.
+    # See https://github.com/pypa/setuptools/issues/1759
+
+    hits = [r for r in output_lines if r.startswith("event on_{}".format(event))]
+
+    for hit in hits:
+        assert "{'EXTRA': 'EXTRA'}" in hit
+
+    assert len(hits) != 0
+
+    result = isolated_cli_runner.invoke(cli, ["clean", "--yes"])
+
+
+@pytest.mark.parametrize("scratch_project_with_plugin", all_events, indirect=True)
+def test_env_extra_flag_passthrough(scratch_project_with_plugin):
+    """Test whether setting extra_flags passes through to each plugin event.
+    """
+    from lektor.environment import Environment
+
+    proj, event = scratch_project_with_plugin
+    os.chdir(proj.tree)
+
+    extra = {"extra": "extra"}
+    env = Environment(proj, extra_flags=extra)
+    plugin_return = env.plugin_controller.emit(event)
+    for plugin in plugin_return:
+        assert plugin_return[plugin]["extra_flags"] == extra

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -170,3 +170,25 @@ def test_env_extra_flag_passthrough(scratch_project_with_plugin):
     plugin_return = env.plugin_controller.emit(event)
     for plugin in plugin_return:
         assert plugin_return[plugin]["extra_flags"] == extra
+
+
+@pytest.mark.parametrize("scratch_project_with_plugin", ["setup_env"], indirect=True)
+def test_multiple_extra_flags(scratch_project_with_plugin):
+    """Test whether setting extra_flags passes through to each plugin event.
+    """
+    proj, event, cli_runner = scratch_project_with_plugin
+
+    # See comment in test_plugin_build_events_via_cli
+    result = cli_runner.invoke(cli, ["build", "-f", "EXTRA", "-f", "ANOTHER"])
+    assert result.exit_code == 0
+
+    # Test that the event was triggered and the current extra flag was passed.
+    output_lines = result.output.split("\n")
+
+    hits = [r for r in output_lines if "event on_{}".format(event) in r]
+
+    for hit in hits:
+        assert "EXTRA" in hit
+        assert "ANOTHER" in hit
+
+    assert len(hits) != 0

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,6 +4,7 @@ import shutil
 
 import pytest
 
+from lektor._compat import PY2
 from lektor.cli import cli
 
 
@@ -89,8 +90,8 @@ def scratch_project_with_plugin(scratch_project_data, request, isolated_cli_runn
     base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
 
     # Move into isolated path.
-    for entry in os.listdir(base):
-        entry_path = os.path.join(base, entry)
+    for entry in os.listdir(str(base)):
+        entry_path = os.path.join(str(base), entry)
         if os.path.isdir(entry_path):
             shutil.copytree(entry_path, entry)
         else:
@@ -124,10 +125,13 @@ def test_plugin_build_events_via_cli(scratch_project_with_plugin):
     # very hacky teardown function. The extra computation time is negligible.
     # See https://github.com/pypa/setuptools/issues/1759
 
-    hits = [r for r in output_lines if r.startswith("event on_{}".format(event))]
+    hits = [r for r in output_lines if "event on_{}".format(event) in r]
 
     for hit in hits:
-        assert "{'EXTRA': 'EXTRA'}" in hit
+        if PY2:
+            assert "{u'EXTRA': u'EXTRA'}" in hit
+        else:
+            assert "{'EXTRA': 'EXTRA'}" in hit
 
     assert len(hits) != 0
 


### PR DESCRIPTION
Fixes #613.

This passes extra_flags to every plugin event, and allows extra_flags in a few more commands like `clean` and `dev shell`. This includes tests for most of the added functionality.

The tests could be improved, but the bigger deficiencies are not easy to overcome:

-  Testing the events hooked by `lektor server`; `server_spawn` and `server_stop`. Maybe there's an easy way I haven't thought of?
- Including cli triggered hooking of the markdown config commands. Tough because of the markdown thread local.
- Cleaning up after creating and installing plugins within the single pytest command. That's much more difficult than I originally realized. See inline comment block.

IMO, none of those are bad enough to block this. I'll happily accept recommended changes though if someone thinks of something I haven't :)

Ping @Andrew-Shay, for https://github.com/lektor/lektor-website/pull/256.