### PR TITLE
Uniform handling of deferred (descriptor) model data

### DIFF
--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -341,8 +341,7 @@ class DataModel:
                 self._child_slug_tmpl[1].evaluate(pad, this=data).strip().split()
             ).strip("/")
         except Exception as exc:
-            reporter.report_generic(
-                "Failed to expand child slug_format: %s" % exc)
+            reporter.report_generic("Failed to expand child slug_format: %s" % exc)
             return "temp-" + slugify(data["_id"])
 
     def get_default_template_name(self):

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -10,6 +10,7 @@ from lektor.environment.expressions import FormatExpression
 from lektor.i18n import generate_i18n_kvs
 from lektor.i18n import get_i18n_block
 from lektor.pagination import Pagination
+from lektor.reporter import reporter
 from lektor.types import builtin_types
 from lektor.types.base import RawValue
 from lektor.utils import bool_from_string
@@ -339,8 +340,9 @@ class DataModel:
             return "_".join(
                 self._child_slug_tmpl[1].evaluate(pad, this=data).strip().split()
             ).strip("/")
-        except Exception:
-            # XXX: log
+        except Exception as exc:
+            reporter.report_generic(
+                "Failed to expand child slug_format: %s" % exc)
             return "temp-" + slugify(data["_id"])
 
     def get_default_template_name(self):

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1295,9 +1295,9 @@ def get_default_slug(record, type_=None):
     is computed by expanding the parent’s ``slug_format`` value.
 
     """
-    parent = getattr(record, 'parent', None)
+    parent = getattr(record, "parent", None)
     if parent is None:
-        return ''
+        return ""
     return parent.datamodel.get_default_child_slug(record.pad, record)
 
 

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
 import errno
 import functools

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1283,6 +1283,22 @@ def _iter_datamodel_choices(datamodel_name, path, is_attachment=False):
     yield "none"
 
 
+def get_default_slug(record, type_=None):
+    """Compute the default slug for a page.
+
+    This computes the default value of ``_slug`` for a page.  The slug
+    is computed by expanding the parent’s ``slug_format`` value.
+
+    """
+    parent = getattr(record, 'parent', None)
+    if parent is None:
+        return ''
+    return parent.datamodel.get_default_child_slug(record.pad, record)
+
+
+default_slug_descriptor = property(get_default_slug)
+
+
 class Database:
     def __init__(self, env, config=None):
         self.env = env
@@ -1502,21 +1518,10 @@ class Database:
                         ctx.record_dependency(dep_model.filename)
         return record
 
-    def get_default_slug(self, data, pad):
-        parent_path = posixpath.dirname(data["_path"])
-        parent = None
-        if parent_path != data["_path"]:
-            parent = pad.get(parent_path)
-        if parent:
-            slug = parent.datamodel.get_default_child_slug(pad, data)
-        else:
-            slug = ""
-        return slug
-
     def process_data(self, data, datamodel, pad):
         # Automatically fill in slugs
         if not data["_slug"]:
-            data["_slug"] = self.get_default_slug(data, pad)
+            data["_slug"] = default_slug_descriptor
         else:
             data["_slug"] = data["_slug"].strip("/")
 

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -452,7 +452,11 @@ class Record(SourceObject):
             else:
                 field = field.lstrip("+")
                 reverse = False
-            rv[idx] = _CmpHelper(self._data.get(field), reverse)
+            try:
+                value = self[field]
+            except KeyError:
+                value = None
+            rv[idx] = _CmpHelper(value, reverse)
         return rv
 
     def __contains__(self, name):

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1288,7 +1288,7 @@ def _iter_datamodel_choices(datamodel_name, path, is_attachment=False):
     yield "none"
 
 
-def get_default_slug(record, type_=None):
+def get_default_slug(record):
     """Compute the default slug for a page.
 
     This computes the default value of ``_slug`` for a page.  The slug

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import re
+
+import pytest
+
+from lektor.datamodel import (
+    ChildConfig,
+    DataModel,
+    )
+from lektor.reporter import BufferReporter
+
+
+class TestDataModel(object):
+    @pytest.fixture
+    def slug_format(self):
+        return None
+
+    @pytest.fixture
+    def datamodel(self, env, slug_format):
+        id_ = 'test'
+        name_i18n = {'en': 'test'}
+        child_config = ChildConfig(slug_format=slug_format)
+        return DataModel(env, id_, name_i18n, child_config=child_config)
+
+    @pytest.mark.parametrize("slug_format, expected_slug", [
+        (None, 'child-id'),
+        ("fmt-{{ this._id }}", 'fmt-child-id'),
+        ("{{ unknown.attr }}", 'temp-child-id'),
+        ])
+    def test_get_default_child_slug(self, datamodel, pad, expected_slug):
+        data = {
+            '_id': 'child-id',
+            }
+        assert datamodel.get_default_child_slug(pad, data) == expected_slug
+
+    @pytest.mark.parametrize("slug_format", ["{{ unknown.attr }}"])
+    def test_get_default_child_slug_reports_failure(self, datamodel, pad):
+        data = {'_id': 'id'}
+        with BufferReporter(pad.env) as reporter:
+            assert datamodel.get_default_child_slug(pad, data) == 'temp-id'
+        _, event_data = reporter.buffer[-1]
+        message = event_data['message']
+        assert re.search(r'failed to expand\b.*\bslug_format\b', message,
+                         re.I)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -3,42 +3,42 @@ import re
 
 import pytest
 
