### PR TITLE
unified installer

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python
+
+import math
+import os
+import shutil
+import sys
+import tempfile
+from subprocess import call
+
+
+_is_win = sys.platform == 'win32'
+
+if not _is_win:
+    sys.stdin = open('/dev/tty', 'r')
+
+if sys.version_info[0] == 2:
+    input = raw_input
+
+prompt = os.environ.get('LEKTOR_SILENT') is None
+
+def get_confirmation():
+    if prompt is False:
+        return
+
+    while True:
+        user_input = input('Continue? [Yn] ').lower().strip()
+
+        if user_input in ('', 'y'):
+            print('')
+            return
+
+        if user_input == 'n':
+            print('')
+            print('Aborted!')
+            sys.exit()
+
+def fail(message):
+    print('Error: %s' % message)
+    sys.exit(1)
+
+def multiprint(*lines):
+    for line in lines:
+        print(line)
+
+
+class Installer(object):
+    APP_NAME = 'lektor'
+    VIRTUALENV_URL = 'https://bootstrap.pypa.io/virtualenv.pyz'
+
+    def __init__(self):
+        multiprint('',
+                   'Welcome to Lektor',
+                   '',
+                   'This script will install Lektor on your computer.',
+                   '')
+
+        self.compute_location()
+
+        self.prompt_installation()
+        get_confirmation()
+
+        if self.check_installation():
+            self.prompt_wipe()
+            get_confirmation()
+
+            self.wipe_installation()
+
+        self.create_virtualenv()
+        self.install_lektor()
+
+        multiprint('',
+                   'All done!')
+
+    def compute_location(self):
+        # this method must set self.lib_dir
+        raise NotImplementedError()
+
+    def check_installation(self):
+        raise NotImplementedError()
+
+    def wipe_installation(self):
+        raise NotImplementedError()
+
+    def prompt_installation(self):
+        raise NotImplementedError()
+
+    def prompt_wipe(self):
+        raise NotImplementedError()
+
+    def create_virtualenv(self):
+        self.mkvirtualenv(self.lib_dir)
+
+    def install_lektor(self):
+        call([self.get_pip(), 'install', '--upgrade', 'Lektor'])
+
+    def get_pip(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def mkvirtualenv(cls, target_dir):
+        """
+        Tries to create a virtualenv by using the built-in `venv` module,
+        or using the `virtualenv` executable if present, or falling back
+        to downloading the official zipapp.
+        """
+
+        created = False
+
+        try:
+            from venv import EnvBuilder
+        except ImportError:
+            pass
+        else:
+            try:
+                # TODO: design decision needed:
+                # on Debian and Ubuntu systems Python is missing `ensurepip`,
+                # prompting the user to install `python3-venv` instead.
+                # we could do the same, or go the download route...
+                import ensurepip
+            except ImportError:
+                pass
+            else:
+                venv = EnvBuilder(with_pip=True,
+                                  symlinks=False if _is_win else True)
+                venv.create(target_dir)
+                created = True
+
+        if not created:
+            try:
+                from shutil import which
+            except ImportError:
+                from distutils.spawn import find_executable as which
+
+            venv_exec = which("virtualenv")
+            if venv_exec:
+                retval = call([venv_exec, '-p', sys.executable, target_dir])
+                if retval:
+                    sys.exit(1)
+                created = True
+
+        if not created:
+            zipapp = cls.fetch_virtualenv()
+            retval = call([sys.executable, zipapp, target_dir])
+            os.unlink(zipapp)
+            if retval:
+                sys.exit(1)
+
+    @classmethod
+    def fetch_virtualenv(cls):
+        try:
+            from urllib.request import urlretrieve
+        except ImportError:
+            from urllib import urlretrieve
+
+        fname = os.path.basename(cls.VIRTUALENV_URL)
+        root, ext = os.path.splitext(fname)
+
+        zipapp = tempfile.mktemp(prefix=root+"-", suffix=ext)
+
+        with Progress() as hook:
+            sys.stdout.write("Downloading virtualenv: ")
+            urlretrieve(cls.VIRTUALENV_URL, zipapp, reporthook=hook)
+
+        return zipapp
+
+    @staticmethod
+    def deletion_error(func, path, excinfo):
+        print('Problem deleting {}'.format(path))
+        print('Please try and delete {} manually'.format(path))
+        print('Aborted!')
+        sys.exit(1)
+
+
+_home = os.environ.get('HOME')
+
+class PosixInstaller(Installer):
+    KNOWN_BIN_PATHS = ['/usr/local/bin', '/opt/local/bin']
+    if _home: # this is always true, but it needs not blow up on windows
+        KNOWN_BIN_PATHS.extend([
+            os.path.join(_home, '.bin'),
+            os.path.join(_home, '.local', 'bin'),
+        ])
+
+    def prompt_installation(self):
+        multiprint('Installing at:',
+                   '  bin: %s' % self.bin_dir,
+                   '  app: %s' % self.lib_dir,
+                   '')
+
+    def prompt_wipe(self):
+        multiprint('Lektor seems to be installed already.',
+                   'Continuing will delete:',
+                   '  %s' % self.lib_dir,
+                   'and remove this symlink:',
+                   '  %s' % self.symlink_path,
+                   '')
+
+    def compute_location(self):
+        """
+        Finds the preferred directory in the user's $PATH,
+        and derives the lib dir from it.
+        """
+
+        paths = [
+            item for item in os.environ['PATH'].split(':')
+            if not item.endswith('/sbin') and os.access(item, os.W_OK)
+        ]
+
+        if not paths:
+            fail('None of the items in $PATH are writable. Run with '
+                 'sudo or add a $PATH item that you have access to.')
+
+        def _sorter(path):
+            try:
+                return self.KNOWN_BIN_PATHS.index(path)
+            except ValueError:
+                return float('inf')
+
+        paths.sort(key=_sorter)
+
+        lib_dir = None
+
+        home = os.environ['HOME']
+        for path in paths:
+            if path.startswith(home):
+                lib_dir = os.path.join(home, '.local', 'lib', self.APP_NAME)
+                break
+
+            if path.endswith('/bin'):
+                parent = os.path.dirname(path)
+                lib_dir = os.path.join(parent, 'lib', self.APP_NAME)
+                break
+
+        if lib_dir is None:
+            fail('Could not determine installation location for Lektor.')
+
+        self.bin_dir = path
+        self.lib_dir = lib_dir
+
+    @property
+    def symlink_path(self):
+        return os.path.join(self.bin_dir, self.APP_NAME)
+
+    def check_installation(self):
+        return os.path.exists(self.lib_dir) \
+            or os.path.lexists(self.symlink_path)
+
+    def wipe_installation(self):
+        if os.path.lexists(self.symlink_path):
+            os.remove(self.symlink_path)
+        if os.path.exists(self.lib_dir):
+            shutil.rmtree(self.lib_dir, onerror=self.deletion_error)
+
+    def get_pip(self):
+        return os.path.join(self.lib_dir, 'bin', 'pip')
+
+    def install_lektor(self):
+        import pdb
+        super(PosixInstaller, self).install_lektor()
+
+        bin = os.path.join(self.lib_dir, 'bin', 'lektor')
+        os.symlink(bin, self.symlink_path)
+
+
+class WindowsInstaller(Installer):
+    APP_NAME = 'lektor-cli' # backwards-compatibility with previous installer
+    LIB_DIR = 'lib'
+
+    def prompt_installation(self):
+        multiprint('Installing at:',
+                   '  %s' % self.install_dir,
+                   '')
+
+    def prompt_wipe(self):
+        multiprint('Lektor seems to be installed already.',
+                   'Continuing will delete:',
+                   '  %s' % self.install_dir,
+                   '')
+
+    def compute_location(self):
+        install_dir = os.path.join(os.environ['LocalAppData'], self.APP_NAME)
+        lib_dir = os.path.join(install_dir, self.LIB_DIR)
+
+        self.install_dir = install_dir
+        self.lib_dir = lib_dir
+
+    def check_installation(self):
+        return os.path.exists(self.install_dir)
+
+    def wipe_installation(self):
+        shutil.rmtree(self.install_dir, onerror=self.deletion_error)
+
+    def get_pip(self):
+        return os.path.join(self.lib_dir, 'Scripts', 'pip.exe')
+
+    def install_lektor(self):
+        super(WindowsInstaller, self).install_lektor()
+
+        exe = os.path.join(self.lib_dir, 'Scripts', 'lektor.exe')
+        link = os.path.join(self.install_dir, 'lektor.cmd')
+
+        with open(link, 'w') as link_file:
+            link_file.write('@echo off\n')
+            link_file.write('"%s" %%*' % exe)
+
+        self.add_to_path(self.install_dir)
+
+    @staticmethod
+    def add_to_path(location):
+        try:
+            from winreg import (
+                OpenKey, CloseKey, QueryValueEx, SetValueEx,
+                HKEY_CURRENT_USER, KEY_ALL_ACCESS, REG_EXPAND_SZ,
+            )
+        except ImportError: # py2
+            from _winreg import (
+                OpenKey, CloseKey, QueryValueEx, SetValueEx,
+                HKEY_CURRENT_USER, KEY_ALL_ACCESS, REG_EXPAND_SZ,
+            )
+        import ctypes
+        from ctypes.wintypes import HWND, UINT, WPARAM, LPARAM, LPVOID
+
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x1A
+
+        reg_key = OpenKey(HKEY_CURRENT_USER, 'Environment', 0, KEY_ALL_ACCESS)
+
+        try:
+            path_value, _ = QueryValueEx(reg_key, 'Path')
+        except WindowsError:
+            path_value = ''
+
+        paths = path_value.split(';')
+        if location not in paths:
+            paths.append(location)
+            path_value = ';'.join(paths)
+            SetValueEx(reg_key, 'Path', 0, REG_EXPAND_SZ, path_value)
+
+        SendMessage = ctypes.windll.user32.SendMessageW
+        SendMessage.argtypes = HWND, UINT, WPARAM, LPVOID
+        SendMessage.restype = LPARAM
+        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, u'Environment')
+
+
+class Progress(object):
+    "A context manager to be used as a urlretrieve reporthook."
+
+    def __init__(self):
+        self.started = False
+
+    def progress(self, count, bsize, total):
+        size = count * bsize
+
+        if size > total:
+            progress = 100
+        else:
+            progress = math.floor(100 * size / total)
+
+        out = sys.stdout
+        if self.started:
+            out.write("\b" * 4)
+
+        out.write("%3d" % progress + "%")
+        out.flush()
+
+        self.started = True
+
+    def finish(self):
+        sys.stdout.write("\n")
+
+    def __enter__(self):
+        return self.progress
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.finish()
+
+
+install = WindowsInstaller if _is_win \
+    else PosixInstaller
+
+
+if __name__ == '__main__':
+    install()

