### PR TITLE
change test that breaks git configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,7 @@
 import os
 import shutil
-import subprocess
 import textwrap
 import pytest
-
-from lektor.utils import is_windows
 
 
 @pytest.fixture(scope='function')
@@ -166,25 +163,6 @@ def os_user(monkeypatch):
     monkeypatch.setattr("pwd.getpwuid", lambda id: struct)
     monkeypatch.setenv("USER", "lektortest")
     return "lektortest"
-
-
-@pytest.fixture(scope='function')
-def git_user_email(request):
-    old_email = subprocess.Popen(['git', 'config', 'user.email'],
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE).communicate()[0].strip()
-    # on windows subprocess need str in input
-    # but returns bytes on exit
-    if is_windows:
-        old_email = old_email.decode('utf-8')
-
-    def cleanup():
-        subprocess.check_call(['git', 'config', 'user.email', old_email])
-    request.addfinalizer(cleanup)
-
-    email = "lektortest@example.com"
-    subprocess.check_call(['git', 'config', 'user.email', email])
-    return email
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,8 +1,11 @@
+from lektor._compat import text_type
+from lektor.quickstart import get_default_author
+from lektor.quickstart import get_default_author_email
+
+
 def test_default_author(os_user):
-    from lektor.quickstart import get_default_author
     assert get_default_author() == "Lektor Test"
 
 
-def test_default_author_email(git_user_email):
-    from lektor.quickstart import get_default_author_email
-    assert get_default_author_email() == "lektortest@example.com"
+def test_default_author_email():
+    assert isinstance(get_default_author_email(), text_type)


### PR DESCRIPTION
This test was testing a one-line function that basically just called out
to `git config` to get the configured email with a test fixture that
had 3 calls to `git config` and would break the local git config.

Testing some functionality by having a test fixture that just duplicates
that code seems somewhat pointless, even more so when that breaks the
test runners git configuration.

If removed the fixture, instead we now only test that the function
returns a string.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->


