### PR TITLE
Set the color space for thumbnails and strip profiles/comments (#611)

### DIFF
--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -509,6 +509,7 @@ def process_image(ctx, source_image, dst_filename,
     else:
         cmdline += ['-resize', resize_key]
 
+    cmdline += ['-strip', "-colorspace", "sRGB"]
     cmdline += ['-quality', str(quality), dst_filename]
 
     reporter.report_debug_info('imagemagick cmd line', cmdline)


### PR DESCRIPTION
This implements the changes proposed in #611 by adding the desired command line arguments to `process_image()`.