--- a/bin/install.py
+++ b/bin/install.py
@@ -13,39 +13,42 @@ except ImportError:
     from urllib import urlretrieve
 
 
-_IS_WIN = sys.platform == 'win32'
+_IS_WIN = sys.platform == "win32"
 
 if not _IS_WIN:
-    sys.stdin = open('/dev/tty', 'r')
+    sys.stdin = open("/dev/tty", "r")
 
 if sys.version_info.major == 2:
     input = raw_input
 
-_silent = os.environ.get('LEKTOR_SILENT')
+_silent = os.environ.get("LEKTOR_SILENT")
 _PROMPT = (
     _silent is None
-    or _silent.lower() in ('', '0', 'off', 'false')
+    or _silent.lower() in ("", "0", "off", "false")
 )
+
 
 def get_confirmation():
     if _PROMPT is False:
         return
 
     while True:
-        user_input = input('Continue? [Yn] ').lower().strip()
+        user_input = input("Continue? [Yn] ").lower().strip()
 
-        if user_input in ('', 'y'):
+        if user_input in ("", "y"):
             print()
             return
 
-        if user_input == 'n':
+        if user_input == "n":
             print()
-            print('Aborted!')
+            print("Aborted!")
             sys.exit()
 
+
 def fail(message):
-    print('Error: %s' % message, file=sys.stderr)
+    print("Error: %s" % message, file=sys.stderr)
     sys.exit(1)
