### PR TITLE
correctly update preview page

### DIFF
--- a/lektor/admin/static/js/views/PreviewPage.jsx
+++ b/lektor/admin/static/js/views/PreviewPage.jsx
@@ -22,8 +22,11 @@ class PreviewPage extends RecordComponent {
     this.syncState();
   }
 
-  shouldComponentUpdate() {
-    return this.getUrlRecordPathWithAlt() !== this.state.pageUrlFor;
+  shouldComponentUpdate(nextProps) {
+    return (
+      this.getUrlRecordPathWithAlt() !== this.state.pageUrlFor ||
+      nextProps.match.params.path !== this.props.match.params.path
+    );
   }
 
   syncState() {


### PR DESCRIPTION
This logic has always been a bit faulty and probably broke recently due
to us avoiding unnecessary re-renders. In addition to checking whether
the correct URL is loaded, we heed to check if the URL that we want to
load changed.

Fix #844