### PR TITLE
offset with _limit None throws TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1185,7 +1185,9 @@ class Query(object):
 
         if self._offset is not None or self._limit is not None:
             iterable = islice(
-                iterable, self._offset or 0, (self._offset or 0) + self._limit
+                iterable,
+                self._offset or 0,
+                (self._offset or 0) + self._limit if self._limit else None,
             )
 
         for item in iterable:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -305,3 +305,10 @@ def test_default_order_by(scratch_project, scratch_env):
     assert list(children.get_order_by()) == ["title"]
     assert list(children.order_by("explicit").get_order_by()) == ["explicit"]
     assert list(myobj.attachments.get_order_by()) == ["attachment_filename"]
+
+def test_offset_without_limit_query(pad):
+    projects = pad.get("/projects")
+
+    x = projects.children.offset(1).order_by("_slug").first()
+
+    assert x["name"]  == "Coffee"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -306,9 +306,10 @@ def test_default_order_by(scratch_project, scratch_env):
     assert list(children.order_by("explicit").get_order_by()) == ["explicit"]
     assert list(myobj.attachments.get_order_by()) == ["attachment_filename"]
 
+
 def test_offset_without_limit_query(pad):
     projects = pad.get("/projects")
 
     x = projects.children.offset(1).order_by("_slug").first()
 
-    assert x["name"]  == "Coffee"
+    assert x["name"] == "Coffee"


### PR DESCRIPTION

### Description of Changes

```python
pad.children.query('/projects').offset(1).first()
```
will throw a TypeError. This pull request fixes that (test supplied).

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


