### PR TITLE
Added function to check errors in publisher outputs #677

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -654,8 +654,8 @@ class GithubPagesPublisher(Publisher):
     def _check_error(line):
         """
         Check that line does not contain a git error keyword.
-        Check if a line (string) is interpreted as an error using a list of error related words. If it is interpreted
-        as an error, an exception is raised.
+        Check if a line (string) is interpreted as an error using a list of error related words.
+        If it is interpreted as an error, an exception is raised.
         :param line: String. Line to evaluate. Ie, 'error: src refspec gh-pages does not match any'
         """
         error_substrings = ['fatal:', 'error:']

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,31 @@
+import pytest
+from lektor.publisher import GithubPagesPublisher, PublishError
+
+@pytest.mark.parametrize(
+    "test_lines_raises",
+    [
+        'fatal:',
+        'Fatal:',
+        'Error:',
+        'error:',
+        'fatal: couldn\'t find remote ref refs/heads/gh-pages',
+        'Fatal: couldn\'t find remote ref refs/heads/gh-pages',
+        'error: Could not fetch origin',
+        'Error: Could not fetch origin',
+        'error: src refspec gh-pages does not match any',
+        'Error: src refspec gh-pages does not match any'
+    ],
+)
+def test_github_pages_publisher_check_error_raises(test_lines_raises):
+    with pytest.raises(PublishError):
+        GithubPagesPublisher._check_error(test_lines_raises)
+
+def test_github_pages_publisher_check_error_passes():
+    test_lines_raises = [
+        'Initial commit',
+        'nothing to commit',
+        'On branch gh-pages'
+    ]
+    for test_line in test_lines_raises:
+        print(test_line)
+        GithubPagesPublisher._check_error(test_line)


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #677

### Description of Changes


<!--- Explain what you've done and why --->
_The list of outputs in deploy are strings without error handling and the deployment is always successful (Done!)_

Added a function to check if a line (string) is interpreted as an error using a list of error related words. If it is interpreted as an error, an exception is raised and the error is displayed (Finishing the execution of the deployment)

<img width="1440" alt="Screen Shot 2020-05-17 at 9 54 47 AM" src="https://user-images.githubusercontent.com/14989202/82152061-7658d800-9824-11ea-8f2b-2172eda05d6c.png">



<!--- Thanks for your help making Lektor better for everyone! --->
