### PR TITLE
speed up EXIF parsing for imagetools.make_image_thumbnail

### DIFF
--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -407,6 +407,12 @@ def read_exif(fp):
     return EXIFInfo(exif)
 
 
+def get_is_rotated_fast(fp):
+    """Fast version of read_exif(fp).is_rotated, using an exif header subset."""
+    exif = exifread.process_file(fp, stop_tag='Orientation', details=False)
+    return EXIFInfo(exif).is_rotated
+
+
 def find_imagemagick(im=None):
     """Finds imagemagick and returns the path to it."""
     # If it's provided explicitly and it's valid, we go with that one.

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -392,7 +392,7 @@ def get_image_info(fp):
         # to make decisions based on the "visual", not the "real" dimensions.
         # thumbnail code also depends on this behaviour.)
         fp.seek(0)
-        if get_is_rotated_fast(fp):
+        if is_rotated(fp):
             width, height = height, width
     else:
         fmt = None
@@ -406,7 +406,7 @@ def read_exif(fp):
     return EXIFInfo(exif)
 
 
-def get_is_rotated_fast(fp):
+def is_rotated(fp):
     """Fast version of read_exif(fp).is_rotated, using an exif header subset."""
     exif = exifread.process_file(fp, stop_tag='Orientation', details=False)
     return EXIFInfo(exif).is_rotated

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -392,8 +392,7 @@ def get_image_info(fp):
         # to make decisions based on the "visual", not the "real" dimensions.
         # thumbnail code also depends on this behaviour.)
         fp.seek(0)
-        exif = read_exif(fp)
-        if exif.is_rotated:
+        if get_is_rotated_fast(fp):
             width, height = height, width
     else:
         fmt = None

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -6,7 +6,7 @@ from hashlib import md5
 import pytest
 
 from lektor._compat import iteritems
-from lektor.imagetools import get_image_info, compute_dimensions
+from lektor.imagetools import get_image_info, compute_dimensions, get_is_rotated_fast
 
 
 def almost_equal(a, b, e=0.00001):
@@ -90,6 +90,16 @@ def test_image_attributes(pad):
         assert image.height == 512
         assert image.format == 'jpeg'
 
+
+def test_get_is_rotated_fast(pad):
+    for img, rotated in (
+            ('test.jpg', True),
+            ('test-sof-last.jpg', True),
+            ('test-progressive.jpg', False)
+    ):
+        image = pad.root.attachments.images.get(img)
+        with open(image.attachment_filename, 'rb') as f:
+            assert get_is_rotated_fast(f) == rotated
 
 def test_image_info_svg_declaration(make_svg):
     w, h = 100, 100

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -6,7 +6,7 @@ from hashlib import md5
 import pytest
 
 from lektor._compat import iteritems
-from lektor.imagetools import get_image_info, compute_dimensions, get_is_rotated_fast
+from lektor.imagetools import get_image_info, compute_dimensions, is_rotated
 
 
 def almost_equal(a, b, e=0.00001):
@@ -91,7 +91,7 @@ def test_image_attributes(pad):
         assert image.format == 'jpeg'
 
 
-def test_get_is_rotated_fast(pad):
+def test_is_rotated(pad):
     for img, rotated in (
             ('test.jpg', True),
             ('test-sof-last.jpg', True),
@@ -99,7 +99,7 @@ def test_get_is_rotated_fast(pad):
     ):
         image = pad.root.attachments.images.get(img)
         with open(image.attachment_filename, 'rb') as f:
-            assert get_is_rotated_fast(f) == rotated
+            assert is_rotated(f) == rotated
 
 def test_image_info_svg_declaration(make_svg):
     w, h = 100, 100


### PR DESCRIPTION
The only EXIF information that is used in `imagetools.make_image_thumbnail` is the `is_rotated` field. However, parsing the complete EXIF header (decoding thumbnails etc.) just for that field comes with a significant overhead, as described in #672. I have added a small helper function `get_is_rotated_fast(fp)` that only parses the header until it finds the `Orientation` header and returns the `is_rotated` value.

**The time for `lektor build` that I described in #672 has gone down from 138 seconds to 22 seconds.**

### Issue(s) Resolved

Fixes #672 

### Description of Changes


* [X] Wrote at least one-line docstrings (for any new functions)
* [X] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
