### PR TITLE
Fix exception message to make it a bit more helpful.

### DIFF
--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -115,9 +115,10 @@ def load_plugins():
         match_name = "lektor-" + ep.name.lower()
         if match_name != ep.dist.project_name.lower():
             raise RuntimeError(
-                "Mismatching entry point name.  Found "
-                '"%s" but expected "%s" for package "%s".'
-                % (ep.name, ep.dist.project_name[7:], ep.dist.project_name)
+                "Disallowed distribution name: distribution name for "
+                "plugin {ep.name!r} must be {match_name!r}.".format(
+                    ep=ep, match_name=match_name
+                )
             )
         rv[ep.name] = ep.load()
     return rv

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -116,9 +116,7 @@ def load_plugins():
         if match_name != ep.dist.project_name.lower():
             raise RuntimeError(
                 "Disallowed distribution name: distribution name for "
-                "plugin {ep.name!r} must be {match_name!r}.".format(
-                    ep=ep, match_name=match_name
-                )
+                f"plugin {ep.name!r} must be {match_name!r}."
             )
         rv[ep.name] = ep.load()
     return rv


### PR DESCRIPTION
This fixes the exception message emitted when a Lektor plugin is detected from a distribution with a non-conforming name.

See lektor/lektor#875 for further discussion.

### Issue(s) Resolved

The current message is incorrect and non-elucidating in many cases.

Fixes #875

### Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

