### PR TITLE
lint: fix code smells pointed out by pylint

### DIFF
--- a/lektor/build_programs.py
+++ b/lektor/build_programs.py
@@ -173,11 +173,11 @@ class PageBuildProgram(BuildProgram):
     def build_artifact(self, artifact):
         try:
             self.source.url_path.encode('ascii')
-        except UnicodeError:
+        except UnicodeError as error:
             raise BuildError('The URL for this record contains non ASCII '
                              'characters.  This is currently not supported '
                              'for portability reasons (%r).' %
-                             self.source.url_path)
+                             self.source.url_path) from error
 
         artifact.render_template_into(
             self.source['_template'], this=self.source)

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -312,8 +312,8 @@ class _RecordQueryProxy(object):
     def __getitem__(self, name):
         try:
             return self.__getattr__(name)
-        except AttributeError:
-            raise KeyError(name)
+        except AttributeError as error:
+            raise KeyError(name) from error
 
 
 F = _RecordQueryProxy()

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -39,8 +39,8 @@ class ThumbnailMode(IntEnum):
         name = label.upper().replace('-', '_')
         try:
             return cls.__members__[name] # pylint: disable=no-member
-        except KeyError:
-            raise ValueError("Invalid thumbnail mode '%s'." % label)
+        except KeyError as error:
+            raise ValueError("Invalid thumbnail mode '%s'." % label) from error
 
 # set the default. do it outside the class to not confuse things
 ThumbnailMode.DEFAULT = ThumbnailMode.FIT

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -21,8 +21,8 @@ def get_plugin(plugin_id_or_class, env=None):
                                             plugin_id_or_class)
     try:
         return env.plugins[plugin_id]
-    except KeyError:
-        raise LookupError('Plugin %r not found' % plugin_id)
+    except KeyError as error:
+        raise LookupError('Plugin %r not found' % plugin_id) from error
 
 
 class Plugin(object):

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -427,7 +427,7 @@ class FtpTlsConnection(FtpConnection):
         return FTP_TLS()
 
     def connect(self):
-        connected = super(FtpTlsConnection, self).connect()
+        connected = super().connect()
         if connected:
             # Upgrade data connection to TLS.
             self.con.prot_p()  # pylint: disable=no-member


### PR DESCRIPTION
On four occasions, this meant using `raise ... from ...`, which improves
tracebacks - otherwise, they'd look like there was some problem in the
exception handling code.

Also use `super()` without arguments in one place.

This is blocked by #818 since these two fixes produce invalid Python 2 code.