### PR TITLE
Frontend: more modernisations and some performance improvements

### DIFF
--- a/lektor/admin/package-lock.json
+++ b/lektor/admin/package-lock.json
@@ -1767,7 +1767,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -3132,15 +3133,6 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -3828,29 +3820,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fbjs": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
-      "integrity": "sha1-TwaV/fzBbDfAsH+s7Iy0xAkWhbk=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
-      }
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -5382,16 +5351,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -6613,16 +6572,6 @@
         "semver": "^5.7.0"
       }
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -7815,6 +7764,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -7976,16 +7926,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-addons-update": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.6.2.tgz",
-      "integrity": "sha1-5TdTxbNIh5dFEMiC1/sHWFHV5QQ=",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.9",
-        "object-assign": "^4.1.0"
       }
     },
     "react-dom": {
@@ -9465,12 +9405,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "ua-parser-js": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
-      "dev": true
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -10663,12 +10597,6 @@
           "dev": true
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
     },
     "whatwg-url": {
       "version": "3.1.0",

--- a/lektor/admin/package-lock.json
+++ b/lektor/admin/package-lock.json
@@ -2712,17 +2712,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -13,7 +13,6 @@
     "babel-plugin-istanbul": "^6.0.0",
     "bootstrap": "~3.3.0",
     "chai": "^4.2.0",
-    "create-react-class": "^15.6.3",
     "css-loader": "^3.4.2",
     "event-source-polyfill": "^1.0.12",
     "file-loader": "^6.0.0",

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -28,7 +28,6 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "^16.13.1",
-    "react-addons-update": "^15.6.2",
     "react-dom": "^16.13.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/lektor/admin/static/js/components/RecordComponent.jsx
+++ b/lektor/admin/static/js/components/RecordComponent.jsx
@@ -1,7 +1,7 @@
 'use strict'
 
 import Component from './Component'
-import { getParentFsPath, urlToFsPath, fsToUrlPath, urlPathToSegments } from '../utils'
+import { getParentFsPath, urlToFsPath, fsToUrlPath } from '../utils'
 
 export function getRecordPathAndAlt (path) {
   if (!path) {
@@ -13,13 +13,7 @@ export function getRecordPathAndAlt (path) {
 
 /* a react component baseclass that has some basic knowledge about
    the record it works with. */
-class RecordComponent extends Component {
-  /* this returns the current record path segments as array */
-  getRecordPathSegments () {
-    const path = this.props.match.params.path
-    return path ? urlPathToSegments(path) : []
-  }
-
+export default class RecordComponent extends Component {
   /* this returns the path of the current record.  If the current page does
    * not have a path component then null is returned. */
   getRecordPath () {
@@ -53,34 +47,4 @@ class RecordComponent extends Component {
   getParentRecordPath () {
     return getParentFsPath(this.getRecordPath())
   }
-
-  /* returns true if this is the root record */
-  isRootRecord () {
-    return this.getRecordPath() === ''
-  }
-
-  /* returns the breadcrumbs for the current record path */
-  getRecordCrumbs () {
-    const segments = this.getRecordPathSegments()
-    if (segments === null) {
-      return []
-    }
-
-    segments.unshift('root')
-
-    const rv = []
-    for (let i = 0; i < segments.length; i++) {
-      const curpath = segments.slice(0, i + 1).join(':')
-      rv.push({
-        id: 'path:' + curpath,
-        urlPath: curpath,
-        segments: segments.slice(1, i + 1),
-        title: segments[i]
-      })
-    }
-
-    return rv
-  }
 }
-
-export default RecordComponent

--- a/lektor/admin/static/js/main.jsx
+++ b/lektor/admin/static/js/main.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom'
 import i18n from './i18n'
 
 import 'bootstrap'
@@ -41,6 +41,9 @@ function Main (props) {
         <Route name='preview' path={`${path}/:path/preview`} component={PreviewPage} />
         <Route name='add-child' path={`${path}/:path/add-child`} component={AddChildPage} />
         <Route name='upload' path={`${path}/:path/upload`} component={AddAttachmentPage} />
+        <Route exact path={path}>
+          <Redirect to={`${path}/root/edit`} />
+        </Route>
         <Route component={BadRoute} />
       </Switch>
     </App>

--- a/lektor/admin/static/js/main.jsx
+++ b/lektor/admin/static/js/main.jsx
@@ -5,14 +5,12 @@ import ReactDOM from 'react-dom'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import i18n from './i18n'
 
-/* eslint-disable no-unused-vars */
-import Bootstrap from 'bootstrap'
-import BootstrapExtras from './bootstrap-extras'
-import FACss from 'font-awesome/css/font-awesome.css'
+import 'bootstrap'
+import './bootstrap-extras'
+import 'font-awesome/css/font-awesome.css'
 
 // polyfill for internet explorer
-import EventSource from 'event-source-polyfill'
-/* eslint-enable no-unused-vars */
+import 'event-source-polyfill'
 
 // route targets
 import App from './views/App'

--- a/lektor/admin/static/js/utils.jsx
+++ b/lektor/admin/static/js/utils.jsx
@@ -101,17 +101,6 @@ export function urlToFsPath (urlPath) {
   return segments.join('/')
 }
 
-export function urlPathToSegments (urlPath) {
-  if (!urlPath) {
-    return null
-  }
-  const rv = urlPath.match(/^:*(.*?):*$/)[1].split('/')
-  if (rv.length >= 1 && rv[0] === 'root') {
-    return rv.slice(1)
-  }
-  return null
-}
-
 export function fsPathFromAdminObservedPath (adminPath) {
   const base = $LEKTOR_CONFIG.site_root.match(/^(.*?)\/*$/)[1]
   if (adminPath.substr(0, base.length) !== base) {

--- a/lektor/admin/static/js/views/EditPage.jsx
+++ b/lektor/admin/static/js/views/EditPage.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import { Prompt } from 'react-router-dom'
-import update from 'react-addons-update'
 
 import RecordComponent from '../components/RecordComponent'
 import { apiRequest, loadData, isMetaKey } from '../utils'
@@ -21,6 +20,7 @@ class EditPage extends RecordComponent {
       hasPendingChanges: false
     }
     this._onKeyPress = this._onKeyPress.bind(this)
+    this.setFieldValue = this.setFieldValue.bind(this)
   }
 
   componentDidMount () {
@@ -90,10 +90,8 @@ class EditPage extends RecordComponent {
       })
   }
 
-  onValueChange (field, value) {
-    const updates = {}
-    updates[field.name] = { $set: value || '' }
-    const rd = update(this.state.recordData, updates)
+  setFieldValue (field, value) {
+    const rd = { ...this.state.recordData, [field.name]: value || '' }
     this.setState({
       recordData: rd,
       hasPendingChanges: true
@@ -185,7 +183,7 @@ class EditPage extends RecordComponent {
         value={this.getValueForField(widget, field)}
         placeholder={this.getPlaceholderForField(widget, field)}
         field={field}
-        onChange={this.onValueChange.bind(this, field)}
+        setFieldValue={this.setFieldValue}
         disabled={!(field.alts_enabled == null || (field.alts_enabled ^ this.state.recordInfo.alt === '_primary'))}
       />
     )

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -2,7 +2,7 @@
 
 import PropTypes from 'prop-types'
 import React from 'react'
-import primitiveWidgets, { BooleanInputWidget, MultiLineTextInputWidget } from './widgets/primitiveWidgets'
+import { DateInputWidget, IntegerInputWidget, FloatInputWidget, UrlInputWidget, SlugInputWidget, BooleanInputWidget, MultiLineTextInputWidget, SingleLineTextInputWidget } from './widgets/primitiveWidgets'
 import { CheckboxesInputWidget, SelectInputWidget } from './widgets/multiWidgets'
 import { FlowWidget } from './widgets/flowWidget'
 import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
@@ -12,14 +12,14 @@ import ToggleGroup from './components/ToggleGroup'
 import i18n from './i18n'
 
 const widgetComponents = {
-  'singleline-text': primitiveWidgets.SingleLineTextInputWidget,
+  'singleline-text': SingleLineTextInputWidget,
   'multiline-text': MultiLineTextInputWidget,
-  datepicker: primitiveWidgets.DateInputWidget,
-  integer: primitiveWidgets.IntegerInputWidget,
-  float: primitiveWidgets.FloatInputWidget,
+  datepicker: DateInputWidget,
+  integer: IntegerInputWidget,
+  float: FloatInputWidget,
   checkbox: BooleanInputWidget,
-  url: primitiveWidgets.UrlInputWidget,
-  slug: primitiveWidgets.SlugInputWidget,
+  url: UrlInputWidget,
+  slug: SlugInputWidget,
   flow: FlowWidget,
   checkboxes: CheckboxesInputWidget,
   select: SelectInputWidget,

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -3,7 +3,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import primitiveWidgets from './widgets/primitiveWidgets'
-import multiWidgets from './widgets/multiWidgets'
+import { CheckboxesInputWidget, SelectInputWidget } from './widgets/multiWidgets'
 import flowWidget from './widgets/flowWidget'
 import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
 import { widgetPropTypes } from './widgets/mixins'
@@ -21,8 +21,8 @@ const widgetComponents = {
   url: primitiveWidgets.UrlInputWidget,
   slug: primitiveWidgets.SlugInputWidget,
   flow: flowWidget.FlowWidget,
-  checkboxes: multiWidgets.CheckboxesInputWidget,
-  select: multiWidgets.SelectInputWidget,
+  checkboxes: CheckboxesInputWidget,
+  select: SelectInputWidget,
   'f-line': LineWidget,
   'f-spacing': SpacingWidget,
   'f-info': InfoWidget,

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -2,9 +2,9 @@
 
 import PropTypes from 'prop-types'
 import React from 'react'
-import primitiveWidgets from './widgets/primitiveWidgets'
+import primitiveWidgets, { BooleanInputWidget, MultiLineTextInputWidget } from './widgets/primitiveWidgets'
 import { CheckboxesInputWidget, SelectInputWidget } from './widgets/multiWidgets'
-import flowWidget from './widgets/flowWidget'
+import { FlowWidget } from './widgets/flowWidget'
 import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
 import { widgetPropTypes } from './widgets/mixins'
 import Component from './components/Component'
@@ -13,14 +13,14 @@ import i18n from './i18n'
 
 const widgetComponents = {
   'singleline-text': primitiveWidgets.SingleLineTextInputWidget,
-  'multiline-text': primitiveWidgets.MultiLineTextInputWidget,
+  'multiline-text': MultiLineTextInputWidget,
   datepicker: primitiveWidgets.DateInputWidget,
   integer: primitiveWidgets.IntegerInputWidget,
   float: primitiveWidgets.FloatInputWidget,
-  checkbox: primitiveWidgets.BooleanInputWidget,
+  checkbox: BooleanInputWidget,
   url: primitiveWidgets.UrlInputWidget,
   slug: primitiveWidgets.SlugInputWidget,
-  flow: flowWidget.FlowWidget,
+  flow: FlowWidget,
   checkboxes: CheckboxesInputWidget,
   select: SelectInputWidget,
   'f-line': LineWidget,

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -6,7 +6,7 @@ import createReactClass from 'create-react-class'
 import primitiveWidgets from './widgets/primitiveWidgets'
 import multiWidgets from './widgets/multiWidgets'
 import flowWidget from './widgets/flowWidget'
-import fakeWidgets from './widgets/fakeWidgets'
+import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
 import { BasicWidgetMixin } from './widgets/mixins'
 import Component from './components/Component'
 import ToggleGroup from './components/ToggleGroup'
@@ -24,10 +24,10 @@ const widgetComponents = {
   flow: flowWidget.FlowWidget,
   checkboxes: multiWidgets.CheckboxesInputWidget,
   select: multiWidgets.SelectInputWidget,
-  'f-line': fakeWidgets.LineWidget,
-  'f-spacing': fakeWidgets.SpacingWidget,
-  'f-info': fakeWidgets.InfoWidget,
-  'f-heading': fakeWidgets.HeadingWidget
+  'f-line': LineWidget,
+  'f-spacing': SpacingWidget,
+  'f-info': InfoWidget,
+  'f-heading': HeadingWidget
 }
 
 const FallbackWidget = createReactClass({

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -2,12 +2,11 @@
 
 import PropTypes from 'prop-types'
 import React from 'react'
-import createReactClass from 'create-react-class'
 import primitiveWidgets from './widgets/primitiveWidgets'
 import multiWidgets from './widgets/multiWidgets'
 import flowWidget from './widgets/flowWidget'
 import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
-import { BasicWidgetMixin } from './widgets/mixins'
+import { widgetPropTypes } from './widgets/mixins'
 import Component from './components/Component'
 import ToggleGroup from './components/ToggleGroup'
 import i18n from './i18n'
@@ -30,21 +29,17 @@ const widgetComponents = {
   'f-heading': HeadingWidget
 }
 
-const FallbackWidget = createReactClass({
-  displayName: 'FallbackWidget',
-  mixins: [BasicWidgetMixin],
-
-  render () {
-    return (
-      <div>
-        <em>
-          Widget "{this.props.type.widget}" not implemented
-          (used by type "{this.props.type.name}")
-        </em>
-      </div>
-    )
-  }
-})
+function FallbackWidget (props) {
+  return (
+    <div>
+      <em>
+        Widget "{props.type.widget}" not implemented
+        (used by type "{props.type.name}")
+      </em>
+    </div>
+  )
+}
+FallbackWidget.propTypes = widgetPropTypes
 
 class FieldBox extends Component {
   render () {
@@ -196,6 +191,5 @@ export default {
   getFieldRows: getFieldRows,
   renderFieldRows: renderFieldRows,
   getFieldColumns: getFieldColumns,
-  FallbackWidget: FallbackWidget,
   FieldBox: FieldBox
 }

--- a/lektor/admin/static/js/widgets.jsx
+++ b/lektor/admin/static/js/widgets.jsx
@@ -7,7 +7,6 @@ import { CheckboxesInputWidget, SelectInputWidget } from './widgets/multiWidgets
 import { FlowWidget } from './widgets/flowWidget'
 import { LineWidget, SpacingWidget, InfoWidget, HeadingWidget } from './widgets/fakeWidgets'
 import { widgetPropTypes } from './widgets/mixins'
-import Component from './components/Component'
 import ToggleGroup from './components/ToggleGroup'
 import i18n from './i18n'
 
@@ -41,9 +40,10 @@ function FallbackWidget (props) {
 }
 FallbackWidget.propTypes = widgetPropTypes
 
-class FieldBox extends Component {
+class FieldBox extends React.PureComponent {
   render () {
-    const { field, value, onChange, placeholder, disabled } = this.props
+    const { field, value, placeholder, disabled } = this.props
+    const onChange = this.props.onChange ? this.props.onChange : (value) => this.props.setFieldValue(field, value)
     const className = 'col-md-' + getFieldColumns(field) + ' field-box'
     let innerClassName = 'field'
     let inner

--- a/lektor/admin/static/js/widgets/fakeWidgets.jsx
+++ b/lektor/admin/static/js/widgets/fakeWidgets.jsx
@@ -1,71 +1,39 @@
 'use strict'
 
-import PropTypes from 'prop-types'
+import { widgetPropTypes } from './mixins'
 import React from 'react'
-import createReactClass from 'create-react-class'
-import { BasicWidgetMixin } from './mixins'
 import i18n from '../i18n'
 
-const FakeWidgetMixin = {
-  mixins: [BasicWidgetMixin],
-  propTypes: {
-    field: PropTypes.any
-  },
-
-  statics: {
-    isFakeWidget: true
-  }
+export function LineWidget () {
+  return <hr />
 }
+LineWidget.isFakeWidget = true
+LineWidget.propTypes = widgetPropTypes
 
-const LineWidget = createReactClass({
-  displayName: 'LineWidget',
-  mixins: [FakeWidgetMixin],
-
-  render () {
-    return <hr />
-  }
-})
-
-const SpacingWidget = createReactClass({
-  displayName: 'SpacingWidget',
-  mixins: [FakeWidgetMixin],
-
-  render () {
-    return <div className='spacing' />
-  }
-})
-
-const InfoWidget = createReactClass({
-  displayName: 'InfoWidget',
-  mixins: [FakeWidgetMixin],
-
-  render () {
-    const label = i18n.trans(this.props.field.label_i18n)
-    return (
-      <div className='info'>
-        <p>
-          {label ? <strong>{label + ': '}</strong> : null}
-          {i18n.trans(this.props.field.description_i18n)}
-        </p>
-      </div>
-    )
-  }
-})
-
-const HeadingWidget = createReactClass({
-  displayName: 'HeadingWidget',
-  mixins: [FakeWidgetMixin],
-
-  render () {
-    return (
-      <h3>{i18n.trans(this.props.type.heading_i18n)}</h3>
-    )
-  }
-})
-
-export default {
-  LineWidget: LineWidget,
-  SpacingWidget: SpacingWidget,
-  InfoWidget: InfoWidget,
-  HeadingWidget: HeadingWidget
+export function SpacingWidget () {
+  return <div className='spacing' />
 }
+SpacingWidget.isFakeWidget = true
+SpacingWidget.propTypes = widgetPropTypes
+
+export function InfoWidget (props) {
+  const label = i18n.trans(props.field.label_i18n)
+  return (
+    <div className='info'>
+      <p>
+        {label ? <strong>{label + ': '}</strong> : null}
+        {i18n.trans(props.field.description_i18n)}
+      </p>
+    </div>
+  )
+}
+InfoWidget.isFakeWidget = true
+InfoWidget.propTypes = widgetPropTypes
+
+export function HeadingWidget (props) {
+  return (
+    <h3>{i18n.trans(props.type.heading_i18n)}</h3>
+  )
+}
+HeadingWidget.isFakeWidget = true
+HeadingWidget.propTypes = widgetPropTypes

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -3,10 +3,9 @@
 /* eslint-env browser */
 
 import React from 'react'
-import createReactClass from 'create-react-class'
 import i18n from '../i18n'
 import metaformat from '../metaformat'
-import { BasicWidgetMixin } from './mixins'
+import { widgetPropTypes } from './mixins'
 import userLabel from '../userLabel'
 import widgets from '../widgets'
 
@@ -129,36 +128,31 @@ const serializeFlowBlock = (flockBlockModel, data) => {
   return metaformat.serialize(rv)
 }
 
-const FlowWidget = createReactClass({
-  displayName: 'FlowWidget',
-  mixins: [BasicWidgetMixin],
+export class FlowWidget extends React.Component {
+  static deserializeValue (value, type) {
+    let blockId = 0
+    return parseFlowFormat(value).map((item) => {
+      const [id, lines] = item
+      const flowBlock = type.flowblocks[id]
+      if (flowBlock !== undefined) {
+        return deserializeFlowBlock(flowBlock, lines, ++blockId)
+      }
+      return null
+    })
+  }
 
-  statics: {
-    deserializeValue: (value, type) => {
-      let blockId = 0
-      return parseFlowFormat(value).map((item) => {
-        const [id, lines] = item
-        const flowBlock = type.flowblocks[id]
-        if (flowBlock !== undefined) {
-          return deserializeFlowBlock(flowBlock, lines, ++blockId)
-        }
-        return null
-      })
-    },
-
-    serializeValue: (value) => {
-      return serializeFlowFormat(value.map((item) => {
-        return [
-          item.flowBlockModel.id,
-          serializeFlowBlock(item.flowBlockModel, item.data)
-        ]
-      }))
-    }
-  },
+  static serializeValue (value) {
+    return serializeFlowFormat(value.map((item) => {
+      return [
+        item.flowBlockModel.id,
+        serializeFlowBlock(item.flowBlockModel, item.data)
+      ]
+    }))
+  }
 
   // XXX: the modification of props is questionable
 
-  moveBlock: function (idx, offset, event) {
+  moveBlock (idx, offset, event) {
     event.preventDefault()
 
     const newIndex = idx + offset
@@ -173,9 +167,9 @@ const FlowWidget = createReactClass({
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }
-  },
+  }
 
-  removeBlock: function (idx, event) {
+  removeBlock (idx, event) {
     event.preventDefault()
 
     if (confirm(i18n.trans('REMOVE_FLOWBLOCK_PROMPT'))) {
@@ -184,9 +178,9 @@ const FlowWidget = createReactClass({
         this.props.onChange(this.props.value)
       }
     }
-  },
+  }
 
-  addNewBlock: function (key, event) {
+  addNewBlock (key, event) {
     event.preventDefault()
 
     const flowBlockModel = this.props.type.flowblocks[key]
@@ -200,23 +194,23 @@ const FlowWidget = createReactClass({
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }
-  },
+  }
 
-  collapseBlock: function (idx) {
+  collapseBlock (idx) {
     this.props.value[idx].collapsed = true
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }
-  },
+  }
 
-  expandBlock: function (idx) {
+  expandBlock (idx) {
     this.props.value[idx].collapsed = false
     if (this.props.onChange) {
       this.props.onChange(this.props.value)
     }
-  },
+  }
 
-  renderFormField: function (blockInfo, field, idx) {
+  renderFormField (blockInfo, field, idx) {
     const widgets = getWidgets()
     const value = blockInfo.data[field.name]
     let placeholder = field.default
@@ -239,7 +233,7 @@ const FlowWidget = createReactClass({
         onChange={onChange}
       />
     )
-  },
+  }
 
   renderBlocks () {
     const widgets = getWidgets()
@@ -296,7 +290,7 @@ const FlowWidget = createReactClass({
         </div>
       )
     })
-  },
+  }
 
   renderAddBlockSection () {
     const choices = []
@@ -330,7 +324,7 @@ const FlowWidget = createReactClass({
         </div>
       </div>
     )
-  },
+  }
 
   render () {
     let { className } = this.props
@@ -343,8 +337,5 @@ const FlowWidget = createReactClass({
       </div>
     )
   }
-})
-
-export default {
-  FlowWidget: FlowWidget
 }
+FlowWidget.propTypes = widgetPropTypes

--- a/lektor/admin/static/js/widgets/flowWidget.jsx
+++ b/lektor/admin/static/js/widgets/flowWidget.jsx
@@ -150,8 +150,6 @@ export class FlowWidget extends React.Component {
     }))
   }
 
-  // XXX: the modification of props is questionable
-
   moveBlock (idx, offset, event) {
     event.preventDefault()
 
@@ -160,12 +158,12 @@ export class FlowWidget extends React.Component {
       return
     }
 
-    const tmp = this.props.value[newIndex]
-    this.props.value[newIndex] = this.props.value[idx]
-    this.props.value[idx] = tmp
+    const newValue = [...this.props.value]
+    newValue[newIndex] = this.props.value[idx]
+    newValue[idx] = this.props.value[newIndex]
 
     if (this.props.onChange) {
-      this.props.onChange(this.props.value)
+      this.props.onChange(newValue)
     }
   }
 
@@ -173,9 +171,8 @@ export class FlowWidget extends React.Component {
     event.preventDefault()
 
     if (confirm(i18n.trans('REMOVE_FLOWBLOCK_PROMPT'))) {
-      this.props.value.splice(idx, 1)
       if (this.props.onChange) {
-        this.props.onChange(this.props.value)
+        this.props.onChange(this.props.value.filter((item, i) => i !== idx))
       }
     }
   }
@@ -190,23 +187,28 @@ export class FlowWidget extends React.Component {
     const newBlockId = Math.max(...blockIds) + 1
 
     // this is a rather ugly way to do this, but hey, it works.
-    this.props.value.push(deserializeFlowBlock(flowBlockModel, [], newBlockId))
+    const newValue = [
+      ...this.props.value,
+      deserializeFlowBlock(flowBlockModel, [], newBlockId)
+    ]
     if (this.props.onChange) {
-      this.props.onChange(this.props.value)
+      this.props.onChange(newValue)
     }
   }
 
   collapseBlock (idx) {
-    this.props.value[idx].collapsed = true
+    const newValue = [...this.props.value]
+    newValue[idx] = { ...this.props.value[idx], collapsed: true }
     if (this.props.onChange) {
-      this.props.onChange(this.props.value)
+      this.props.onChange(newValue)
     }
   }
 
   expandBlock (idx) {
-    this.props.value[idx].collapsed = false
+    const newValue = [...this.props.value]
+    newValue[idx] = { ...this.props.value[idx], collapsed: false }
     if (this.props.onChange) {
-      this.props.onChange(this.props.value)
+      this.props.onChange(newValue)
     }
   }
 
@@ -221,7 +223,7 @@ export class FlowWidget extends React.Component {
 
     const onChange = !this.props.onChange ? null : (value) => {
       blockInfo.data[field.name] = value
-      this.props.onChange(this.props.value)
+      this.props.onChange([...this.props.value])
     }
 
     return (

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -6,13 +6,15 @@ function ValidationFailure (options) {
   this.type = options.type || 'error'
 }
 
+export const widgetPropTypes = {
+  value: PropTypes.any,
+  type: PropTypes.object,
+  placeholder: PropTypes.any,
+  onChange: PropTypes.func
+}
+
 const BasicWidgetMixin = {
-  propTypes: {
-    value: PropTypes.any,
-    type: PropTypes.object,
-    placeholder: PropTypes.any,
-    onChange: PropTypes.func
-  },
+  propTypes: widgetPropTypes,
 
   getInputClass () {
     let rv = 'form-control'

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -13,17 +13,21 @@ export const widgetPropTypes = {
   onChange: PropTypes.func
 }
 
+export function getInputClass (type) {
+  let rv = 'form-control'
+  if (type.size === 'small') {
+    rv = 'input-sm ' + rv
+  } else if (type.size === 'large') {
+    rv = 'input-lg ' + rv
+  }
+  return rv
+}
+
 const BasicWidgetMixin = {
   propTypes: widgetPropTypes,
 
   getInputClass () {
-    let rv = 'form-control'
-    if (this.props.type.size === 'small') {
-      rv = 'input-sm ' + rv
-    } else if (this.props.type.size === 'large') {
-      rv = 'input-lg ' + rv
-    }
-    return rv
+    return getInputClass(this.props.type)
   },
 
   getValidationFailure () {

--- a/lektor/admin/static/js/widgets/mixins.jsx
+++ b/lektor/admin/static/js/widgets/mixins.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import i18n from '../i18n'
 
-function ValidationFailure (options) {
+export function ValidationFailure (options) {
   this.message = options.message || i18n.trans('INVALID_INPUT')
   this.type = options.type || 'error'
 }
@@ -21,24 +21,4 @@ export function getInputClass (type) {
     rv = 'input-lg ' + rv
   }
   return rv
-}
-
-const BasicWidgetMixin = {
-  propTypes: widgetPropTypes,
-
-  getInputClass () {
-    return getInputClass(this.props.type)
-  },
-
-  getValidationFailure () {
-    if (this.getValidationFailureImpl) {
-      return this.getValidationFailureImpl()
-    }
-    return null
-  }
-}
-
-export {
-  ValidationFailure,
-  BasicWidgetMixin
 }

--- a/lektor/admin/static/js/widgets/multiWidgets.jsx
+++ b/lektor/admin/static/js/widgets/multiWidgets.jsx
@@ -1,126 +1,98 @@
 'use strict'
 
 import React from 'react'
-import createReactClass from 'create-react-class'
 import { flipSetValue } from '../utils'
 import i18n from '../i18n'
-import { BasicWidgetMixin } from './mixins'
+import { getInputClass, widgetPropTypes } from './mixins'
 
-const CheckboxesInputWidget = createReactClass({
-  displayName: 'CheckboxesInputWidget',
-  mixins: [BasicWidgetMixin],
-
-  statics: {
-    deserializeValue: (value) => {
-      if (value === '') {
-        return null
-      }
-      let rv = value.split(',').map((x) => {
-        return x.match(/^\s*(.*?)\s*$/)[1]
-      })
-      if (rv.length === 1 && rv[0] === '') {
-        rv = []
-      }
-      return rv
-    },
-
-    serializeValue: (value) => {
-      return (value || '').join(', ')
-    }
-  },
-
-  onChange: function (field, event) {
-    const newValue = flipSetValue(this.props.value,
-      field, event.target.checked)
-    if (this.props.onChange) {
-      this.props.onChange(newValue)
-    }
-  },
-
-  isActive: function (field) {
-    let value = this.props.value
-    if (value == null) {
-      value = this.props.placeholder
-      if (value == null) {
-        return false
-      }
-    }
-    for (const item of value) {
-      if (item === field) {
-        return true
-      }
-    }
-    return false
-  },
-
-  render () {
-    let { className, value, placeholder, type, ...otherProps } = this.props // eslint-disable-line no-unused-vars
-    className = (className || '') + ' checkbox'
-
-    const choices = this.props.type.choices.map((item) => {
-      return (
-        <div className={className} key={item[0]}>
-          <label>
-            <input
-              type='checkbox'
-              {...otherProps}
-              checked={this.isActive(item[0])}
-              onChange={this.onChange.bind(this, item[0])}
-            />
-            {i18n.trans(item[1])}
-          </label>
-        </div>
-      )
-    })
-    return (
-      <div className='checkboxes'>
-        {choices}
-      </div>
-    )
+function deserializeCheckboxValue (value) {
+  if (value === '') {
+    return null
   }
-})
-
-const SelectInputWidget = createReactClass({
-  displayName: 'SelectInputWidget',
-  mixins: [BasicWidgetMixin],
-
-  onChange (event) {
-    this.props.onChange(event.target.value)
-  },
-
-  render () {
-    let { className, type, value, placeholder, onChange, ...otherProps } = this.props // eslint-disable-line no-unused-vars
-    value = value || placeholder
-
-    const choices = this.props.type.choices.map((item) => {
-      return (
-        <option key={item[0]} value={item[0]}>
-          {i18n.trans(item[1])}
-        </option>
-      )
-    })
-    choices.unshift(
-      <option key='' value=''>----</option>
-    )
-
-    return (
-      <div className='form-group'>
-        <div className={className}>
-          <select
-            className={this.getInputClass()}
-            onChange={onChange ? this.onChange : null}
-            value={value}
-            {...otherProps}
-          >
-            {choices}
-          </select>
-        </div>
-      </div>
-    )
+  let rv = value.split(',').map((x) => {
+    return x.match(/^\s*(.*?)\s*$/)[1]
+  })
+  if (rv.length === 1 && rv[0] === '') {
+    rv = []
   }
-})
-
-export default {
-  CheckboxesInputWidget: CheckboxesInputWidget,
-  SelectInputWidget: SelectInputWidget
+  return rv
 }
+
+function serializeCheckboxValue (value) {
+  return (value || '').join(', ')
+}
+
+function checkboxIsActive (field, props) {
+  let value = props.value
+  if (value == null) {
+    value = props.placeholder
+    if (value == null) {
+      return false
+    }
+  }
+  for (const item of value) {
+    if (item === field) {
+      return true
+    }
+  }
+  return false
+}
+
+export function CheckboxesInputWidget (props) {
+  let { className, value, placeholder, type, onChange, ...otherProps } = props
+  className = (className || '') + ' checkbox'
+
+  function onChangeHandler (field, event) {
+    const newValue = flipSetValue(props.value, field, event.target.checked)
+    onChange(newValue)
+  }
+
+  const choices = type.choices.map((item) => (
+    <div className={className} key={item[0]}>
+      <label>
+        <input
+          type='checkbox'
+          {...otherProps}
+          checked={checkboxIsActive(item[0], props)}
+          onChange={(e) => onChangeHandler(item[0], e)}
+        />
+        {i18n.trans(item[1])}
+      </label>
+    </div>
+  ))
+  return (
+    <div className='checkboxes'>
+      {choices}
+    </div>
+  )
+}
+CheckboxesInputWidget.propTypes = widgetPropTypes
+CheckboxesInputWidget.deserializeValue = deserializeCheckboxValue
+CheckboxesInputWidget.serializeValue = serializeCheckboxValue
+
+export function SelectInputWidget (props) {
+  const { className, type, value, placeholder, onChange, ...otherProps } = props
+
+  const choices = type.choices.map((item) => (
+    <option key={item[0]} value={item[0]}>
+      {i18n.trans(item[1])}
+    </option>
+  ))
+
+  return (
+    <div className='form-group'>
+      <div className={className}>
+        <select
+          className={getInputClass(type)}
+          value={value || placeholder || ''}
+          onChange={(e) => onChange(e.target.value)}
+          {...otherProps}
+        >
+          <option key='' value=''>----</option>
+          {choices}
+        </select>
+      </div>
+    </div>
+  )
+}
+SelectInputWidget.propTypes = widgetPropTypes

--- a/lektor/admin/static/js/widgets/multiWidgets.jsx
+++ b/lektor/admin/static/js/widgets/multiWidgets.jsx
@@ -5,23 +5,6 @@ import { flipSetValue } from '../utils'
 import i18n from '../i18n'
 import { getInputClass, widgetPropTypes } from './mixins'
 
-function deserializeCheckboxValue (value) {
-  if (value === '') {
-    return null
-  }
-  let rv = value.split(',').map((x) => {
-    return x.match(/^\s*(.*?)\s*$/)[1]
-  })
-  if (rv.length === 1 && rv[0] === '') {
-    rv = []
-  }
-  return rv
-}
-
-function serializeCheckboxValue (value) {
-  return (value || '').join(', ')
-}
-
 function checkboxIsActive (field, props) {
   let value = props.value
   if (value == null) {
@@ -38,37 +21,54 @@ function checkboxIsActive (field, props) {
   return false
 }
 
-export function CheckboxesInputWidget (props) {
-  let { className, value, placeholder, type, onChange, ...otherProps } = props
-  className = (className || '') + ' checkbox'
-
-  function onChangeHandler (field, event) {
-    const newValue = flipSetValue(props.value, field, event.target.checked)
-    onChange(newValue)
+export class CheckboxesInputWidget extends React.PureComponent {
+  static serializeValue (value) {
+    return (value || '').join(', ')
   }
 
-  const choices = type.choices.map((item) => (
-    <div className={className} key={item[0]}>
-      <label>
-        <input
-          type='checkbox'
-          {...otherProps}
-          checked={checkboxIsActive(item[0], props)}
-          onChange={(e) => onChangeHandler(item[0], e)}
-        />
-        {i18n.trans(item[1])}
-      </label>
-    </div>
-  ))
-  return (
-    <div className='checkboxes'>
-      {choices}
-    </div>
-  )
+  static deserializeValue (value) {
+    if (value === '') {
+      return null
+    }
+    let rv = value.split(',').map((x) => {
+      return x.match(/^\s*(.*?)\s*$/)[1]
+    })
+    if (rv.length === 1 && rv[0] === '') {
+      rv = []
+    }
+    return rv
+  }
+
+  render () {
+    let { className, value, placeholder, type, onChange, ...otherProps } = this.props
+    className = (className || '') + ' checkbox'
+
+    function onChangeHandler (field, event) {
+      const newValue = flipSetValue(this.props.value, field, event.target.checked)
+      onChange(newValue)
+    }
+
+    const choices = type.choices.map((item) => (
+      <div className={className} key={item[0]}>
+        <label>
+          <input
+            type='checkbox'
+            {...otherProps}
+            checked={checkboxIsActive(item[0], this.props)}
+            onChange={(e) => onChangeHandler(item[0], e)}
+          />
+          {i18n.trans(item[1])}
+        </label>
+      </div>
+    ))
+    return (
+      <div className='checkboxes'>
+        {choices}
+      </div>
+    )
+  }
 }
 CheckboxesInputWidget.propTypes = widgetPropTypes
-CheckboxesInputWidget.deserializeValue = deserializeCheckboxValue
-CheckboxesInputWidget.serializeValue = serializeCheckboxValue
 
 export function SelectInputWidget (props) {
   const { className, type, value, placeholder, onChange, ...otherProps } = props

--- a/lektor/admin/static/js/widgets/primitiveWidgets.jsx
+++ b/lektor/admin/static/js/widgets/primitiveWidgets.jsx
@@ -1,7 +1,6 @@
 'use strict'
 
 import React from 'react'
-import jQuery from 'jquery'
 import { ValidationFailure, getInputClass, widgetPropTypes } from './mixins'
 import { isValidUrl } from '../utils'
 import userLabel from '../userLabel'
@@ -174,6 +173,11 @@ export function UrlInputWidget (props) {
 UrlInputWidget.propTypes = widgetPropTypes
 
 export class MultiLineTextInputWidget extends React.Component {
+  constructor (props) {
+    super(props)
+    this.recalculateSize = this.recalculateSize.bind(this)
+  }
+
   onChange (event) {
     this.recalculateSize()
     if (this.props.onChange) {
@@ -183,11 +187,11 @@ export class MultiLineTextInputWidget extends React.Component {
 
   componentDidMount () {
     this.recalculateSize()
-    window.addEventListener('resize', this.recalculateSize.bind(this))
+    window.addEventListener('resize', this.recalculateSize)
   }
 
   componentWillUnmount () {
-    window.removeEventListener('resize', this.recalculateSize.bind(this))
+    window.removeEventListener('resize', this.recalculateSize)
   }
 
   componentDidUpdate (prevProps) {
@@ -221,10 +225,10 @@ export class MultiLineTextInputWidget extends React.Component {
       diff = 0
     }
 
-    const updateScrollPosition = jQuery(node).is(':focus')
+    const updateScrollPosition = node === document.activeElement
     // Cross-browser compatibility for scroll position
     const oldScrollTop = document.documentElement.scrollTop || document.body.scrollTop
-    const oldHeight = jQuery(node).outerHeight()
+    const oldHeight = node.offsetHeight
 
     node.style.height = 'auto'
     const newHeight = (node.scrollHeight - diff)
@@ -252,7 +256,7 @@ export class MultiLineTextInputWidget extends React.Component {
         <textarea
           ref='ta'
           className={getInputClass(type)}
-          onChange={onChange ? this.onChange.bind(this) : undefined}
+          onChange={this.onChange.bind(this)}
           style={style}
           {...otherProps}
         />

--- a/lektor/admin/static/webpack.config.js
+++ b/lektor/admin/static/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = {
       'bootstrap',
       'react',
       'react-dom',
-      'react-addons-update',
       'react-router-dom'
     ]
   },


### PR DESCRIPTION



### Related Issues / Links

Ref #746, #449 
<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

This is based on #746 

The first few commits (after the ones from #746) remove the remaining use of mixins (https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html). This allows us to get rid of the `create-react-class` dependency.

The last commit removes another deprecated dependency (`react-addon-update`) and provides a performance enhancement by avoiding unnecessary rerenders on the edit page: Before, every typed character would cause all the inputs on the page to be rerendered, now only the edited one is.

Additionally, these refactorings turned up some unused code that I deleted.