### PR TITLE
flow rendering fix - admin UI

### DIFF
--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -13,7 +13,6 @@ class EditPage extends RecordEditComponent {
     super(props)
 
     this.state = {
-      recordInitialData: null,
       recordData: null,
       recordDataModel: null,
       recordInfo: null,
@@ -80,9 +79,19 @@ class EditPage extends RecordEditComponent {
       alt: this.getRecordAlt()
     }, null, makeRichPromise)
       .then((resp) => {
+        // transform resp.data into actual data
+        let recordData = {}
+        resp.datamodel.fields.forEach(field => {
+          const widget = widgets.getWidgetComponentWithFallback(field.type)
+          let value = resp.data[field.name] || ''
+          if (widget.deserializeValue) {
+            value = widget.deserializeValue(value, field.type)
+          }
+          recordData[field.name] = value
+        })
+
         this.setState({
-          recordInitialData: resp.data,
-          recordData: {},
+          recordData: recordData,
           recordDataModel: resp.datamodel,
           recordInfo: resp.record_info,
           hasPendingChanges: false
@@ -109,16 +118,9 @@ class EditPage extends RecordEditComponent {
 
       let value = this.state.recordData[field.name]
 
-      if (value !== undefined) {
-        const Widget = widgets.getWidgetComponentWithFallback(field.type)
-        if (Widget.serializeValue) {
-          value = Widget.serializeValue(value, field.type)
-        }
-      } else {
-        value = this.state.recordInitialData[field.name]
-        if (value === undefined) {
-          value = null
-        }
+      const Widget = widgets.getWidgetComponentWithFallback(field.type)
+      if (Widget.serializeValue) {
+        value = Widget.serializeValue(value, field.type)
       }
 
       rv[field.name] = value
@@ -153,14 +155,7 @@ class EditPage extends RecordEditComponent {
   }
 
   getValueForField (widget, field) {
-    let value = this.state.recordData[field.name]
-    if (value === undefined) {
-      value = this.state.recordInitialData[field.name] || ''
-      if (widget.deserializeValue) {
-        value = widget.deserializeValue(value, field.type)
-      }
-    }
-    return value
+    return this.state.recordData[field.name]
   }
 
   getPlaceholderForField (widget, field) {

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -129,20 +129,18 @@ const serializeFlowBlock = (flockBlockModel, data) => {
   return metaformat.serialize(rv)
 }
 
-// ever growing counter of block ids.  Good enough for what we do I think.
-let lastBlockId = 0
-
 const FlowWidget = createReactClass({
   displayName: 'FlowWidget',
   mixins: [BasicWidgetMixin],
 
   statics: {
     deserializeValue: (value, type) => {
+      let blockId = 0
       return parseFlowFormat(value).map((item) => {
         const [id, lines] = item
         const flowBlock = type.flowblocks[id]
         if (flowBlock !== undefined) {
-          return deserializeFlowBlock(flowBlock, lines, ++lastBlockId)
+          return deserializeFlowBlock(flowBlock, lines, ++blockId)
         }
         return null
       })
@@ -193,9 +191,12 @@ const FlowWidget = createReactClass({
 
     const flowBlockModel = this.props.type.flowblocks[key]
 
+    // find the first available id for this new block - use findMax + 1
+    const blockIds = this.props.value.map(block => block.localId)
+    const newBlockId = Math.max(...blockIds) + 1
+
     // this is a rather ugly way to do this, but hey, it works.
-    this.props.value.push(deserializeFlowBlock(flowBlockModel, [],
-      ++lastBlockId))
+    this.props.value.push(deserializeFlowBlock(flowBlockModel, [], newBlockId))
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

*no open issues about this*

Fixes issue of constant unnecessary mounting/unmounting of flow widgets. For complex widgets that parse values on mount (such as gui markdown editor, and others), this has big performance issues.


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


* [x] Make serialization of data occur only when data is loaded by the API
* [x] Make flow's `deserializeValue` a pure function


<!--- Explain what you've done and why --->

---

On `EditPage.jsx`, every time a field is updated (ie. user changes text in a strings field), the render method is called.

This causes `renderFormFields` to be called, which in turn calls `renderFormField` for each field. The value prop for each field is set to `getValueForField`.

`getValueForField` looks first at `state.recordData`, but this might not be set, as by default, this is empty, and is only populated when a field calls its `onChange` prop. Therefore, if `state.recordData` is empty (which it will be if a field hasn't been changed and onChange hasn't fired), it grabs the value from `state.recordInitialData`, which is populated by the result of the initial API call.

This value might be serialized, and it wants the deserialized value, so it checks if the static function `deserializeValue` exists on the appropriate widget class, and if so, calls it on the serialized value to get the deserialized value.

This is all fine, except that `deserializeValue` is not a pure function for a flow widget. `deserializeValue` increments the `lastBlockId` counter inside `flowWidget.jsx`, which is used to keep track of how many flow blocks are displayed (ie. when a new flow block is added, `lastBlockId` is incremented).

When deserializing the flow widget content, `lastBlockId` is used to create unique `localId`s for each flow block, which is then used for the `key` prop in the widget. However, as `deserializeValue` isn't pure, and can be called many many times, this leads to the deserialized blocks getting new `localId`s every time it is called, and as this is used for the `key` prop, this forces a unmount/mount of the flow blocks.

The fix for this is to remove `state.recordInitialData`, and make it so that when the data is fetched from the API, instead of setting `state.recordInitialData` to the API data and `state.recordData` to empty, it goes through the API data, deserializes where appropriate, and puts this in `state.recordData`.

This means that deserialization happens **once** - when the data is loaded (which matches up nicely with serialization, which happens once when the page is saved).

Additionally, static method `deserializeValue` was converted into a pure function, which removes the need for the global `lastBlockId` in `flowWidget.jsx`.

<!--- Thanks for your help making Lektor better for everyone! --->
