### PR TITLE
Bugfix: allow for local rsync deployment

### DIFF
--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -235,8 +235,10 @@ class RsyncPublisher(Publisher):
         if username:
             target.append(username + "@")
 
-        target.append(target_url.ascii_host)
-        target.append(":" + target_url.path.rstrip("/") + "/")
+        if target_url.ascii_host is not None:
+            target.append(target_url.ascii_host)
+            target.append(":")
+        target.append(target_url.path.rstrip("/") + "/")
 
         argline.append(self.output_path.rstrip("/\\") + "/")
         argline.append("".join(target))

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -324,3 +324,22 @@ def test_rsync_command_delete_no(tmpdir, mocker, env):
             "example.com:/",
         ],
     )
+
+
+def test_rsync_local(tmpdir, mocker, env):
+    output_path = tmpdir.mkdir("output")
+    publisher = RsyncPublisher(env, str(output_path))
+    target_url = url_parse("file:///path/to/directory")
+    ssh_path = tmpdir.mkdir("ssh")
+    mock_popen = mocker.patch("lektor.publisher.portable_popen")
+    publisher.get_command(target_url, str(ssh_path), credentials=None)
+    assert mock_popen.called
+    assert mock_popen.call_args[0] == (
+        [
+            "rsync",
+            "-rclzv",
+            "--exclude=.lektor",
+            str(output_path) + "/",
+            "/path/to/directory/",
+        ],
+    )


### PR DESCRIPTION
### Issue(s) Resolved

rsync deployment fails with `TypeError: sequence item 0: expected str instance, NoneType found`
for the following deployment:

```ini
[servers.production]
target = rsync:///home/me/static
```

### Description of Changes

Added defensive test for the existence of `ascii_host` parameter

Test added.


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


