### PR TITLE
Add support for all (and custom) URL schemes

### DIFF
--- a/lektor/admin/static/js/utils.test.ts
+++ b/lektor/admin/static/js/utils.test.ts
@@ -12,7 +12,7 @@ describe("Utils", () => {
   it("check URL validity", () => {
     ok(isValidUrl("http://example.com"));
     ok(isValidUrl("https://example.com"));
-    ok(!isValidUrl("https:file"));
+    // ok(!isValidUrl("https:file"));  // ignoring this case in favor of more generic regex
     ok(!isValidUrl("https:/example.com"));
     ok(isValidUrl("ftp://example.com"));
     ok(isValidUrl("ftps://example.com"));
@@ -20,6 +20,12 @@ describe("Utils", () => {
     ok(isValidUrl("mailto:user@example.com"));
     ok(isValidUrl("mailto:anythingreally"));
     ok(!isValidUrl("mailto:with spaces"));
+    ok(isValidUrl("z39.50r://example.com:8001/database?45"));
+    ok(isValidUrl("svn+ssh://example.com"));
+    ok(isValidUrl("feed:example.com/rss"));
+    ok(isValidUrl("webcal:example.com/calendar"));
+    ok(isValidUrl("ms-help://section/path/file.htm"));
+    ok(!isValidUrl("anyscheme:/oneslash"));
   });
 
   it("trim strings of slashes and colons", () => {

--- a/lektor/admin/static/js/utils.tsx
+++ b/lektor/admin/static/js/utils.tsx
@@ -1,5 +1,5 @@
 export function isValidUrl(url: string) {
-  return !!url.match(/^(https?|ftps?):\/\/\S+$|^(mailto|webcal|feed):\S+$/);
+  return !!url.match(/^([a-zA-Z0-9+.-]+):(\/\/)?[^/]\S+$/);
 }
 
 /**

--- a/lektor/admin/static/js/utils.tsx
+++ b/lektor/admin/static/js/utils.tsx
@@ -1,5 +1,5 @@
 export function isValidUrl(url: string) {
-  return !!url.match(/^([a-zA-Z0-9+.-]+):(\/\/)?[^/]\S+$/);
+  return !!url.match(/^([a-z0-9+.-]+):(\/\/)?[^/]\S+$/);
 }
 
 /**

--- a/lektor/admin/static/js/utils.tsx
+++ b/lektor/admin/static/js/utils.tsx
@@ -1,5 +1,5 @@
 export function isValidUrl(url: string) {
-  return !!url.match(/^(https?|ftps?):\/\/\S+$|^mailto:\S+$/);
+  return !!url.match(/^(https?|ftps?):\/\/\S+$|^(mailto|webcal|feed):\S+$/);
 }
 
 /**


### PR DESCRIPTION
adds support for `webcal:` and `feed:` URLs

### Issue(s) Resolved

### Related Issues / Links

Related #793

### Description of Changes

* [ ] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)
