### PR TITLE
fix handling of encoded admin URL

### DIFF
--- a/lektor/admin/static/js/components/RecordComponent.jsx
+++ b/lektor/admin/static/js/components/RecordComponent.jsx
@@ -7,7 +7,7 @@ export function getRecordPathAndAlt (path) {
   if (!path) {
     return [null, null]
   }
-  const items = path.split(/\+/, 2)
+  const items = decodeURIComponent(path).split(/\+/, 2)
   return [urlToFsPath(items[0]), items[1]]
 }
 

--- a/lektor/admin/static/js/components/RecordComponent.test.js
+++ b/lektor/admin/static/js/components/RecordComponent.test.js
@@ -8,5 +8,6 @@ describe('Get Record paths', () => {
     deepStrictEqual(getRecordPathAndAlt('root:about'), ['/about', undefined])
     deepStrictEqual(getRecordPathAndAlt('root+fr'), ['', 'fr'])
     deepStrictEqual(getRecordPathAndAlt('root:blog+fr'), ['/blog', 'fr'])
+    deepStrictEqual(getRecordPathAndAlt('root:blog%2Bfr'), ['/blog', 'fr'])
   })
 })


### PR DESCRIPTION
Maybe react-router changed behaviour at some point, decoding the URL
before splitting it into path and alt does the trick.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #815 


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->




<!--- Thanks for your help making Lektor better for everyone! --->
