### PR TITLE
sticky position for save button

### DIFF
--- a/lektor/admin/static/less/main.less
+++ b/lektor/admin/static/less/main.less
@@ -476,6 +476,9 @@ div.actions {
   border-radius: @panel-radius;
   padding: 10px;
   margin: 15px 0;
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
 
   > * {
     margin-right: 5px;


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #43

### Description of Changes

This uses `position: sticky` for the "actions" `<div>` containing the save button, so that it is always shown. This also applies on other admin pages if they contain too much content to show without scrolling.