### PR TITLE
Implement slug styles (name TBD)

### DIFF
--- a/lektor/environment.py
+++ b/lektor/environment.py
@@ -398,6 +398,13 @@ class Config(object):
             return style
         return 'relative'
 
+    @cached_property
+    def default_slug_style(self):
+        """The default strategy for converting slugs into URLs."""
+        style = self.values['PROJECT'].get('default_slug_style')
+        if style in ('auto', 'always_file', 'always_dir', 'leaf_html'):
+            return style
+        return 'auto'
 
 def lookup_from_bag(*args):
     pieces = '.'.join(x for x in args if x)


### PR DESCRIPTION
Slug styles specify how slugs are turned into file and directory names
in the URL path. This is roughly based off the design in
https://github.com/lektor/lektor/issues/809#issuecomment-687136459.

As is, this PR fixes #344 and deals with the tricky "global" part of
doing #809 properly. It also enables pages with dots in their slugs to
be paginated and fixes some issues with the dev server resolving
descendants of such pages incorrectly. It is still a prototype, though
(I have only done some casual manual testing and yet to write any
tests or documentation; wanted to get the overall design reviewed first).

In addition to a sitewide default setting and per-page setting, we would
likely also want datamodels to be able to specify the slug style of
their pages and/or their child pages. To stay similar to the current way
`slug_format` can be configured, it seems we should also allow
datamodels to specify the slug styles of their children, but as
mentioend in #806 that behavior is a little strange and worth
reconsidering, so this PR doesn't try to implement any such behavior.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

Fixes #344

### Related Issues / Links

#809, #806

### Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
