### PR TITLE
Reexport types for compatibility

### DIFF
--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -15,6 +15,11 @@ from lektor.context import get_locale
 from lektor.context import site_proxy
 from lektor.context import url_to
 from lektor.environment.config import Config
+from lektor.environment.config import DEFAULT_CONFIG  # noqa - reexport
+from lektor.environment.config import ServerInfo  # noqa - reexport
+from lektor.environment.config import update_config_from_ini  # noqa - reexport
+from lektor.environment.expressions import Expression  # noqa - reexport
+from lektor.environment.expressions import FormatExpression  # noqa - reexport
 from lektor.markdown import Markdown
 from lektor.packages import load_packages
 from lektor.pluginsystem import initialize_plugins

--- a/lektor/types/__init__.py
+++ b/lektor/types/__init__.py
@@ -1,3 +1,7 @@
+from lektor.types.base import BadValue  # noqa - reexport
+from lektor.types.base import get_undefined_info  # noqa - reexport
+from lektor.types.base import RawValue  # noqa - reexport
+from lektor.types.base import Type  # noqa - reexport
 from lektor.types.fake import HeadingType
 from lektor.types.fake import InfoType
 from lektor.types.fake import LineType


### PR DESCRIPTION
As noted in https://github.com/lektor/lektor/pull/871#issuecomment-774532318, I moved things around a bit too hastily - other packages might depend on some of the objects that got moved around in #871. This PR adds "reexports" for all the types that got moved around.