### PR TITLE
Add support for output_path in project file

### DIFF
--- a/lektor/project.py
+++ b/lektor/project.py
@@ -98,7 +98,8 @@ class Project(object):
         config = self.open_config()
         output_path = config.get('project.output_path', '')
         if output_path:
-            return os.path.normpath(output_path)
+            return os.path.join(self.tree, os.path.normpath(output_path))
+
         return os.path.join(get_cache_dir(), 'builds', self.id)
 
     def get_package_cache_path(self):

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -96,7 +96,7 @@ class Project(object):
     def get_output_path(self):
         """The path where output files are stored."""
         config = self.open_config()
-        output_path = config.get('project.output_path', '')
+        output_path = config.get('project.output_path')
         if output_path:
             return os.path.join(self.tree, os.path.normpath(output_path))
 

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -95,6 +95,10 @@ class Project(object):
 
     def get_output_path(self):
         """The path where output files are stored."""
+        config = self.open_config()
+        output_path = config.get('project.output_path', '')
+        if output_path:
+            return os.path.normpath(output_path)
         return os.path.join(get_cache_dir(), 'builds', self.id)
 
     def get_package_cache_path(self):


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #688 


### Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

Lektor project file now supports "output_path" key.
The preference order will look like:
* Values set via cli `-O/--output-path`
* `LEKTOR_OUTPUT_PATH` environment variable
* `output_path` in lektor project file
* default cache folder (os-specific)

I haven't found any similar tests in the codebase, so it would be helpful if I get some direction here.