### PR TITLE
Ctrl+e/Meta+e keyboard shortcuts for the edit page.

### DIFF
--- a/lektor/admin/static/js/components/LinkWithHotkey.tsx
+++ b/lektor/admin/static/js/components/LinkWithHotkey.tsx
@@ -1,0 +1,55 @@
+import React, { MutableRefObject, ReactNode, useEffect, useRef } from "react";
+import { NavLink } from "react-router-dom";
+import { getKey, KeyboardShortcut, keyboardShortcutHandler } from "../utils";
+
+/**
+ * React hook to add a global keyboard shortcut for the given
+ * key for the lifetime of the component.
+ */
+function useKeyboardShortcut(
+  key: KeyboardShortcut,
+  action: (ev: KeyboardEvent) => void
+): void {
+  useEffect(() => {
+    const handler = keyboardShortcutHandler(key, action);
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+}
+
+/**
+ * Add a global keyboard shortcut for the given key and simulate
+ * a click on the ref'ed element.
+ */
+function useKeyboardShortcutRef<T extends HTMLElement>(
+  key: KeyboardShortcut
+): MutableRefObject<T | null> {
+  const el = useRef<T | null>(null);
+  useKeyboardShortcut(key, () => {
+    el.current?.click();
+  });
+  return el;
+}
+
+export default function LinkWithHotkey(props: {
+  to: string;
+  children: ReactNode;
+  shortcut: KeyboardShortcut;
+}) {
+  let path = props.to;
+  if (path.substr(0, 1) !== "/") {
+    path = `${$LEKTOR_CONFIG.admin_root}/${path}`;
+  }
+  const el = useKeyboardShortcutRef<HTMLAnchorElement>(props.shortcut);
+
+  return (
+    <NavLink
+      to={path}
+      activeClassName="active"
+      title={getKey(props.shortcut)}
+      ref={el}
+    >
+      {props.children}
+    </NavLink>
+  );
+}

--- a/lektor/admin/static/js/header/GlobalActions.tsx
+++ b/lektor/admin/static/js/header/GlobalActions.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { RecordProps } from "../components/RecordComponent";
-import { isMetaKey, getCanonicalUrl } from "../utils";
+import { getCanonicalUrl, keyboardShortcutHandler } from "../utils";
 import { loadData } from "../fetch";
 import { trans } from "../i18n";
 import dialogSystem from "../dialogSystem";
@@ -21,13 +21,10 @@ function showPublishDialog() {
   dialogSystem.showDialog(Publish);
 }
 
-function onKeyPress(event: KeyboardEvent) {
-  // Command+g/Ctrl+g to open the find files dialog.
-  if (event.key === "g" && isMetaKey(event)) {
-    event.preventDefault();
-    dialogSystem.showDialog(FindFiles);
-  }
-}
+const onKeyPress = keyboardShortcutHandler(
+  { key: "Control+g", mac: "Meta+g", preventDefault: true },
+  () => dialogSystem.showDialog(FindFiles)
+);
 
 class GlobalActions extends Component<RecordProps, unknown> {
   constructor(props: RecordProps) {

--- a/lektor/admin/static/js/sidebar/AttachmentActions.tsx
+++ b/lektor/admin/static/js/sidebar/AttachmentActions.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import React, { memo } from "react";
 import {
   getUrlRecordPathWithAlt,
   RecordProps,
@@ -7,36 +7,34 @@ import Link from "../components/Link";
 import { RecordInfo } from "../components/types";
 import { trans } from "../i18n";
 
-type Props = RecordProps & { recordInfo: RecordInfo };
-
-export default class AttachmentActions extends PureComponent<Props, unknown> {
-  render() {
-    const attachments = this.props.recordInfo.attachments;
-    return (
-      <div className="section">
-        <h3>{trans("ATTACHMENTS")}</h3>
-        <ul className="nav record-attachments">
-          {attachments.length > 0 ? (
-            attachments.map((atch) => {
-              const urlPath = getUrlRecordPathWithAlt(
-                atch.path,
-                this.props.record.alt
-              );
-              return (
-                <li key={atch.id}>
-                  <Link to={`${urlPath}/edit`}>
-                    {atch.id} ({atch.type})
-                  </Link>
-                </li>
-              );
-            })
-          ) : (
-            <li key="_missing">
-              <em>{trans("NO_ATTACHMENTS")}</em>
-            </li>
-          )}
-        </ul>
-      </div>
-    );
-  }
+function AttachmentActions({
+  recordInfo,
+  record,
+}: RecordProps & { recordInfo: RecordInfo }) {
+  const attachments = recordInfo.attachments;
+  return (
+    <div className="section">
+      <h3>{trans("ATTACHMENTS")}</h3>
+      <ul className="nav record-attachments">
+        {attachments.length > 0 ? (
+          attachments.map((atch) => {
+            const urlPath = getUrlRecordPathWithAlt(atch.path, record.alt);
+            return (
+              <li key={atch.id}>
+                <Link to={`${urlPath}/edit`}>
+                  {atch.id} ({atch.type})
+                </Link>
+              </li>
+            );
+          })
+        ) : (
+          <li key="_missing">
+            <em>{trans("NO_ATTACHMENTS")}</em>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
 }
+
+export default memo(AttachmentActions);

--- a/lektor/admin/static/js/sidebar/PageActions.tsx
+++ b/lektor/admin/static/js/sidebar/PageActions.tsx
@@ -9,6 +9,7 @@ import { trans } from "../i18n";
 import { getPlatform } from "../utils";
 import { loadData } from "../fetch";
 import { bringUpDialog } from "../richPromise";
+import LinkWithHotkey from "../components/LinkWithHotkey";
 
 const getBrowseButtonTitle = () => {
   const platform = getPlatform();
@@ -44,6 +45,8 @@ function BrowseFSLink({ record }: Pick<RecordProps, "record">) {
   );
 }
 
+const editKey = { key: "Control+e", mac: "Meta+e", preventDefault: true };
+
 function PageActions({
   record,
   recordInfo,
@@ -59,9 +62,9 @@ function PageActions({
       </h3>
       <ul className="nav">
         <li key="edit">
-          <Link to={`${urlPath}/edit`}>
+          <LinkWithHotkey to={`${urlPath}/edit`} shortcut={editKey}>
             {recordInfo.is_attachment ? trans("EDIT_METADATA") : trans("EDIT")}
-          </Link>
+          </LinkWithHotkey>
         </li>
         {recordInfo.can_be_deleted && (
           <li key="delete">

--- a/lektor/admin/static/js/utils.tsx
+++ b/lektor/admin/static/js/utils.tsx
@@ -70,12 +70,15 @@ export interface KeyboardShortcut {
   preventDefault?: boolean;
 }
 
+export function getKey(shortcut: KeyboardShortcut): string {
+  return getPlatform() === "mac" && shortcut.mac ? shortcut.mac : shortcut.key;
+}
+
 export function keyboardShortcutHandler(
   shortcut: KeyboardShortcut,
   action: (ev: KeyboardEvent) => void
 ): (ev: KeyboardEvent) => void {
-  const key =
-    getPlatform() === "mac" && shortcut.mac ? shortcut.mac : shortcut.key;
+  const key = getKey(shortcut);
   return (ev) => {
     let eventKey = ev.key;
     if (ev.altKey) {

--- a/lektor/admin/static/js/utils.tsx
+++ b/lektor/admin/static/js/utils.tsx
@@ -64,15 +64,36 @@ export function getPlatform() {
   return "other";
 }
 
-/**
- * Whether the meta key (command on Mac, Ctrl otherwise) and no other control
- * keys is pressed.
- * @param event - A keyboard event.
- */
-export function isMetaKey(event: KeyboardEvent) {
-  return getPlatform() === "mac"
-    ? event.metaKey && !event.altKey && !event.shiftKey
-    : event.ctrlKey && !event.altKey && !event.shiftKey;
+export interface KeyboardShortcut {
+  key: string;
+  mac?: string;
+  preventDefault?: boolean;
+}
+
+export function keyboardShortcutHandler(
+  shortcut: KeyboardShortcut,
+  action: (ev: KeyboardEvent) => void
+): (ev: KeyboardEvent) => void {
+  const key =
+    getPlatform() === "mac" && shortcut.mac ? shortcut.mac : shortcut.key;
+  return (ev) => {
+    let eventKey = ev.key;
+    if (ev.altKey) {
+      eventKey = `Alt+${eventKey}`;
+    }
+    if (ev.ctrlKey) {
+      eventKey = `Control+${eventKey}`;
+    }
+    if (ev.metaKey) {
+      eventKey = `Meta+${eventKey}`;
+    }
+    if (eventKey === key) {
+      if (shortcut.preventDefault) {
+        ev.preventDefault();
+      }
+      action(ev);
+    }
+  };
 }
 
 export function getParentFsPath(fsPath: string) {

--- a/lektor/admin/static/js/views/EditPage.tsx
+++ b/lektor/admin/static/js/views/EditPage.tsx
@@ -6,7 +6,7 @@ import {
   pathToAdminPage,
   RecordProps,
 } from "../components/RecordComponent";
-import { isMetaKey } from "../utils";
+import { keyboardShortcutHandler } from "../utils";
 import { loadData } from "../fetch";
 import { trans, Translatable, trans_fallback, trans_format } from "../i18n";
 import {
@@ -96,6 +96,8 @@ function getPlaceholderForField(
 class EditPage extends Component<RecordProps, State> {
   form: RefObject<HTMLFormElement>;
 
+  onKeyPress: (ev: KeyboardEvent) => void;
+
   constructor(props: RecordProps) {
     super(props);
 
@@ -106,8 +108,15 @@ class EditPage extends Component<RecordProps, State> {
       hasPendingChanges: false,
     };
     this.form = createRef();
+    this.onKeyPress = keyboardShortcutHandler(
+      { key: "Control+s", mac: "Meta+s", preventDefault: true },
+      () => {
+        if (this.form.current?.reportValidity()) {
+          this.saveChanges();
+        }
+      }
+    );
 
-    this.onKeyPress = this.onKeyPress.bind(this);
     this.setFieldValue = this.setFieldValue.bind(this);
     this.saveChanges = this.saveChanges.bind(this);
     this.renderFormField = this.renderFormField.bind(this);
@@ -127,17 +136,6 @@ class EditPage extends Component<RecordProps, State> {
 
   componentWillUnmount() {
     window.removeEventListener("keydown", this.onKeyPress);
-  }
-
-  onKeyPress(event: KeyboardEvent) {
-    // Command+s/Ctrl+s to save
-    if (event.key === "s" && isMetaKey(event)) {
-      event.preventDefault();
-      const form = this.form.current;
-      if (form && form.reportValidity()) {
-        this.saveChanges();
-      }
-    }
   }
 
   syncEditor() {


### PR DESCRIPTION
There's already a couple of keyboard shortcuts, and having one to switch between the edit page seems useful. Control+e seems to be a rather unproblematic choice. This PR supersedes #579 to implement this.

In the process I've refactored the current code to handle keyboard shortcuts to make it easier to implement more in the future. I ended up adding a new component for an `<a>` that should be associated with a keyboard shortcut, so the refactorings to change two components from classes to function components are somewhat unrelated since no use of hooks in them was actually needed.