### PR TITLE
feature: new chooser field type and admin UI widget

### DIFF
--- a/lektor/admin/static/js/flowformat.jsx
+++ b/lektor/admin/static/js/flowformat.jsx
@@ -1,0 +1,124 @@
+import metaformat from './metaformat'
+import widgets from './widgets'
+
+/* circular references require us to do this */
+const getWidgetComponent = (type) => {
+  return widgets.getWidgetComponent(type)
+}
+
+const parseFlowFormat = (value) => {
+  let blocks = []
+  let buf = []
+  let lines = value.split(/\r?\n/)
+  let block = null
+
+  for (const line of lines) {
+    // leading whitespace is ignored.
+    if (block === null && line.match(/^\s*$/)) {
+      continue
+    }
+
+    const blockStart = line.match(/^####\s*([^#]*?)\s*####\s*$/)
+    if (!blockStart) {
+      if (block === null) {
+        // bad format :(
+        return null
+      }
+    } else {
+      if (block !== null) {
+        blocks.push([block, buf])
+        buf = []
+      }
+      block = blockStart[1]
+      continue
+    }
+
+    buf.push(line.replace(/^#####(.*?)#####$/, '####$1####'))
+  }
+
+  if (block !== null) {
+    blocks.push([block, buf])
+  }
+
+  return blocks
+}
+
+const serializeFlowFormat = (blocks) => {
+  let rv = []
+  blocks.forEach((block) => {
+    const [blockName, lines] = block
+    rv.push('#### ' + blockName + ' ####\n')
+    lines.forEach((line) => {
+      rv.push(line.replace(/^(####(.*)####)(\r?\n)?$/, '#$1#$3'))
+    })
+  })
+
+  rv = rv.join('')
+
+  /* we need to chop of the last newline if it exists because this would
+     otherwise add a newline to the last block.  This is just a side effect
+     of how we serialize the meta format internally */
+  if (rv[rv.length - 1] === '\n') {
+    rv = rv.substr(0, rv.length - 1)
+  }
+
+  return rv
+}
+
+const deserializeFlowBlock = (flowBlockModel, lines, localId) => {
+  let data = {}
+  let rawData = {}
+
+  metaformat.tokenize(lines).forEach((item) => {
+    const [key, lines] = item
+    const value = lines.join('')
+    rawData[key] = value
+  })
+
+  flowBlockModel.fields.forEach((field) => {
+    let value = rawData[field.name] || ''
+    const Widget = getWidgetComponent(field.type)
+    if (!value && field['default']) {
+      value = field['default']
+    }
+    if (Widget && Widget.deserializeValue) {
+      value = Widget.deserializeValue(value, field.type)
+    }
+    data[field.name] = value
+  })
+
+  return {
+    localId: localId || null,
+    flowBlockModel: flowBlockModel,
+    data: data
+  }
+}
+
+const serializeFlowBlock = (flockBlockModel, data) => {
+  let rv = []
+  flockBlockModel.fields.forEach((field) => {
+    const Widget = getWidgetComponent(field.type)
+    if (Widget === null) {
+      return
+    }
+
+    let value = data[field.name]
+    if (value === undefined || value === null) {
+      return
+    }
+
+    if (Widget.serializeValue) {
+      value = Widget.serializeValue(value, field.type)
+    }
+
+    rv.push([field.name, value])
+  })
+  return metaformat.serialize(rv)
+}
+
+export default {
+  parseFlowFormat: parseFlowFormat,
+  serializeFlowFormat: serializeFlowFormat,
+  deserializeFlowBlock: deserializeFlowBlock,
+  serializeFlowBlock: serializeFlowBlock
+}

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -6,6 +6,7 @@ import createReactClass from 'create-react-class'
 import primitiveWidgets from './widgets/primitiveWidgets'
 import multiWidgets from './widgets/multiWidgets'
 import flowWidget from './widgets/flowWidget'
+import chooserWidget from './widgets/chooserWidget'
 import fakeWidgets from './widgets/fakeWidgets'
 import { BasicWidgetMixin } from './widgets/mixins'
 import Component from './components/Component'
@@ -22,6 +23,7 @@ const widgetComponents = {
   'url': primitiveWidgets.UrlInputWidget,
   'slug': primitiveWidgets.SlugInputWidget,
   'flow': flowWidget.FlowWidget,
+  'chooser': chooserWidget.ChooserWidget,
   'checkboxes': multiWidgets.CheckboxesInputWidget,
   'select': multiWidgets.SelectInputWidget,
   'f-line': fakeWidgets.LineWidget,

--- a/lektor/admin/static/js/widgets/chooserWidget.jsx
+++ b/lektor/admin/static/js/widgets/chooserWidget.jsx
@@ -173,9 +173,7 @@ class ChooserWidget extends React.Component {
     if (event) event.preventDefault()
 
     // just use the first flowblock type, as they're all the same
-    const idx = Object.keys(this.props.type.flowblocks)[0]
-    const key = this.props.type.flowblocks[idx].id
-
+    const key = this.props.type.flowblock_order[0]
     const flowBlockModel = this.props.type.flowblocks[key]
 
     // find the first available id for this new block - use findMax + 1

--- a/lektor/admin/static/js/widgets/chooserWidget.jsx
+++ b/lektor/admin/static/js/widgets/chooserWidget.jsx
@@ -1,0 +1,380 @@
+'use strict'
+
+/* eslint-env browser */
+
+import PropTypes from 'prop-types'
+import React from 'react'
+import i18n from '../i18n'
+import metaformat from '../metaformat'
+import widgets from '../widgets'
+
+/* circular references require us to do this */
+const getWidgetComponent = (type) => {
+  return widgets.getWidgetComponent(type)
+}
+
+const getWidgets = () => {
+  return widgets
+}
+
+const parseFlowFormat = (value) => {
+  let blocks = []
+  let buf = []
+  let lines = value.split(/\r?\n/)
+  let block = null
+
+  for (const line of lines) {
+    // leading whitespace is ignored.
+    if (block === null && line.match(/^\s*$/)) {
+      continue
+    }
+
+    const blockStart = line.match(/^####\s*([^#]*?)\s*####\s*$/)
+    if (!blockStart) {
+      if (block === null) {
+        // bad format :(
+        return null
+      }
+    } else {
+      if (block !== null) {
+        blocks.push([block, buf])
+        buf = []
+      }
+      block = blockStart[1]
+      continue
+    }
+
+    buf.push(line.replace(/^#####(.*?)#####$/, '####$1####'))
+  }
+
+  if (block !== null) {
+    blocks.push([block, buf])
+  }
+
+  return blocks
+}
+
+const serializeFlowFormat = (blocks) => {
+  let rv = []
+  blocks.forEach((block) => {
+    const [blockName, lines] = block
+    rv.push('#### ' + blockName + ' ####\n')
+    lines.forEach((line) => {
+      rv.push(line.replace(/^(####(.*)####)(\r?\n)?$/, '#$1#$3'))
+    })
+  })
+
+  rv = rv.join('')
+
+  /* we need to chop of the last newline if it exists because this would
+     otherwise add a newline to the last block.  This is just a side effect
+     of how we serialize the meta format internally */
+  if (rv[rv.length - 1] === '\n') {
+    rv = rv.substr(0, rv.length - 1)
+  }
+
+  return rv
+}
+
+const deserializeFlowBlock = (flowBlockModel, lines, localId) => {
+  let data = {}
+  let rawData = {}
+
+  metaformat.tokenize(lines).forEach((item) => {
+    const [key, lines] = item
+    const value = lines.join('')
+    rawData[key] = value
+  })
+
+  flowBlockModel.fields.forEach((field) => {
+    let value = rawData[field.name] || ''
+    const Widget = getWidgetComponent(field.type)
+    if (!value && field['default']) {
+      value = field['default']
+    }
+    if (Widget && Widget.deserializeValue) {
+      value = Widget.deserializeValue(value, field.type)
+    }
+    data[field.name] = value
+  })
+
+  return {
+    localId: localId || null,
+    flowBlockModel: flowBlockModel,
+    data: data
+  }
+}
+
+const serializeFlowBlock = (flockBlockModel, data) => {
+  let rv = []
+  flockBlockModel.fields.forEach((field) => {
+    const Widget = getWidgetComponent(field.type)
+    if (Widget === null) {
+      return
+    }
+
+    let value = data[field.name]
+    if (value === undefined || value === null) {
+      return
+    }
+
+    if (Widget.serializeValue) {
+      value = Widget.serializeValue(value, field.type)
+    }
+
+    rv.push([field.name, value])
+  })
+  return metaformat.serialize(rv)
+}
+
+class ChooserWidget extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      displayId: this.props.value.length === 0 ? false : 1
+    }
+  }
+
+  // XXX: the modification of props is questionable
+
+  moveBlock (idx, offset, event) {
+    event.preventDefault()
+
+    const newIndex = idx + offset
+    if (newIndex < 0 || newIndex >= this.props.value.length) {
+      return
+    }
+
+    const tmp = this.props.value[newIndex]
+    this.props.value[newIndex] = this.props.value[idx]
+    this.props.value[idx] = tmp
+
+    if (this.props.onChange) {
+      this.props.onChange(this.props.value)
+    }
+  }
+
+  removeBlock (idx, event) {
+    event.preventDefault()
+
+    if (confirm(i18n.trans('REMOVE_FLOWBLOCK_PROMPT'))) {
+      this.props.value.splice(idx, 1)
+      if (this.props.onChange) {
+        this.props.onChange(this.props.value)
+      }
+
+      if (this.props.value.length === 0) {
+        this.setState({
+          displayId: false
+        })
+      } else {
+        const newVal = this.props.value[idx] ? this.props.value[idx] : this.props.value[idx - 1]
+        this.setState({
+          displayId: newVal.localId
+        })
+      }
+    }
+  }
+
+  addNewBlock (event) {
+    if (event) event.preventDefault()
+
+    // just use the first flowblock type, as they're all the same
+    const idx = Object.keys(this.props.type.flowblocks)[0]
+    const key = this.props.type.flowblocks[idx].id
+
+    const flowBlockModel = this.props.type.flowblocks[key]
+
+    // find the first available id for this new block - use findMax + 1
+    const blockIds = this.props.value.map(block => block.localId)
+    const newBlockId = blockIds.length === 0 ? 1 : Math.max(...blockIds) + 1
+
+    // this is a rather ugly way to do this, but hey, it works.
+    this.props.value.push(deserializeFlowBlock(flowBlockModel, [], newBlockId))
+    if (this.props.onChange) {
+      this.props.onChange(this.props.value)
+    }
+    this.setState({
+      displayId: newBlockId
+    })
+  }
+
+  renderBlocks () {
+    const widgets = getWidgets()
+    const idx = this.getCurrentBlockIndex()
+    if (idx === false) return null
+
+    // just use the first flowblock fields, as there's only one flowblock type
+    const blockInfo = this.props.value[idx]
+    const rows = widgets.getFieldRows(this.props.value[0].flowBlockModel.fields, null)
+
+    const renderedRows = rows.map((item, idx) => {
+      const [rowType, row] = item
+
+      const fields = row.map((field, idx) => {
+        const onChange = !this.props.onChange ? null : (value) => {
+          blockInfo.data[field.name] = value
+          this.props.onChange(this.props.value)
+        }
+        const value = blockInfo.data[field.name]
+        const placeholder = ''
+
+        return (
+          <widgets.FieldBox
+            key={idx}
+            value={value}
+            placeholder={placeholder}
+            field={field}
+            onChange={onChange}
+          />
+        )
+      })
+
+      return (
+        <div className='row field-row' key={rowType + '-' + idx}>
+          {fields}
+        </div>
+      )
+    })
+
+    return renderedRows
+  }
+
+  getCurrentBlockIndex () {
+    if (this.state.displayId === false) return false
+    return this.props.value.findIndex(el => el.localId === this.state.displayId)
+  }
+
+  keyFieldValue () {
+    const idx = this.getCurrentBlockIndex()
+    if (idx === false) return false
+    return this.props.value[idx].data[this.props.type.key_field]
+  }
+
+  keyFieldIsDuplicate () {
+    const keyFields = this.props.value.reduce((res, val) => {
+      if (val.localId === this.state.displayId) return res
+      return res.concat(val.data[this.props.type.key_field])
+    }, [])
+
+    const currentVal = this.keyFieldValue()
+    if (currentVal === false) return false
+    return keyFields.indexOf(currentVal) !== -1
+  }
+
+  renderChooserButtons () {
+    const idx = this.getCurrentBlockIndex()
+    return (
+      <div className='btn-group action-bar'>
+        <button
+          className='btn btn-default btn-xs'
+          title={i18n.trans('UP')}
+          disabled={idx === false || idx === 0}
+          onClick={this.moveBlock.bind(this, idx, -1)}>
+          <i className='fa fa-fw fa-chevron-up' />
+        </button>
+        <button
+          className='btn btn-default btn-xs'
+          title={i18n.trans('DOWN')}
+          disabled={idx === false || idx >= this.props.value.length - 1}
+          onClick={this.moveBlock.bind(this, idx, 1)}>
+          <i className='fa fa-fw fa-chevron-down' />
+        </button>
+        <button
+          className='btn btn-default btn-xs'
+          title={i18n.trans('REMOVE')}
+          disabled={idx === false}
+          onClick={this.removeBlock.bind(this, idx)}>
+          <i className='fa fa-fw fa-times' />
+        </button>
+        <button
+          className='btn btn-default btn-xs'
+          title={i18n.trans('ADD_FLOWBLOCK')}
+          disabled={this.keyFieldValue() && (this.keyFieldValue().trim() === '' || this.keyFieldIsDuplicate())}
+          onClick={this.addNewBlock.bind(this)}>
+          <i className='fa fa-fw fa-plus' />
+        </button>
+      </div>
+    )
+  }
+
+  render () {
+    let { className } = this.props
+    className = (className || '') + ' flow'
+
+    const selectOptions = this.props.value.map((val, idx) => {
+      return <option key={val.localId} value={val.localId}>{val.data[this.props.type.key_field]}</option>
+    })
+
+    // check for key field error
+    let help = null
+    const keyFieldVal = this.keyFieldValue()
+    if (keyFieldVal && keyFieldVal.trim() === '') {
+      className += ' has-feedback has-error'
+      help = <div className='validation-block validation-block-error'>Key Field can't be empty</div>
+    } else if (this.keyFieldIsDuplicate()) {
+      className += ' has-feedback has-error'
+      help = <div className='validation-block validation-block-error'>Key Field must be unique</div>
+    }
+
+    const selectChange = event => {
+      this.setState({
+        displayId: parseInt(event.target.value)
+      })
+    }
+
+    return (
+      <div className={className}>
+        <div className='flow-block row equal'>
+          <div className='col-md-3 form-group chooser-select'>
+            {help}
+            <select
+              size='2'
+              className='form-control'
+              onChange={selectChange}
+              value={this.state.displayId}>
+              {selectOptions}
+            </select>
+            {this.renderChooserButtons()}
+          </div>
+          <div className='col-md-9'>
+            {this.renderBlocks()}
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+ChooserWidget.deserializeValue = (value, type) => {
+  let blockId = 0
+  return parseFlowFormat(value).map((item) => {
+    const [id, lines] = item
+    const flowBlock = type.flowblocks[id]
+    if (flowBlock !== undefined) {
+      return deserializeFlowBlock(flowBlock, lines, ++blockId)
+    }
+    return null
+  })
+}
+
+ChooserWidget.serializeValue = (value) => {
+  return serializeFlowFormat(value.map((item) => {
+    return [
+      item.flowBlockModel.id,
+      serializeFlowBlock(item.flowBlockModel, item.data)
+    ]
+  }))
+}
+
+ChooserWidget.propTypes = {
+  value: PropTypes.any,
+  type: PropTypes.object,
+  placeholder: PropTypes.any,
+  onChange: PropTypes.func
+}
+
+export default {
+  ChooserWidget: ChooserWidget
+}

--- a/lektor/admin/static/js/widgets/chooserWidget.jsx
+++ b/lektor/admin/static/js/widgets/chooserWidget.jsx
@@ -5,130 +5,15 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../i18n'
-import metaformat from '../metaformat'
+import flowformat from '../flowformat'
 import widgets from '../widgets'
 
 /* circular references require us to do this */
-const getWidgetComponent = (type) => {
-  return widgets.getWidgetComponent(type)
-}
-
 const getWidgets = () => {
   return widgets
 }
 
-const parseFlowFormat = (value) => {
-  let blocks = []
-  let buf = []
-  let lines = value.split(/\r?\n/)
-  let block = null
-
-  for (const line of lines) {
-    // leading whitespace is ignored.
-    if (block === null && line.match(/^\s*$/)) {
-      continue
-    }
-
-    const blockStart = line.match(/^####\s*([^#]*?)\s*####\s*$/)
-    if (!blockStart) {
-      if (block === null) {
-        // bad format :(
-        return null
-      }
-    } else {
-      if (block !== null) {
-        blocks.push([block, buf])
-        buf = []
-      }
-      block = blockStart[1]
-      continue
-    }
-
-    buf.push(line.replace(/^#####(.*?)#####$/, '####$1####'))
-  }
-
-  if (block !== null) {
-    blocks.push([block, buf])
-  }
-
-  return blocks
-}
-
-const serializeFlowFormat = (blocks) => {
-  let rv = []
-  blocks.forEach((block) => {
-    const [blockName, lines] = block
-    rv.push('#### ' + blockName + ' ####\n')
-    lines.forEach((line) => {
-      rv.push(line.replace(/^(####(.*)####)(\r?\n)?$/, '#$1#$3'))
-    })
-  })
-
-  rv = rv.join('')
-
-  /* we need to chop of the last newline if it exists because this would
-     otherwise add a newline to the last block.  This is just a side effect
-     of how we serialize the meta format internally */
-  if (rv[rv.length - 1] === '\n') {
-    rv = rv.substr(0, rv.length - 1)
-  }
-
-  return rv
-}
-
-const deserializeFlowBlock = (flowBlockModel, lines, localId) => {
-  let data = {}
-  let rawData = {}
-
-  metaformat.tokenize(lines).forEach((item) => {
-    const [key, lines] = item
-    const value = lines.join('')
-    rawData[key] = value
-  })
-
-  flowBlockModel.fields.forEach((field) => {
-    let value = rawData[field.name] || ''
-    const Widget = getWidgetComponent(field.type)
-    if (!value && field['default']) {
-      value = field['default']
-    }
-    if (Widget && Widget.deserializeValue) {
-      value = Widget.deserializeValue(value, field.type)
-    }
-    data[field.name] = value
-  })
-
-  return {
-    localId: localId || null,
-    flowBlockModel: flowBlockModel,
-    data: data
-  }
-}
-
-const serializeFlowBlock = (flockBlockModel, data) => {
-  let rv = []
-  flockBlockModel.fields.forEach((field) => {
-    const Widget = getWidgetComponent(field.type)
-    if (Widget === null) {
-      return
-    }
-
-    let value = data[field.name]
-    if (value === undefined || value === null) {
-      return
-    }
-
-    if (Widget.serializeValue) {
-      value = Widget.serializeValue(value, field.type)
-    }
-
-    rv.push([field.name, value])
-  })
-  return metaformat.serialize(rv)
-}
-
 class ChooserWidget extends React.Component {
-
   // XXX: the modification of props is questionable
 
   moveBlock (idx, offset, event) {
@@ -181,7 +66,7 @@ class ChooserWidget extends React.Component {
     const newBlockId = blockIds.length === 0 ? 1 : Math.max(...blockIds) + 1
 
     // this is a rather ugly way to do this, but hey, it works.
-    this.props.value.blocks.push(deserializeFlowBlock(flowBlockModel, [], newBlockId))
+    this.props.value.blocks.push(flowformat.deserializeFlowBlock(flowBlockModel, [], newBlockId))
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }
@@ -341,11 +226,11 @@ class ChooserWidget extends React.Component {
 
 ChooserWidget.deserializeValue = (value, type) => {
   let blockId = 0
-  const blocks = parseFlowFormat(value).map((item) => {
+  const blocks = flowformat.parseFlowFormat(value).map((item) => {
     const [id, lines] = item
     const flowBlock = type.flowblocks[id]
     if (flowBlock !== undefined) {
-      return deserializeFlowBlock(flowBlock, lines, ++blockId)
+      return flowformat.deserializeFlowBlock(flowBlock, lines, ++blockId)
     }
     return null
   })
@@ -357,10 +242,10 @@ ChooserWidget.deserializeValue = (value, type) => {
 
 ChooserWidget.serializeValue = (value) => {
   const blocks = value.blocks
-  return serializeFlowFormat(blocks.map((item) => {
+  return flowformat.serializeFlowFormat(blocks.map((item) => {
     return [
       item.flowBlockModel.id,
-      serializeFlowBlock(item.flowBlockModel, item.data)
+      flowformat.serializeFlowBlock(item.flowBlockModel, item.data)
     ]
   }))
 }

--- a/lektor/admin/static/js/widgets/chooserWidget.jsx
+++ b/lektor/admin/static/js/widgets/chooserWidget.jsx
@@ -201,10 +201,15 @@ class ChooserWidget extends React.Component {
       }
     }
 
+    const widgets = getWidgets()
+    const selectWidth = widgets.getFieldColumns({
+      type: { width: this.props.type.select_width }})
+    const fieldsWidth = 12 - selectWidth
+
     return (
       <div className={className}>
         <div className='flow-block row equal'>
-          <div className='col-md-2 form-group chooser-select'>
+          <div className={`col-md-${selectWidth} form-group chooser-select`}>
             {help}
             <select
               size='2'
@@ -215,7 +220,7 @@ class ChooserWidget extends React.Component {
             </select>
             {this.renderChooserButtons()}
           </div>
-          <div className='col-md-10'>
+          <div className={`col-md-${fieldsWidth}`}>
             {this.renderBlocks()}
           </div>
         </div>

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -5,128 +5,14 @@
 import React from 'react'
 import createReactClass from 'create-react-class'
 import i18n from '../i18n'
-import metaformat from '../metaformat'
+import flowformat from '../flowformat'
 import { BasicWidgetMixin } from './mixins'
 import userLabel from '../userLabel'
 import widgets from '../widgets'
 
 /* circular references require us to do this */
-const getWidgetComponent = (type) => {
-  return widgets.getWidgetComponent(type)
-}
-
 const getWidgets = () => {
   return widgets
-}
-
-const parseFlowFormat = (value) => {
-  let blocks = []
-  let buf = []
-  let lines = value.split(/\r?\n/)
-  let block = null
-
-  for (const line of lines) {
-    // leading whitespace is ignored.
-    if (block === null && line.match(/^\s*$/)) {
-      continue
-    }
-
-    const blockStart = line.match(/^####\s*([^#]*?)\s*####\s*$/)
-    if (!blockStart) {
-      if (block === null) {
-        // bad format :(
-        return null
-      }
-    } else {
-      if (block !== null) {
-        blocks.push([block, buf])
-        buf = []
-      }
-      block = blockStart[1]
-      continue
-    }
-
-    buf.push(line.replace(/^#####(.*?)#####$/, '####$1####'))
-  }
-
-  if (block !== null) {
-    blocks.push([block, buf])
-  }
-
-  return blocks
-}
-
-const serializeFlowFormat = (blocks) => {
-  let rv = []
-  blocks.forEach((block) => {
-    const [blockName, lines] = block
-    rv.push('#### ' + blockName + ' ####\n')
-    lines.forEach((line) => {
-      rv.push(line.replace(/^(####(.*)####)(\r?\n)?$/, '#$1#$3'))
-    })
-  })
-
-  rv = rv.join('')
-
-  /* we need to chop of the last newline if it exists because this would
-     otherwise add a newline to the last block.  This is just a side effect
-     of how we serialize the meta format internally */
-  if (rv[rv.length - 1] === '\n') {
-    rv = rv.substr(0, rv.length - 1)
-  }
-
-  return rv
-}
-
-const deserializeFlowBlock = (flowBlockModel, lines, localId) => {
-  let data = {}
-  let rawData = {}
-
-  metaformat.tokenize(lines).forEach((item) => {
-    const [key, lines] = item
-    const value = lines.join('')
-    rawData[key] = value
-  })
-
-  flowBlockModel.fields.forEach((field) => {
-    let value = rawData[field.name] || ''
-    const Widget = getWidgetComponent(field.type)
-    if (!value && field['default']) {
-      value = field['default']
-    }
-    if (Widget && Widget.deserializeValue) {
-      value = Widget.deserializeValue(value, field.type)
-    }
-    data[field.name] = value
-  })
-
-  return {
-    localId: localId || null,
-    flowBlockModel: flowBlockModel,
-    data: data
-  }
-}
-
-const serializeFlowBlock = (flockBlockModel, data) => {
-  let rv = []
-  flockBlockModel.fields.forEach((field) => {
-    const Widget = getWidgetComponent(field.type)
-    if (Widget === null) {
-      return
-    }
-
-    let value = data[field.name]
-    if (value === undefined || value === null) {
-      return
-    }
-
-    if (Widget.serializeValue) {
-      value = Widget.serializeValue(value, field.type)
-    }
-
-    rv.push([field.name, value])
-  })
-  return metaformat.serialize(rv)
 }
 
 // ever growing counter of block ids.  Good enough for what we do I think.
@@ -138,21 +24,21 @@ const FlowWidget = createReactClass({
 
   statics: {
     deserializeValue: (value, type) => {
-      return parseFlowFormat(value).map((item) => {
+      return flowformat.parseFlowFormat(value).map((item) => {
         const [id, lines] = item
         const flowBlock = type.flowblocks[id]
         if (flowBlock !== undefined) {
-          return deserializeFlowBlock(flowBlock, lines, ++lastBlockId)
+          return flowformat.deserializeFlowBlock(flowBlock, lines, ++lastBlockId)
         }
         return null
       })
     },
 
     serializeValue: (value) => {
-      return serializeFlowFormat(value.map((item) => {
+      return flowformat.serializeFlowFormat(value.map((item) => {
         return [
           item.flowBlockModel.id,
-          serializeFlowBlock(item.flowBlockModel, item.data)
+          flowformat.serializeFlowBlock(item.flowBlockModel, item.data)
         ]
       }))
     }
@@ -194,7 +80,7 @@ const FlowWidget = createReactClass({
     const flowBlockModel = this.props.type.flowblocks[key]
 
     // this is a rather ugly way to do this, but hey, it works.
-    this.props.value.push(deserializeFlowBlock(flowBlockModel, [],
+    this.props.value.push(flowformat.deserializeFlowBlock(flowBlockModel, [],
       ++lastBlockId))
     if (this.props.onChange) {
       this.props.onChange(this.props.value)

--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -365,6 +365,26 @@ div.application {
       margin-top: 5px;
       float: right;
     }
+
+    .chooser-select {
+      padding: 10px 0;
+      display: flex;
+      flex-direction: column;
+
+      .validation-block {
+        flex: 0 1 auto;
+        margin: 0;
+        padding: 0;
+      }
+
+      .action-bar {
+        flex: 0 1 auto;
+      }
+
+      select {
+        flex: 1 1 auto;
+      }
+    }
   }
 
   .help-text {
@@ -558,4 +578,10 @@ pre.traceback {
   background: @header-taint;
   color: white;
   padding: 10px 15px;
+}
+
+.row.equal {
+  display: flex;
+  display: -webkit-flex;
+  flex-wrap: wrap;
 }

--- a/lektor/types/__init__.py
+++ b/lektor/types/__init__.py
@@ -97,7 +97,7 @@ from lektor.types.primitives import \
 from lektor.types.multi import CheckboxesType, SelectType
 from lektor.types.special import SortKeyType, SlugType, UrlType
 from lektor.types.formats import MarkdownType
-from lektor.types.flow import FlowType
+from lektor.types.flow import FlowType, ChooserType
 from lektor.types.fake import LineType, SpacingType, InfoType, HeadingType
 
 
@@ -127,6 +127,7 @@ builtin_types = {
 
     # Flow
     'flow': FlowType,
+    'chooser': ChooserType,
 
     # Fake
     'line': LineType,

--- a/lektor/types/flow.py
+++ b/lektor/types/flow.py
@@ -233,3 +233,18 @@ class FlowType(Type):
         rv['flowblock_order'] = block_order
 
         return rv
+
+
+class ChooserType(FlowType):
+    widget = 'chooser'
+
+    def __init__(self, env, options):
+        FlowType.__init__(self, env, options)
+        flow_block = options.get('flow_block', None)
+        self.flow_blocks = [flow_block] if flow_block else None
+        self.key_field = options.get('key_field', False)
+
+    def to_json(self, pad, record=None, alt=PRIMARY_ALT):
+        rv = FlowType.to_json(self, pad, record, alt)
+        rv['key_field'] = self.key_field
+        return rv

--- a/lektor/types/flow.py
+++ b/lektor/types/flow.py
@@ -243,8 +243,10 @@ class ChooserType(FlowType):
         flow_block = options.get('flow_block', None)
         self.flow_blocks = [flow_block] if flow_block else None
         self.key_field = options.get('key_field', False)
+        self.select_width = options.get('select_width') or '1/6'
 
     def to_json(self, pad, record=None, alt=PRIMARY_ALT):
         rv = FlowType.to_json(self, pad, record, alt)
         rv['key_field'] = self.key_field
+        rv['select_width'] = self.select_width
         return rv

--- a/tests/demo-project/flowblocks/reference.ini
+++ b/tests/demo-project/flowblocks/reference.ini
@@ -1,0 +1,10 @@
+[block]
+name = Reference
+
+[fields.number]
+label = Number
+type = integer
+
+[fields.reference]
+label = Reference
+type = string

--- a/tests/demo-project/templates/blocks/reference.html
+++ b/tests/demo-project/templates/blocks/reference.html
@@ -1,0 +1,1 @@
+<li id="reference-{{ this.number }}">{{ this.reference }}</li>


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

*no open issues*


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [x] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->

The `flow` widget is great, however it has the limitation that if many blocks are used (on some pages I have 100+) the page is very long, and where more complex custom widgets are used (gui markdown and others), trying to render this many on the page causes the browser to crash. Even with the rather excellent new feature of being able to collapse the blocks, it is rather unwieldy when that many blocks are added.

I've therefore come up with a new type of widget which I'm calling *chooser*. This is very similar to flow (and indeed is compatible in most ways), however has the following differences.

- Rather than being able to add flow blocks of different types, *chooser* is limited to only one type of flow block.
- Rather than displaying all the blocks in a list, only one is displayed, alongside a selection list, allowing you to choose which block is being edited.
- The selection list obviously requires some way of identifying the blocks, and due to this, a `key_field` must be specified in the chooser configuration, which specifies the field that is displayed in the list.

Hopefully this makes sense, and if not maybe the example below helps to illustrate it.

I've not yet written any documentation for this on [getlektor.com](https://github.com/lektor/lektor-website) but I can do that shortly if this PR gets accepted.

I have however added tests for the new `chooser` type. There weren't any tests for `flow` that I could see, so I added some for that too.

---

## Example

Suppose you have the following flow block, used for adding references/citations to an article. Each reference has a number, and the reference text.

```ini
[block]
name = Reference
button_label = Reference

[fields.number]
label = Number
type = integer
width = 1/4

[fields.reference]
label = Reference
type = bbcodeinline
```

In the model file for the page, the usage is very similar to flow, except only one `flow_block` is specified, and a `key_field` needs to be specified too:

```ini
[fields.references]
label = References
type = chooser
flow_block = reference
key_field = number
```

On the admin UI page, this is displayed as the following widget, where the selection box on the left is showing the value of the `key_field` for each block, and upon choosing one, it can be edited using the fields to the right:

![chooser-widget](https://user-images.githubusercontent.com/13520342/62097204-face7000-b27d-11e9-8599-55041b310d80.png)

The usage in templates is exactly the same as `flow` (and indeed uses the `FlowType` and `FlowDescriptor` classes).



<!--- Thanks for your help making Lektor better for everyone! --->
