### PR TITLE
Load loopcontrols and debug jinja extensions

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -428,9 +428,9 @@ class Environment(object):
 
         self.jinja_env = CustomJinjaEnvironment(
             autoescape=self.select_jinja_autoescape,
-            extensions=['jinja2.ext.autoescape',
-                        'jinja2.ext.with_',
-                        'jinja2.ext.do'],
+            extensions=['jinja2.ext.debug',
+                        'jinja2.ext.do',
+                        'jinja2.ext.loopcontrols'],
             loader=jinja2.FileSystemLoader(
                 template_paths)
         )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,6 +1,6 @@
 def test_jinja2_extensions(env):
     extensions = env.jinja_env.extensions
 
-    assert 'jinja2.ext.AutoEscapeExtension' in extensions.keys()
-    assert 'jinja2.ext.WithExtension' in extensions.keys()
+    assert 'jinja2.ext.DebugExtension' in extensions.keys()
     assert 'jinja2.ext.ExprStmtExtension' in extensions.keys()
+    assert 'jinja2.ext.LoopControlExtension' in extensions.keys()


### PR DESCRIPTION
This loads all available jinja extensions, adding the 3 of the 6 built-in jinja extensions that were previously excluded: i18n, loopcontrols, and debug. https://jinja.palletsprojects.com/en/2.11.x/extensions/

Rather than hardcoding them, this method will pick up however many are available. This will keep up with any additions, infrequent thought they may be, and pick up any that plugins potentially add. Writing it this way provides a little future-proofing.