### PR TITLE
Fix reference cycle in Environment

### DIFF
--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -260,7 +260,8 @@ class Environment:
         )
         return values
 
-    def select_jinja_autoescape(self, filename):
+    @staticmethod
+    def select_jinja_autoescape(filename):
         if filename is None:
             return False
         return filename.endswith((".html", ".htm", ".xml", ".xhtml"))

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,6 +1,16 @@
+import sys
+
+
 def test_jinja2_extensions(env):
     extensions = env.jinja_env.extensions
 
     assert "jinja2.ext.AutoEscapeExtension" in extensions.keys()
     assert "jinja2.ext.WithExtension" in extensions.keys()
     assert "jinja2.ext.ExprStmtExtension" in extensions.keys()
+
+
+def test_no_reference_cycle_in_environment(project):
+    env = project.make_env(load_plugins=False)
+    # reference count should be two: one from our `env` variable, and
+    # another from the argument to sys.getrefcount
+    assert sys.getrefcount(env) == 2


### PR DESCRIPTION
There is a reference cycle in instances of `Environment` which prevents them from being quickly garbage collected.

Fixing it is probably not of high importance, since the garbage collector will eventually find discarded instances.
In this case, however, the fix is easy, and since other parts of the Lektor code appear to go to some trouble to
hold weakrefs to the environment instances, I figure it might as well be fixed.

The reference cycle is as follows:  In [`Environment.__init__`](https://github.com/lektor/lektor/blob/25ba7c7df2646078ae6667781e51444ee305bf8e/lektor/environment/__init__.py#L121), the bound method `self.select_jinja_autoescape` is passed to the constructor for `CustomJinjaEnvironment`.  Bound methods hold a reference to the object they are bound to. The resulting jinja environment is saved in `self.jinja_env`, completing the cycle.

There appears to be no reason that `Environment.select_jinja_autoescape` can not be made a static method.  Making it so fixes the cycle.

* [x] Added unit test(s) covering the changes (if testable)
