### PR TITLE
require Python 3.6 and remove Python 3.5 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.5', '3.6', '3.7']
+        PYTHON_VERSION: ['3.6', '3.7']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.5', '3.9']
+        PYTHON_VERSION: ['3.6', '3.9']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -294,7 +294,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.5', '3.9']
+        PYTHON_VERSION: ['3.6', '3.9']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms="any",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
         "Babel",
         "click>=6.0",
@@ -59,7 +59,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Ref #878 

That we'd drop Python 3.5 has already been announced with the release of Lektor 3.2, so this PR removes it from the CI matrix and adds the requirement for 3.6.

[I saw that 3.5 compat caused some extra work in #877 so I think it's time to make this change]