+
 
 def multiprint(*lines, **kwargs):
     for line in lines:
@@ -53,15 +56,17 @@ def multiprint(*lines, **kwargs):
 
 
 class Installer(object):
-    APP_NAME = 'lektor'
-    VIRTUALENV_URL = 'https://bootstrap.pypa.io/virtualenv.pyz'
+    APP_NAME = "lektor"
+    VIRTUALENV_URL = "https://bootstrap.pypa.io/virtualenv.pyz"
 
     def __init__(self):
-        multiprint('',
-                   'Welcome to Lektor',
-                   '',
-                   'This script will install Lektor on your computer.',
-                   '')
+        multiprint(
+            "",
+            "Welcome to Lektor",
+            "",
+            "This script will install Lektor on your computer.",
+            "",
+        )
 
         self.compute_location()
 
@@ -77,8 +82,10 @@ class Installer(object):
         self.create_virtualenv()
         self.install_lektor()
 
-        multiprint('',
-                   'All done!')
+        multiprint(
+            "",
+            "All done!",
+        )
 
     def compute_location(self):
         # this method must set self.lib_dir
@@ -100,7 +107,7 @@ class Installer(object):
         self.mkvirtualenv(self.lib_dir)
 
     def install_lektor(self):
-        call([self.get_pip(), 'install', '--upgrade', 'Lektor'])
+        call([self.get_pip(), "install", "--upgrade", "Lektor"])
 
     def get_pip(self):
         raise NotImplementedError()
