### PR TITLE
fix pylint false-positive errors for no-member and no-name-in-module

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,7 @@
 [I[MASTER]
 ignore = .git
+extension-pkg-whitelist = math,zlib
+generated-members = struct.unpack,sqlite3.sqlite_version,sqlite3.connect
 
 [FORMAT]
 max-line-length=100


### PR DESCRIPTION
In my environment, `make test` failed because of pylint errors as follows:

```
=============================================================== FAILURES ================================================================
______________________________________________________ [pylint] lektor/builder.py _______________________________________________________
E: 28,44: Module 'sqlite3' has no 'sqlite_version' member (no-member)
E:997,14: Module 'sqlite3' has no 'connect' member (no-member)
_____________________________________________________ [pylint] lektor/imagetools.py _____________________________________________________
E:339,16: Module 'struct' has no 'unpack' member (no-member)
E:341,28: Module 'struct' has no 'unpack' member (no-member)
E:343,24: Module 'struct' has no 'unpack' member (no-member)
E:368,25: Module 'struct' has no 'unpack' member (no-member)
E:377,28: Module 'struct' has no 'unpack' member (no-member)
_____________________________________________________ [pylint] lektor/pagination.py _____________________________________________________
E:  1, 0: No name 'ceil' in module 'math' (no-name-in-module)
____________________________________________________ [pylint] lektor/sourcesearch.py ____________________________________________________
E:120,10: Module 'sqlite3' has no 'connect' member (no-member)
________________________________________________ [pylint] lektor/admin/modules/serve.py _________________________________________________
E:  4, 0: No name 'adler32' in module 'zlib' (no-name-in-module)
```

However, none of these errors is a real error:

```
$ python -c "from sqlite3 import sqlite_version, connect"
$ python -c "from struct import unpack"                  
$ python -c "from math import ceil"    
$ python -c "from zlib import adler32"
```

So I hardcoded pylint exceptions for these imports into the pylintrc.
