### PR TITLE
Relative URLs, fixes #713

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -155,7 +155,7 @@ def test_basic_template_rendering(pad, builder):
 
     assert '<title>My Website</title>' in rv
     assert '<h1>Welcome</h1>' in rv
-    assert '<link href="./static/style.css" rel="stylesheet">' in rv
+    assert '<link href="static/style.css" rel="stylesheet">' in rv
     assert '<p>Welcome to this pretty nifty website.</p>' in rv
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -145,7 +145,7 @@ def test_thumbnail_dimensions_reported(builder):
         html = f.read()
 
     for t, (w, h) in _THUMBNAILS.items():
-        assert '<img src="./%s" width="%s" height="%s">' % (t, w, h) in html
+        assert '<img src="%s" width="%s" height="%s">' % (t, w, h) in html
 
 
 def test_thumbnail_dimensions_real(builder):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -75,7 +75,7 @@ def test_markdown_linking(pad, builder):
     prog, _ = builder.build(blog_index)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'Look at my <a href="../blog/2015/12/post1/hello.txt">'
+            b'Look at my <a href="2015/12/post1/hello.txt">'
             b'attachment</a>'
         ) in f.read()
 
@@ -84,8 +84,7 @@ def test_markdown_linking(pad, builder):
     prog, _ = builder.build(blog_post)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'Look at my <a href="../../../../blog/2015/12/post1/hello.txt">'
-            b'attachment</a>'
+            b'Look at my <a href="hello.txt">attachment</a>.'
         ) in f.read()
 
 
@@ -95,7 +94,7 @@ def test_markdown_images(pad, builder):
     prog, _ = builder.build(blog_index)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'This is an image <img src="../blog/2015/12/'
+            b'This is an image <img src="2015/12/'
             b'post1/logo.png" alt="logo">.'
         ) in f.read()
 
@@ -104,8 +103,7 @@ def test_markdown_images(pad, builder):
     prog, _ = builder.build(blog_post)
     with prog.artifacts[0].open('rb') as f:
         assert (
-            b'This is an image <img src="../../../../blog/'
-            b'2015/12/post1/logo.png" alt="logo">.'
+            b'This is an image <img src="logo.png" alt="logo">.'
         ) in f.read()
 
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -21,14 +21,14 @@ def test_basic_url_to_with_alts(pad):
     wolf_de = pad.get('/projects/wolf', alt='de')
     slave_de = pad.get('/projects/slave', alt='de')
 