@@ -142,7 +149,7 @@ class Installer(object):
 
             venv_exec = which("virtualenv")
             if venv_exec:
-                retval = call([venv_exec, '-p', sys.executable, target_dir])
+                retval = call([venv_exec, "-p", sys.executable, target_dir])
                 if retval:
                     sys.exit(1)
                 created = True
@@ -159,7 +166,7 @@ class Installer(object):
         fname = os.path.basename(cls.VIRTUALENV_URL)
         root, ext = os.path.splitext(fname)
 
-        zipapp = tempfile.mktemp(prefix=root+"-", suffix=ext)
+        zipapp = tempfile.mktemp(prefix=root + "-", suffix=ext)
 
         with Progress() as hook:
             sys.stdout.write("Downloading virtualenv: ")
@@ -169,37 +176,43 @@ class Installer(object):
 
     @staticmethod
     def deletion_error(func, path, excinfo):
-        multiprint('Problem deleting {}'.format(path),
-                   'Please try and delete {} manually'.format(path),
-                   'Aborted!',
-                   file=sys.stderr)
+        multiprint(
+            "Problem deleting {}".format(path),
+            "Please try and delete {} manually".format(path),
+            "Aborted!",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
-_HOME = os.environ.get('HOME')
+_HOME = os.environ.get("HOME")
+
 
 class PosixInstaller(Installer):
     # prefer system bin dirs
-    KNOWN_BIN_PATHS = ['/usr/local/bin', '/opt/local/bin']
-    if _HOME: # true on *nix, but we need it to prevent blowing up on windows
-        KNOWN_BIN_PATHS.extend([
-            os.path.join(_HOME, '.bin'),
-            os.path.join(_HOME, '.local', 'bin'),
-        ])
+    KNOWN_BIN_PATHS = ["/usr/local/bin", "/opt/local/bin"]
+    if _HOME:  # true on *nix, but we need it to prevent blowing up on windows
+        KNOWN_BIN_PATHS.extend(
+            [os.path.join(_HOME, ".bin"), os.path.join(_HOME, ".local", "bin"),]
+        )
 
     def prompt_installation(self):
-        multiprint('Installing at:',
-                   '  bin: %s' % self.bin_dir,
-                   '  app: %s' % self.lib_dir,
-                   '')
+        multiprint(
+            "Installing at:",
+            "  bin: %s" % self.bin_dir,
+            "  app: %s" % self.lib_dir,
+            "",
+        )
 
     def prompt_wipe(self):
-        multiprint('Lektor seems to be installed already.',
-                   'Continuing will delete:',
-                   '  %s' % self.lib_dir,
-                   'and remove this symlink:',
-                   '  %s' % self.symlink_path,
-                   '')
+        multiprint(
+            "Lektor seems to be installed already.",
+            "Continuing will delete:",
+            "  %s" % self.lib_dir,
+            "and remove this symlink:",
+            "  %s" % self.symlink_path,
+            "",
+        )
 
     def compute_location(self):
         """
@@ -210,13 +223,16 @@ class PosixInstaller(Installer):
         # look for writable directories in the user's $PATH
         # (that are not sbin)
         paths = [
-            item for item in os.environ['PATH'].split(':')
-            if not item.endswith('/sbin') and os.access(item, os.W_OK)
+            item
+            for item in os.environ["PATH"].split(":")
+            if not item.endswith("/sbin") and os.access(item, os.W_OK)
         ]
 
         if not paths:
-            fail('None of the items in $PATH are writable. Run with '
-                 'sudo or add a $PATH item that you have access to.')
+            fail(
+                "None of the items in $PATH are writable. Run with "
+                "sudo or add a $PATH item that you have access to."
+            )
 
         # ... and prioritize them according to KNOWN_BIN_PATHS.
         # this makes sure we perform a system install when possible.
@@ -224,25 +240,24 @@ class PosixInstaller(Installer):
             try:
                 return self.KNOWN_BIN_PATHS.index(path)
             except ValueError:
-                return float('inf')
+                return float("inf")
 
         paths.sort(key=_sorter)
 
         lib_dir = None
 
-        home = os.environ['HOME']
         for path in paths:
-            if path.startswith(home):
-                lib_dir = os.path.join(home, '.local', 'lib', self.APP_NAME)
+            if path.startswith(_HOME):
+                lib_dir = os.path.join(_HOME, ".local", "lib", self.APP_NAME)
                 break
 
-            if path.endswith('/bin'):
+            if path.endswith("/bin"):
                 parent = os.path.dirname(path)
-                lib_dir = os.path.join(parent, 'lib', self.APP_NAME)
+                lib_dir = os.path.join(parent, "lib", self.APP_NAME)
                 break
 
         if lib_dir is None:
-            fail('Could not determine installation location for Lektor.')
+            fail("Could not determine installation location for Lektor.")
 
         self.bin_dir = path
         self.lib_dir = lib_dir
@@ -262,32 +277,36 @@ class PosixInstaller(Installer):
             shutil.rmtree(self.lib_dir, onerror=self.deletion_error)
 
     def get_pip(self):
-        return os.path.join(self.lib_dir, 'bin', 'pip')
+        return os.path.join(self.lib_dir, "bin", "pip")
 
     def install_lektor(self):
         super(PosixInstaller, self).install_lektor()
 
-        bin = os.path.join(self.lib_dir, 'bin', 'lektor')
+        bin = os.path.join(self.lib_dir, "bin", "lektor")
         os.symlink(bin, self.symlink_path)
 
 
 class WindowsInstaller(Installer):
-    APP_NAME = 'lektor-cli' # backwards-compatibility with previous installer
-    LIB_DIR = 'lib'
+    APP_NAME = "lektor-cli"  # backwards-compatibility with previous installer
+    LIB_DIR = "lib"
 
     def prompt_installation(self):
-        multiprint('Installing at:',
-                   '  %s' % self.install_dir,
-                   '')
+        multiprint(
+            "Installing at:",
+            "  %s" % self.install_dir,
+            "",
+        )
 
     def prompt_wipe(self):
-        multiprint('Lektor seems to be installed already.',
-                   'Continuing will delete:',
-                   '  %s' % self.install_dir,
-                   '')
+        multiprint(
+            "Lektor seems to be installed already.",
+            "Continuing will delete:",
+            "  %s" % self.install_dir,
+            "",
+        )
 
     def compute_location(self):
-        install_dir = os.path.join(os.environ['LocalAppData'], self.APP_NAME)
+        install_dir = os.path.join(os.environ["LocalAppData"], self.APP_NAME)
         lib_dir = os.path.join(install_dir, self.LIB_DIR)
 
         self.install_dir = install_dir
@@ -300,16 +319,16 @@ class WindowsInstaller(Installer):
         shutil.rmtree(self.install_dir, onerror=self.deletion_error)
 
     def get_pip(self):
-        return os.path.join(self.lib_dir, 'Scripts', 'pip.exe')
+        return os.path.join(self.lib_dir, "Scripts", "pip.exe")
 
     def install_lektor(self):
         super(WindowsInstaller, self).install_lektor()
 
-        exe = os.path.join(self.lib_dir, 'Scripts', 'lektor.exe')
-        link = os.path.join(self.install_dir, 'lektor.cmd')
+        exe = os.path.join(self.lib_dir, "Scripts", "lektor.exe")
+        link = os.path.join(self.install_dir, "lektor.cmd")
 
-        with open(link, 'w') as link_file:
-            link_file.write('@echo off\n')
+        with open(link, "w") as link_file:
+            link_file.write("@echo off\n")
             link_file.write('"{}" %*'.format(exe))
 
         self.add_to_path(self.install_dir)
@@ -321,7 +340,7 @@ class WindowsInstaller(Installer):
                 OpenKey, CloseKey, QueryValueEx, SetValueEx,
                 HKEY_CURRENT_USER, KEY_ALL_ACCESS, REG_EXPAND_SZ,
             )
-        except ImportError: # py2
+        except ImportError:  # py2
             from _winreg import (
                 OpenKey, CloseKey, QueryValueEx, SetValueEx,
                 HKEY_CURRENT_USER, KEY_ALL_ACCESS, REG_EXPAND_SZ,
@@ -332,23 +351,23 @@ class WindowsInstaller(Installer):
         HWND_BROADCAST = 0xFFFF
         WM_SETTINGCHANGE = 0x1A
 
-        reg_key = OpenKey(HKEY_CURRENT_USER, 'Environment', 0, KEY_ALL_ACCESS)
+        reg_key = OpenKey(HKEY_CURRENT_USER, "Environment", 0, KEY_ALL_ACCESS)
 
         try:
-            path_value, _ = QueryValueEx(reg_key, 'Path')
+            path_value, _ = QueryValueEx(reg_key, "Path")
         except WindowsError:
-            path_value = ''
+            path_value = ""
 
-        paths = path_value.split(';')
+        paths = path_value.split(";")
         if location not in paths:
             paths.append(location)
-            path_value = ';'.join(paths)
-            SetValueEx(reg_key, 'Path', 0, REG_EXPAND_SZ, path_value)
+            path_value = ";".join(paths)
+            SetValueEx(reg_key, "Path", 0, REG_EXPAND_SZ, path_value)
 
         SendMessage = ctypes.windll.user32.SendMessageW
         SendMessage.argtypes = HWND, UINT, WPARAM, LPVOID
         SendMessage.restype = LPARAM
-        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, u'Environment')
+        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, u"Environment")
 
 
 class Progress(object):
@@ -388,5 +407,5 @@ install = WindowsInstaller if _IS_WIN \
     else PosixInstaller
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     install()


### PR DESCRIPTION
~~This fixes #720, but does not fix #635 (yet, more on that later).~~
This fixes #720 and #635 (but uncovers a new windows issue, more on that later).

So, the big change:
 - fix the great annoyance that was separate installers for *nix and windows,
 - while getting rid of the python embedded in sh / ps,
 - and moving the code over to the main project, out of the website.

What I intend to do:
 - import the old install.sh and install.ps with all their commit history;
 - update the *nix docs to download and run the python file directly (using a .sh was pointless);
 - figure out a way to handle windows. The old instructions were downloading the .ps using ps scripting anyway, shouldn't be too hard.
 - for now copy the installer(s) manually over to the website assets; set up an automated job later on.

Now, I need help with the following:
 - code review. Not so much the logic (which I think I reproduced accurately from the old code), but rather the style and structure. I tried to make it elegant and logical, but I'm not entirely happy with it.
 - a crazy spectacular issue with windows 10. I'll describe it in a new message.