### PR TITLE
Includes setup.cfg in plugin template

### DIFF
--- a/lektor/quickstart-templates/plugin/setup.cfg.in
+++ b/lektor/quickstart-templates/plugin/setup.cfg.in
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -23,7 +23,7 @@ def test_new_plugin(project_cli_runner):
     assert result.exit_code == 0
     path = os.path.join('packages', 'plugin-name')
     assert set(os.listdir(path)) == set(
-        ['lektor_plugin_name.py', 'setup.py', '.gitignore', 'README.md'])
+        ['lektor_plugin_name.py', 'setup.cfg', 'setup.py', '.gitignore', 'README.md'])
 
     # gitignore
     gitignore_expected = textwrap.dedent("""
@@ -239,7 +239,7 @@ def test_new_plugin_path(project_cli_runner):
     assert result.exit_code == 0
     path = 'path'
     assert set(os.listdir(path)) == set(
-        ['lektor_plugin_name.py', 'setup.py', '.gitignore', 'README.md'])
+        ['lektor_plugin_name.py', 'setup.cfg', 'setup.py', '.gitignore', 'README.md'])
 
 
 def test_new_plugin_path_param(project_cli_runner):
@@ -254,7 +254,7 @@ def test_new_plugin_path_param(project_cli_runner):
     assert result.exit_code == 0
     path = 'path'
     assert set(os.listdir(path)) == set(
-        ['lektor_plugin_name.py', 'setup.py', '.gitignore', 'README.md'])
+        ['lektor_plugin_name.py', 'setup.cfg', 'setup.py', '.gitignore', 'README.md'])
 
 
 def test_new_plugin_path_and_name_params(project_cli_runner):
@@ -268,7 +268,7 @@ def test_new_plugin_path_and_name_params(project_cli_runner):
     assert result.exit_code == 0
     path = 'path'
     assert set(os.listdir(path)) == set(
-        ['lektor_plugin_name.py', 'setup.py', '.gitignore', 'README.md'])
+        ['lektor_plugin_name.py', 'setup.cfg', 'setup.py', '.gitignore', 'README.md'])
 
 
 # new-theme


### PR DESCRIPTION
### Issue(s) Resolved
Fixes #634 


### Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


Hey,

Unlike the other files in the plugin template, `setup.cfg` does not include any dynamically set value.
I've updated existing tests, should I include a test for `setup.cfg` contents?

~ :v: 