### PR TITLE
Fix #698

### DIFF
--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -43,6 +43,7 @@
     "lint": "standard",
     "test": "nyc mocha static/js/**/*.test.js",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov",
+    "dev": "webpack --watch --config ./static/webpack.config.js --context ./static",
     "webpack": "webpack --config ./static/webpack.config.js --context ./static"
   },
   "babel": {

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -13,6 +13,7 @@ class EditPage extends RecordEditComponent {
     super(props)
 
     this.state = {
+      recordInitialData: null,
       recordData: null,
       recordDataModel: null,
       recordInfo: null,
@@ -79,19 +80,9 @@ class EditPage extends RecordEditComponent {
       alt: this.getRecordAlt()
     }, null, makeRichPromise)
       .then((resp) => {
-        // transform resp.data into actual data
-        let recordData = {}
-        resp.datamodel.fields.forEach(field => {
-          const widget = widgets.getWidgetComponentWithFallback(field.type)
-          let value = resp.data[field.name] || ''
-          if (widget.deserializeValue) {
-            value = widget.deserializeValue(value, field.type)
-          }
-          recordData[field.name] = value
-        })
-
         this.setState({
-          recordData: recordData,
+          recordInitialData: resp.data,
+          recordData: {},
           recordDataModel: resp.datamodel,
           recordInfo: resp.record_info,
           hasPendingChanges: false
@@ -118,9 +109,16 @@ class EditPage extends RecordEditComponent {
 
       let value = this.state.recordData[field.name]
 
-      const Widget = widgets.getWidgetComponentWithFallback(field.type)
-      if (Widget.serializeValue) {
-        value = Widget.serializeValue(value, field.type)
+      if (value !== undefined) {
+        const Widget = widgets.getWidgetComponentWithFallback(field.type)
+        if (Widget.serializeValue) {
+          value = Widget.serializeValue(value, field.type)
+        }
+      } else {
+        value = this.state.recordInitialData[field.name]
+        if (value === undefined) {
+          value = null
+        }
       }
 
       rv[field.name] = value
@@ -155,7 +153,14 @@ class EditPage extends RecordEditComponent {
   }
 
   getValueForField (widget, field) {
-    return this.state.recordData[field.name]
+    let value = this.state.recordData[field.name]
+    if (value === undefined) {
+      value = this.state.recordInitialData[field.name] || ''
+      if (widget.deserializeValue) {
+        value = widget.deserializeValue(value, field.type)
+      }
+    }
+    return value
   }
 
   getPlaceholderForField (widget, field) {


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #698 


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


The commit  11e94e1 added a performance optimisation by deserialising once upon load and not on every re-render. However, it was implemented in a way that also set fields to `''` (an empty string) so that they ended up being sent to the backend, causing the bug.

I've reverted the commit and ported the "deserialise on load" part.


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