-from lektor.datamodel import (
-    ChildConfig,
-    DataModel,
-    )
+from lektor.datamodel import ChildConfig
+from lektor.datamodel import DataModel
 from lektor.reporter import BufferReporter
 
 
-class TestDataModel(object):
+class TestDataModel:
     @pytest.fixture
     def slug_format(self):
         return None
 
     @pytest.fixture
     def datamodel(self, env, slug_format):
-        id_ = 'test'
-        name_i18n = {'en': 'test'}
+        id_ = "test"
+        name_i18n = {"en": "test"}
         child_config = ChildConfig(slug_format=slug_format)
         return DataModel(env, id_, name_i18n, child_config=child_config)
 
-    @pytest.mark.parametrize("slug_format, expected_slug", [
-        (None, 'child-id'),
-        ("fmt-{{ this._id }}", 'fmt-child-id'),
-        ("{{ unknown.attr }}", 'temp-child-id'),
-        ])
+    @pytest.mark.parametrize(
+        "slug_format, expected_slug",
+        [
+            (None, "child-id"),
+            ("fmt-{{ this._id }}", "fmt-child-id"),
+            ("{{ unknown.attr }}", "temp-child-id"),
+        ],
+    )
     def test_get_default_child_slug(self, datamodel, pad, expected_slug):
         data = {
-            '_id': 'child-id',
-            }
+            "_id": "child-id",
+        }
         assert datamodel.get_default_child_slug(pad, data) == expected_slug
 
     @pytest.mark.parametrize("slug_format", ["{{ unknown.attr }}"])
     def test_get_default_child_slug_reports_failure(self, datamodel, pad):
-        data = {'_id': 'id'}
+        data = {"_id": "id"}
         with BufferReporter(pad.env) as reporter:
-            assert datamodel.get_default_child_slug(pad, data) == 'temp-id'
+            assert datamodel.get_default_child_slug(pad, data) == "temp-id"
         _, event_data = reporter.buffer[-1]
-        message = event_data['message']
-        assert re.search(r'failed to expand\b.*\bslug_format\b', message,
-                         re.I)
+        message = event_data["message"]
+        assert re.search(r"failed to expand\b.*\bslug_format\b", message, re.I)


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

**TLDR**; Lektor provides a mechanism whereby the computation of model field values can be deferred until such time as the values are accessed (e.g. via template expansion).  (The built-in `markdown` type makes use of this feature, as do a number of  plugin-provided extension types.)  Currently, there are a couple of places where reference to such a deferred field value will not work — worse yet, in these cases, failure is silent and, thus, confusing.  This pull request aims to fix things so that deferred field values will work as expected in those cases.

#### Background

