### PR TITLE
Bug in Pagination.iter_pages()

### DIFF
--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -86,10 +86,10 @@ class Pagination(object):
                range is specified by the ``left_edge`` argument (which
                may be zero).
 
-            2. A range around the current page.  This range will include
-               ``left_edge`` pages before the current page, and
-               ``right_edge`` pages after the current page.  This
-               range always includes the current page.
+            2. A range around the current page.  This range will
+               include ``left_current`` pages before the current page,
+               and ``right_current`` pages after the current page.
+               This range always includes the current page.
 
             3. Finally, a range (always ending at the last page) at
                the end of the page sequence.  The length of this range

--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -77,9 +77,28 @@ class Pagination(object):
 
     def iter_pages(self, left_edge=2, left_current=2,
                    right_current=5, right_edge=2):
-        """Iterates over the page numbers in the pagination.  The four
-        parameters control the thresholds how many numbers should be produced
-        from the sides.  Skipped page numbers are represented as `None`.
+        """Iterate over the page numbers in the pagination, with elision.
+
+        In the general case, this returns the concatenation of three ranges:
+
+            1. A range (always starting at page one) at the beginning
+               of the page number sequence.  The length of the this
+               range is specified by the ``left_edge`` argument (which
+               may be zero).
+
+            2. A range around the current page.  This range will include
+               ``left_edge`` pages before the current page, and
+               ``right_edge`` pages after the current page.  This
+               range always includes the current page.
+
+            3. Finally, a range (always ending at the last page) at
+               the end of the page sequence.  The length of this range
+               is specified by the ``right_edge`` argument.
+
+        If any of these ranges overlap, they will be merged.  A
+        ``None`` will be inserted between non-overlapping ranges to
+        signify that pages have been elided.
+
         This is how you could render such a pagination in the templates:
         .. sourcecode:: html+jinja
             {% macro render_pagination(pagination, endpoint) %}
@@ -97,6 +116,7 @@ class Pagination(object):
               {%- endfor %}
               </div>
             {% endmacro %}
+
         """
         last = 0
         for num in range_type(1, self.pages + 1):

--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -102,10 +102,12 @@ class Pagination(object):
         for num in range_type(1, self.pages + 1):
             # pylint: disable=chained-comparison
             if num <= left_edge or \
-               (num > self.page - left_current - 1 and
-                num < self.page + right_current) or \
+               (num >= self.page - left_current and
+                num <= self.page + right_current) or \
                num > self.pages - right_edge:
                 if last + 1 != num:
                     yield None
                 yield num
                 last = num
+        if last != self.pages:
+            yield None

--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -87,9 +87,9 @@ class Pagination(object):
                may be zero).
 
             2. A range around the current page.  This range will
-               include ``left_current`` pages before the current page,
-               and ``right_current`` pages after the current page.
-               This range always includes the current page.
+               include ``left_current`` pages before, and
+               ``right_current`` pages after the current page.  This
+               range always includes the current page.
 
             3. Finally, a range (always ending at the last page) at
                the end of the page sequence.  The length of this range


### PR DESCRIPTION


### Issue(s) Resolved

As is, [`Pagination.iter_pages()`][1] does not work correctly.

Assuming that I understand correctly how `iter_pages` is supposed to work, there are two issues with the current implementation:

1. There is an off-by-one error in the interpretation of the `right_current` argument.  As things stand now, if one wants to include one page on either side of the current page in the page list, then one must set `left_current=1`, but `right_current=2`.  (Setting `right_current=1` will result in no pages being listed to the right of the current page.  Setting `right_current=0` can result in the current page not even being listed.)

2. If one sets `right_edge=0` to prevent the listing of any pages at the end of the page range,  the current implementation does not include a trailing `None` (to represent the elided pages) in the resulting page list.  (It should do so when the "current" page range does not include the final page.)

[1]: <https://github.com/lektor/lektor/blob/04509f83319472e883e5b04ab7c530263743e343/lektor/pagination.py#L78>


### Description of Changes

This pull request first introduces some unit tests for `iter_pages`.  (It seems to be totally untested in the current test suite.)  Many of these tests fail.

The second commit in this pull request fixes the bugs in `iter_pages`.

### Discussion

This does change the behavior of `iter_pages`, and so may affect any sites which currently use it.  Worst case, though, it will result in one extra page button in the pager.
