### PR TITLE
fix: make negative numbers valid in integer type widget

### DIFF
--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -112,7 +112,7 @@ const IntegerInputWidget = createReactClass({
   },
 
   getValidationFailureImpl () {
-    if (this.props.value && !this.props.value.match(/^\d+$/)) {
+    if (this.props.value && !this.props.value.match(/^-?\d+$/)) {
       return new ValidationFailure({
         message: i18n.trans('ERROR_INVALID_NUMBER')
       })


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

*none open*

Fixes bug where `integer` type widget only accepts positive numbers.


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

From the docs on the [integer type](https://www.getlektor.com/docs/api/db/types/integer/):

> The integer type is one of the most basic ones in Lektor. It can store arbitrary natural numbers **both negative and positive**.

However the validation regex for the integer input widget was `/^\d+$/`, therefore not allowing negative numbers to be added.


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