Lektor provides a mechanism whereby the computation of certain values of page model data can be deferred until template-evaluation time.  (For example, the compilation of markdown text within a field of type `markdown` does not happen until template-evaluation time.)  (This late-evaluation happens in [Record.__getitem__](https://github.com/lektor/lektor/blob/16413178e3fe1cec15806611f154ebc4abe80c58/lektor/db.py#L457), where, if field value appears to be a *descriptor*, its `.__get__` method is called to compute the final value.)

Normally, these deferred values are transparently computed when they are accessed, either programmatically (e.g. `page['body']`) or within a Jinja template expression (e.g. `{{ this.body }}`), so for the most part, these deferred types “just work”.

There are a couple of code paths in the current code base which access the raw model data directly, rather than accessing it through `Record.__getitem__`.  In these cases, deferred values do not work.  Worse yet, currently, no warning or error messages are generated when this happens, so the failures are hard for the user to diagnose.

Fortunately, both of these cases are fairly straightforward to fix.  This pull request does that.

#### Problematic code-paths

There are, however, a couple of code-paths where access to model data does not currently go through `Record.__getitem__`.  Attempts to access deferred values in those code-paths will fail (usually in a subtle way, without generating any sort of explicit error or warning message.)

Two code-paths where this happens are:
* The computation of the default slug for a child page, based on the parents [slug_format](https://www.getlektor.com/docs/models/children/#child-slug-behavior).
* In [Record.get_sort_key](https://github.com/lektor/lektor/blob/16413178e3fe1cec15806611f154ebc4abe80c58/lektor/db.py#L446).

There are other places where the raw model data is accessed directly without going through `Record.__getitem__`, but in those cases, specific system fields (e.g. `_model` or  `_hidden`) are being accessed.  I do not believe these system fields ever contain deferred values, so directly accessing them does/should not cause issues.

##### Default slug computation

The computation of the default value for a page’s `_slug` happens in [Database.get_default_slug](https://github.com/lektor/lektor/blob/16413178e3fe1cec15806611f154ebc4abe80c58/lektor/db.py#L1472).

For example, suppose we would like to create URLs for blog posts that contain the year of publication.   Setting `slug_format` to

```html+jinja
{{ "{0.year:04d}/{1}".format(this.pub_date, this._id) }}
```

in the datamodel for the blog parent page will do this.

This currently fails, however, in cases where `pub_date` is a deferred value. This might happen when using the [lektor-git-timestamp](https://github.com/dairiki/lektor-git-timestamp) plugin which can be used to auto-compute `pub_date` from the git commit timestamps. Currently, when the `slug_format` value is jinja-evaluated, `this` is set not to a `Page` instance, but rather to a dict containing the raw page data. `This.pub_date` in this context is the deferred descriptor, not the actual desired value. Currently this will result in [silent failure](https://github.com/lektor/lektor/blob/16413178e3fe1cec15806611f154ebc4abe80c58/lektor/datamodel.py#L336) of the expansion of `slug_format`.

This can be fixed by deferring the computation of the default `_slug` value until after the `Page` instance is fully constructed.

##### Record.get_sort_key

In [Record.get_sort_key](https://github.com/lektor/lektor/blob/16413178e3fe1cec15806611f154ebc4abe80c58/lektor/db.py#L446), the sort key value is fetched directly from the raw model data,\
rather than through `Record.__getitem__`.

As a result, if attempts are made to sort blog posts by, e.g., `pub_date`, and pub_date is a deferred value as described above, this will cause problems.

This can be fixed, simply by using `Record.__getitem__` to access the sort field’s value.


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


* [X] Wrote at least one-line docstrings (for any new functions)
* [X] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

* Modified `Database.process_data` to defer computation of the default `_slug`.  This solves the issue with `slug_format`s which access deferred model data.
* Modified `Record.sort_key` to access model field values using `Record.__getitem__` rather than accessing the raw model data (`this._data`) directly.  This fixes the issue with using deferred fields as sort keys.
* Added a diagnostic message to indicate when expansion of `slug_format` fails (instead of silently using the fall-back slug when there is an error in the `slug_format`.)



<!--- Thanks for your help making Lektor better for everyone! --->
