### PR TITLE
ci: do not brew update on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,6 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install system dependencies
         run: |
-          brew update
           brew install imagemagick
           brew install ffmpeg
       - name: Install python dependencies


### PR DESCRIPTION
Saves some time, the image should be updated regularly anyway and this
seems to lead to broken builds every now and then
