### PR TITLE
insert code for edit button before </head> and </body> if possible

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -18,7 +18,7 @@ bp = Blueprint('serve', __name__)
 def rewrite_html_for_editing(fp, edit_url):
     contents = fp.read()
 
-    button = u'''
+    button_style = u'''
     <style type="text/css">
       #lektor-edit-link {
         position: fixed;
@@ -48,6 +48,8 @@ def rewrite_html_for_editing(fp, edit_url):
         border: 1px solid #aaa!important;
       }
     </style>
+    '''
+    button_script = u'''
     <script type="text/javascript">
       (function() {
         if (window != window.top) {
@@ -65,7 +67,18 @@ def rewrite_html_for_editing(fp, edit_url):
         'edit_url': edit_url,
     }
 
-    return BytesIO(contents + button.encode('utf-8'))
+    head_endpos = contents.find(b'</head>')
+    body_endpos = contents.find(b'</body>')
+    if head_endpos >= 0 and body_endpos >= 0:
+        return BytesIO(contents[:head_endpos] +
+                       button_style.encode('utf-8') +
+                       contents[head_endpos:body_endpos] +
+                       button_script.encode('utf-8') +
+                       contents[body_endpos:])
+    else:
+        return BytesIO(contents +
+                       button_style.encode('utf-8') +
+                       button_script.encode('utf-8'))
 
 
 def send_file(filename):


### PR DESCRIPTION
In order to fix problems with HTML validation, the `<style>` part of the
edit button is now inserted before `</head>` and the `<script>` part is
inserted before `</body>`. If one of these closing tags doesn't exist,
append code at the end, just like before.

(Tests are failing locally, but in places unrelated to this code change.)

### Issue(s) Resolved

Fixes #639

### Related Issues / Links

(only the one linked above)

### Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
