### PR TITLE
Bump jinja2 to avoid incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'Flask',
         'functools32;python_version<"3.2.3"',
         'inifile',
-        'Jinja2>=2.4',
+        'Jinja2>=2.11',
         'mistune>=0.7.0,<2',
         'pip',
         'requests[security]',


### PR DESCRIPTION
Lektor is not actually fully compatibile with jinja down to v2.4, as currently specified in the setup.py. Bumping the minimum version to 2.8 (released sufficiently long ago IMO, https://github.com/pallets/jinja/releases/tag/2.8) fixes the following traceback when building https://github.com/lektor/lektor-website.

```
E docs/project/index.html (UndefinedError: Missing value in field 'sort_key': Missing sort key)
Finished build in 5.67 sec
Traceback (most recent call last):
  File "/home/joe/miniconda3/envs/lektor/bin/lektor", line 11, in <module>
    load_entry_point('Lektor', 'console_scripts', 'lektor')()
  File "/home/joe/wrkspc/lktr/lektor/lektor/cli.py", line 632, in main
    cli.main(args=args, prog_name=name)
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/joe/wrkspc/lktr/lektor/lektor/cli.py", line 241, in build_cmd
    success = _build()
  File "/home/joe/wrkspc/lktr/lektor/lektor/cli.py", line 234, in _build
    failures = builder.build_all()
  File "/home/joe/wrkspc/lktr/lektor/lektor/builder.py", line 1142, in build_all
    self.extend_build_queue(to_build, prog)
  File "/home/joe/wrkspc/lktr/lektor/lektor/builder.py", line 1124, in extend_build_queue
    queue.extend(prog.iter_child_sources())
  File "/home/joe/wrkspc/lktr/lektor/lektor/db.py", line 1151, in __iter__
    iterable, key=lambda x: x.get_sort_key(order_by))
  File "/home/joe/wrkspc/lktr/lektor/lektor/db.py", line 145, in __lt__
    return a < b
  File "/home/joe/miniconda3/envs/lektor/lib/python2.7/site-packages/jinja2/runtime.py", line 485, in _fail_with_undefined_error
    raise self._undefined_exception(hint)
jinja2.exceptions.UndefinedError: Missing value in field 'sort_key': Missing sort key
```