-    assert wolf_en.url_to(slave_en) == '../../projects/slave/'
-    assert wolf_de.url_to(slave_de) == '../../../de/projects/sklave/'
+    assert wolf_en.url_to(slave_en) == '../slave/'
+    assert wolf_de.url_to(slave_de) == '../sklave/'
     assert slave_en.url_to(slave_de) == '../../de/projects/sklave/'
     assert slave_de.url_to(slave_en) == '../../../projects/slave/'
 
 
 @pytest.mark.parametrize('path, alt, absolute, external, base_url, expected', [
-    ('/projects/slave', '', None, None, None, '../../projects/slave/'),
+    ('/projects/slave', '', None, None, None, '../slave/'),
     ('/projects/slave', 'de', None, None, None, '../../de/projects/sklave/'),
     ('/projects/slave', 'de', True, None, None, '/de/projects/sklave/'),
     ('/projects/slave', 'de', True, True, None, '/de/projects/sklave/'),
@@ -37,11 +37,11 @@ def test_basic_url_to_with_alts(pad):
     ('/projects/slave', 'de', None, True, '/content/', '/projects/slave1/de/projects/sklave/'),
     ('/projects/slave', 'de', None, None, '/content/', '../de/projects/sklave/'),
     ('', 'de', None, None, None, '../../de/projects/wolf/'),
-    ('!', 'de', None, None, None, '../../projects/wolf/'),
-    ('!/projects/slave', 'de', None, None, None, '../../projects/slave'),
-    ('!/projects/slave', None, None, None, None, '../../projects/slave'),
-    ('!', None, None, None, None, '../../projects/wolf/'),
-    ('', None, None, None, None, '../../projects/wolf/'),
+    ('!', 'de', None, None, None, './'),
+    ('!/projects/slave', 'de', None, None, None, '../slave'),
+    ('!/projects/slave', None, None, None, None, '../slave'),
+    ('!', None, None, None, None, './'),
+    ('', None, None, None, None, './'),
     ('/projects/slave', None, True, None, None, '/projects/slave/'),
     ('/projects/slave', None, True, True, None, '/projects/slave/'),
     ('/projects/slave', None, True, True, '/content/', '/projects/slave/'),
@@ -49,7 +49,7 @@ def test_basic_url_to_with_alts(pad):
     ('/projects/slave', None, None, True, None, '/projects/slave1/projects/slave/'),
     ('/projects/slave', None, None, True, '/content/', '/projects/slave1/projects/slave/'),
     ('/projects/slave', None, None, None, '/content/', '../projects/slave/'),
-    ('/projects/slave', None, None, None, None, '../../projects/slave/'),
+    ('/projects/slave', None, None, None, None, '../slave/'),
 
 ])
 def test_url_to_all_params(pad, path, alt, absolute, external, base_url, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,11 +69,11 @@ def test_parse_path():
 
 
 @pytest.mark.parametrize("base, target, expected", [
-    ("/", "./a/", "./a/"),
-    ("/", "./a", "./a"),
-    ("/fr/blog/2015/11/a/", "/fr/blog/2015/11/a/a.jpg", "../../../../../fr/blog/2015/11/a/a.jpg"),
-    ("/fr/blog/2015/11/a/", "/fr/blog/", "../../../../../fr/blog/"),
-    ("/fr/blog/2015/11/a.php", "/fr/blog/", "../../../../fr/blog/"),
+    ("/", "./a/", "a/"),
+    ("/", "./a", "a"),
+    ("/fr/blog/2015/11/a/", "/fr/blog/2015/11/a/a.jpg", "a.jpg"),
+    ("/fr/blog/2015/11/a/", "/fr/blog/", "../../../"),
+    ("/fr/blog/2015/11/a.php", "/fr/blog/", "../../"),
     ("/fr/blog/2015/11/a/", "/images/b.svg", "../../../../../images/b.svg"),
 ])
 def test_make_relative_url(base, target, expected):

--- a/tests/test_videotools.py
+++ b/tests/test_videotools.py
@@ -135,10 +135,10 @@ def test_thumbnail_height(builder):
 
     # The first thumbnail has the same dimensions as the source video,
     # seeked to 1.5 seconds in
-    assert '<img src="./test@t00-00-01-5.jpg" width="320" height="180">' in html
+    assert '<img src="test@t00-00-01-5.jpg" width="320" height="180">' in html
 
     # Thumbnail is half the original width, so its computed height is half.
-    assert '<img src="./test@t00-00-00_160.jpg" width="160" height="90">' in html
+    assert '<img src="test@t00-00-00_160.jpg" width="160" height="90">' in html
 
     # There should also be a square thumbnail
-    assert '<img src="./test@t00-00-02_160x160_crop.jpg" width="160" height="160">' in html
+    assert '<img src="test@t00-00-02_160x160_crop.jpg" width="160" height="160">' in html


### PR DESCRIPTION
### Issue(s) Resolved
Fixes #713

### Description of Changes
* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

Actual relative URLs that omit unnecessary folder traversing.

Example:
`/articles/2019/07/brownies` -> link to ->
`/articles/2019/07/brownies/image-gallery`

Previous output:
`../../../../articles/2019/07/brownies/image-gallery/`
Ouput with this PR:
`image-gallery/`

**Note:**
Resources in the same directory are linked without `./` in front.
With the only exception if the link target is the same.
`/blog/`
-> link to `/blog/` will result in `./`
-> link to `/blog/a.jpg` will result in `a.jpg`

Tiny URLs for all :)