### PR TITLE
Revert "temporary workaround for problems with GH actions macos images"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,9 +308,6 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install system dependencies
         run: |
-          # Temporary workaround for https://github.com/actions/virtual-environments/issues/1811
-          brew untap local/homebrew-openssl
-          brew untap local/homebrew-python2
           brew update
           brew install imagemagick
           brew install ffmpeg


### PR DESCRIPTION
This reverts commit 1e141315a56ab632275c7df60fbc6da8e2447299.
 
The new GH actions image should have been deployed and this should be fixed now.