### PR TITLE
Fall back to PollingObserver if creation of default Observer fails.

### DIFF
--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -93,16 +93,10 @@ class BasicWatcher:
         return True
 
     def __iter__(self):
-        # Alias this since we may need it during interpreter shutdown
-        queue_Empty = queue.Empty
-
         while 1:
-            try:
-                item = self.event_handler.queue.get(timeout=1)
-                if self.is_interesting(*item):
-                    yield item
-            except queue_Empty:
-                pass
+            time_, event_type, path = self.event_handler.queue.get()
+            if self.is_interesting(time_, event_type, path):
+                yield time_, event_type, path
 
 
 class Watcher(BasicWatcher):

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -11,9 +11,6 @@ from watchdog.observers.polling import PollingObserver
 
 from lektor.utils import get_cache_dir
 
-# Alias this as this can be called during interpreter shutdown
-_Empty = queue.Empty
-
 
 class EventHandler(FileSystemEventHandler):
     def __init__(self):
@@ -76,12 +73,15 @@ class BasicWatcher:
         return True
 
     def __iter__(self):
+        # Alias this since we may need it during interpreter shutdown
+        queue_Empty = queue.Empty
+
         while 1:
             try:
                 item = self.event_handler.queue.get(timeout=1)
                 if self.is_interesting(*item):
                     yield item
-            except _Empty:
+            except queue_Empty:
                 pass
 
 

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -64,7 +64,7 @@ class BasicWatcher:
         observer = observer_class()
         for path in self.paths:
             observer.schedule(self.event_handler, path, recursive=True)
-        observer.setDaemon(True)
+        observer.daemon = True
         observer.start()
         self.observer = observer
 

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -51,7 +51,7 @@ class BasicWatcher:
             try:
                 self._start_observer(observer_class)
             except Exception as exc:
-                untried.remove(observer_class)
+                untried.discard(observer_class)
                 if len(untried) == 0:
                     raise
                 click.secho(

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -61,6 +61,8 @@ class BasicWatcher:
         self.stop()
 
     def _start_observer(self, observer_class=Observer):
+        if self.observer is not None:
+            raise RuntimeError("Watcher already started.")
         observer = observer_class()
         for path in self.paths:
             observer.schedule(self.event_handler, path, recursive=True)

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -45,6 +45,10 @@ class BasicWatcher:
         self.observer = None
 
     def start(self):
+        # Remove duplicates since there is no point in trying a given
+        # observer class more than once. (This also simplifies the logic
+        # for presenting sensible warning messages about broken
+        # observers.)
         observer_classes = list(_unique_everseen(self.observer_classes))
         for observer_class, next_observer_class in zip_longest(
             observer_classes, observer_classes[1:]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,9 +1,13 @@
 import functools
 
 import py
+import pytest
+from watchdog.observers.api import BaseObserver
+from watchdog.observers.polling import PollingObserver
 
 from lektor import utils
-from lektor import watcher
+from lektor.watcher import BasicWatcher
+from lektor.watcher import Watcher
 
 
 def test_is_interesting(env):
@@ -11,7 +15,7 @@ def test_is_interesting(env):
     cache_dir = py.path.local(utils.get_cache_dir())
     build_dir = py.path.local("build")
 
-    w = watcher.Watcher(env, str(build_dir))
+    w = Watcher(env, str(build_dir))
 
     # This partial makes the testing code shorter
     is_interesting = functools.partial(w.is_interesting, 0, "generic")
@@ -23,3 +27,35 @@ def test_is_interesting(env):
 
     w.output_path = None
     assert is_interesting(str(build_dir / "output.file"))
+
+
+class BrokenObserver(PollingObserver):
+    # The InotifyObserver, when it fails due to insufficient system
+    # inotify resources, does not fail until an attempt is made to start it.
+    def start(self):
+        raise OSError("crapout")
+
+
+class TestBasicWatcher:
+    # pylint: disable=no-self-use
+
+    @pytest.fixture
+    def paths(self, tmp_path):
+        return [str(tmp_path)]
+
+    def test_creates_observer(self, paths):
+        with BasicWatcher(paths) as watcher:
+            assert isinstance(watcher.observer, BaseObserver)
+
+    def test_default_observer_broken(self, paths, capsys):
+        observer_classes = (BrokenObserver, PollingObserver)
+        with BasicWatcher(paths, observer_classes=observer_classes) as watcher:
+            assert watcher.observer.__class__ is PollingObserver
+        assert "crapout" in capsys.readouterr().out
+
+    def test_default_observer_is_polling(self, paths, capsys):
+        observer_classes = (BrokenObserver, BrokenObserver)
+        with pytest.raises(OSError, match=r"crapout"):
+            with BasicWatcher(paths, observer_classes=observer_classes):
+                pass
+        assert capsys.readouterr() == ("", "")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -59,3 +59,10 @@ class TestBasicWatcher:
             with BasicWatcher(paths, observer_classes=observer_classes):
                 pass
         assert capsys.readouterr() == ("", "")
+
+    def test_perverse_usage(self, paths):
+        # This exercises a bug which occurred when BasicWatcher was
+        # called with repeated (failing) values in observer_classes.
+        observer_classes = (BrokenObserver, BrokenObserver, PollingObserver)
+        with BasicWatcher(paths, observer_classes=observer_classes) as watcher:
+            assert isinstance(watcher.observer, BaseObserver)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -101,17 +101,18 @@ class TestBasicWatcher:
 
     def test_iter(self, tmp_path):
         file1 = tmp_path / "file1"
-        file2 = tmp_path / "file2"
         file1.touch()
         with BasicWatcher([str(tmp_path)]) as watcher:
             it = IterateInThread(watcher)
 
+            file2 = tmp_path / "file2"
             file2.touch()
             assert next(it)[1:] == ("created", str(file2))
             assert next(it)[1:] == ("closed", str(file2))
 
-            file1 = file1.rename(tmp_path / "file1_renamed")
-            assert next(it)[1:] == ("moved", str(file1))
+            file1_renamed = tmp_path / "file1_renamed"
+            file1.rename(file1_renamed)
+            assert next(it)[1:] == ("moved", str(file1_renamed))
 
             assert it.queue.empty()
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -66,3 +66,8 @@ class TestBasicWatcher:
         observer_classes = (BrokenObserver, BrokenObserver, PollingObserver)
         with BasicWatcher(paths, observer_classes=observer_classes) as watcher:
             assert isinstance(watcher.observer, BaseObserver)
+
+    def test_raises_error_if_started_twice(self, paths):
+        with BasicWatcher(paths) as watcher:
+            with pytest.raises(RuntimeError, match="already started"):
+                watcher.start()


### PR DESCRIPTION
The `watchdog` distribution provides several different types of "Observers" that can be used to watch for file changes. On Linux, the default observer is `InotifyObserver`. There are other observers which are used on different OSes. There is also a `PollingObserver`, which  — while not as efficient as the other observers — should work anywhere.

Sometimes creation of the `InotifyObserver` fails.  This can be caused by inotify resource limits being exhausted by other processes running on the users system, for example.

This change makes it so that if creation of the default `Observer` fails, Lektor will fall back to using a `PollingObserver` (rather than just crapping out.)

### Issue(s) Resolved

Fixes #861

### Concerns

I suspect that is still possible that exceptions due to inotify limits may still be possible after the Observer has been created, while it is in use.  If that is indeed a possibility, this does not fix that.

### Description of Changes


* [x] Wrote at least one-line docstrings (for any new functions)
* [x] Added unit test(s) covering the changes (if testable)

