### PR TITLE
Thumbnailing: only issue implicit upscale warning when actually upscaling

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -822,7 +822,7 @@ class Image(Attachment):
         if mode is None:
             mode = ThumbnailMode.DEFAULT
         else:
-            mode = ThumbnailMode.from_label(mode)
+            mode = ThumbnailMode(mode)
 
         if width is not None:
             width = int(width)
@@ -946,7 +946,7 @@ class VideoFrame:
         if mode is None:
             mode = ThumbnailMode.DEFAULT
         else:
-            mode = ThumbnailMode.from_label(mode)
+            mode = ThumbnailMode(mode)
 
         video = self.video
         return make_video_thumbnail(

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -564,8 +564,8 @@ def make_image_thumbnail(
     # this needs to change to an exception in the future.
     if mode != ThumbnailMode.FIT and (width is None or height is None):
         warnings.warn(
-            '"%s" mode requires both `width` and `height` to be defined. '
-            'Falling back to "fit" mode.`' % mode.value
+            f'"{mode.value}" mode requires both `width` and `height` '
+            'to be specified. Falling back to "fit" mode.'
         )
         mode = ThumbnailMode.FIT
 

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -582,12 +582,16 @@ def make_image_thumbnail(
     if format == "svg":
         return Thumbnail(source_url_path, width, height)
 
-    if height is None:
-        upscaling_requested = width > source_width
-    elif width is None:
-        upscaling_requested = height > source_height
+    if mode == ThumbnailMode.FIT:
+        computed_width, computed_height = compute_dimensions(
+            width, height, source_width, source_height
+        )
     else:
-        upscaling_requested = width > source_width and height > source_height
+        computed_width, computed_height = width, height
+
+    upscaling_requested = (
+        computed_width > source_width or computed_height > source_height
+    )
 
     # this part needs to be removed once backward-compatibility period passes
     if upscale is None and upscaling_requested:
@@ -601,13 +605,6 @@ def make_image_thumbnail(
 
     if upscaling_requested and not upscale:
         return Thumbnail(source_url_path, source_width, source_height)
-
-    if mode == ThumbnailMode.FIT:
-        computed_width, computed_height = compute_dimensions(
-            width, height, source_width, source_height
-        )
-    else:
-        computed_width, computed_height = width, height
 
     suffix = get_suffix(width, height, mode, quality=quality)
     dst_url_path = get_dependent_url(

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -6,7 +6,7 @@ import re
 import struct
 import warnings
 from datetime import datetime
-from enum import IntEnum
+from enum import Enum
 from xml.etree import ElementTree as etree
 
 import exifread
@@ -22,30 +22,32 @@ from lektor.utils import portable_popen
 datetime.strptime("", "")
 
 
-class ThumbnailMode(IntEnum):
-    FIT, CROP, STRETCH = range(1, 4)
+class ThumbnailMode(Enum):
+    FIT = "fit"
+    CROP = "crop"
+    STRETCH = "stretch"
+
+    DEFAULT = "fit"
 
     @property
     def label(self):
         """The mode's label as used in templates."""
-        # our constants are uppercase with underscores,
-        # while template uses lowercase and dashes.
-        return self.name.lower().replace("_", "-")  # pylint: disable=no-member
+        warnings.warn(
+            "ThumbnailMode.label is deprecated. (Use ThumbnailMode.value instead.)",
+            DeprecationWarning,
+        )
+        return self.value
 
     @classmethod
     def from_label(cls, label):
-        """
-        Looks up the thumbnail mode by its textual representation.
-        """
-        name = label.upper().replace("-", "_")
-        try:
-            return cls.__members__[name]  # pylint: disable=unsubscriptable-object
-        except KeyError as error:
-            raise ValueError("Invalid thumbnail mode '%s'." % label) from error
-
-
-# set the default. do it outside the class to not confuse things
-ThumbnailMode.DEFAULT = ThumbnailMode.FIT
+        """Looks up the thumbnail mode by its textual representation."""
+        warnings.warn(
+            "ThumbnailMode.from_label is deprecated. "
+            "Use the ThumbnailMode constructor, "
+            'e.g. "ThumbnailMode(label)", instead.',
+            DeprecationWarning,
+        )
+        return cls(label)
 
 
 def _convert_gps(coords, hem):
@@ -299,7 +301,7 @@ def get_suffix(width, height, mode, quality=None):
     if height is not None:
         suffix += "x%s" % height
     if mode != ThumbnailMode.DEFAULT:
-        suffix += "_%s" % mode.label
+        suffix += "_%s" % mode.value
     if quality is not None:
         suffix += "_q%s" % quality
     return suffix
@@ -563,7 +565,7 @@ def make_image_thumbnail(
     if mode != ThumbnailMode.FIT and (width is None or height is None):
         warnings.warn(
             '"%s" mode requires both `width` and `height` to be defined. '
-            'Falling back to "fit" mode.`' % mode.label
+            'Falling back to "fit" mode.`' % mode.value
         )
         mode = ThumbnailMode.FIT
 

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -61,7 +61,7 @@ def _combine_make(make, model):
     model = model or ""
     if make and model.startswith(make):
         return make
-    return u" ".join([make, model]).strip()
+    return " ".join([make, model]).strip()
 
 
 _parse_svg_units_re = re.compile(
@@ -171,7 +171,7 @@ class EXIFInfo:
 
     @property
     def f(self):
-        return u"ƒ/%s" % self.f_num
+        return "ƒ/%s" % self.f_num
 
     @property
     def exposure_time(self):
@@ -190,14 +190,14 @@ class EXIFInfo:
     def focal_length(self):
         val = self._get_float("EXIF FocalLength")
         if val is not None:
-            return u"%smm" % val
+            return "%smm" % val
         return None
 
     @property
     def focal_length_35mm(self):
         val = self._get_float("EXIF FocalLengthIn35mmFilm")
         if val is not None:
-            return u"%dmm" % val
+            return "%dmm" % val
         return None
 
     @property

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -591,12 +591,10 @@ def make_image_thumbnail(
     else:
         computed_width, computed_height = width, height
 
-    upscaling_requested = (
-        computed_width > source_width or computed_height > source_height
-    )
+    would_upscale = computed_width > source_width or computed_height > source_height
 
     # this part needs to be removed once backward-compatibility period passes
-    if upscale is None and upscaling_requested:
+    if would_upscale and upscale is None:
         warnings.warn(
             "Your image is being scaled up since the requested thumbnail "
             "size is larger than the source. This default will change "
@@ -605,7 +603,7 @@ def make_image_thumbnail(
         )
         upscale = True
 
-    if upscaling_requested and not upscale:
+    if would_upscale and not upscale:
         return Thumbnail(source_url_path, source_width, source_height)
 
     suffix = get_suffix(width, height, mode, quality=quality)

--- a/lektor/videotools.py
+++ b/lektor/videotools.py
@@ -214,7 +214,7 @@ def get_suffix(seek, width, height, mode, quality):
         suffix += "_%s" % "x".join(str(x) for x in [width, height] if x is not None)
 
     if mode != ThumbnailMode.DEFAULT:
-        suffix += "_%s" % mode.label
+        suffix += "_%s" % mode.value
 
     if quality is not None:
         suffix += "_q%s" % quality
@@ -290,7 +290,7 @@ def make_video_thumbnail(
 ):
     if mode != ThumbnailMode.FIT and (width is None or height is None):
         msg = '"%s" mode requires both `width` and `height` to be defined.'
-        raise ValueError(msg % mode.label)
+        raise ValueError(msg % mode.value)
 
     if upscale is None:
         upscale = {

--- a/tests/demo-project/templates/page.html
+++ b/tests/demo-project/templates/page.html
@@ -24,7 +24,7 @@
     <img src="{{ ts|url }}" width="{{ ts.width }}" height="{{ ts.height }}">
 
     {# larger than original#}
-    {% set t0 = img.thumbnail(400, 600) %}
+    {% set t0 = img.thumbnail(400, 600, upscale=True) %}
     <img alt="original" src="{{ t0|url }}" width="{{ t0.width }}" height="{{ t0.height }}">
   {% endfor %}
 


### PR DESCRIPTION
Issue the implicit upscaling warning only when actually upscaling.

### Issue(s) Resolved

Currently, whenever "fit"-mode thumbnails are created without specifying an explicit value for the `upscale` argument, a warning is issued. ("Your images are currently scaled up when the thumbnail requested is larger than the source. This default will change in the future. If you want to preserve the current behaviour, use `upscale=True`.")

I think this warning should only be issued when the user is actually requesting an upscaled thumbnail.

Consider the case where the user requests a thumbnail that is smaller than the original (e.g. `image.thumbnail(48)`, where `image.width` is, say, 256).  This currently works just like it always did — it generates a 48px wide thumbnail.  Even when the default becomes `upscale=False`, it will still work just like it always did.  There's no need for the warning since the behavior is not going to change.

The only case the change to default `upscale=False` will affect anything is where the user was upscaling to begin with, so that's the case where the warning is necessary.

Unnecessary warnings clutter the build output and make it too easy to ignore the "real" warnings.

### Description of Changes

This PR fixes things so that that warning is only issued when the user is, in fact, upscaling.

While I was munging things, I cleaned-up a few other things, too.

- Fixed what I think is a bug in the logic for detecting when the image is being upscaled.  (The [current logic][] thinks that the image is being upscaled if *both* the requested width *and* the requested height are greater than the source dimensions, but upscaling will happen in at least one dimension — in any of the three modes — if *either* the requested width *or* the requested height exceeds the source dimension.)
- Converted the implementation of `ThumbnailMode` from `IntEnum` to `Enum`. Converting to a string-valued enum makes the `value` and `from_value` methods superfluous.  It does not appear that the fact that the enum had integer values was used anywhere.
- Added some unit tests for `lektor.imagetools.make_image_thumbnail()`

[current logic]: <https://github.com/lektor/lektor/blob/671ba9ee25ac4267bb863334aced7fb15b3cfa2a/lektor/imagetools.py#L610>

* [x] Added unit test(s) covering the changes (if testable)


