### PR TITLE
lint: enable no-self-use

### DIFF
--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -74,6 +74,7 @@ class Asset(SourceObject):
         return iter(())
 
     def get_child(self, name, from_url=False):
+        # pylint: disable=no-self-use
         return None
 
     def resolve_url_path(self, url_path):

--- a/lektor/build_programs.py
+++ b/lektor/build_programs.py
@@ -138,6 +138,7 @@ class BuildProgram:
         building.  An individual build never recurses down to this, but
         a `build_all` will use this.
         """
+        # pylint: disable=no-self-use
         return iter(())
 
 

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -343,7 +343,8 @@ class BuildState:
         )
         return cur.fetchone() is not None
 
-    def _get_artifact_config_hash(self, cur, artifact_name):
+    @staticmethod
+    def _get_artifact_config_hash(cur, artifact_name):
         """Returns the artifact's config hash."""
         cur.execute(
             """
@@ -1159,7 +1160,8 @@ class Builder:
                 return ctx
         return None
 
-    def update_source_info(self, prog, build_state):
+    @staticmethod
+    def update_source_info(prog, build_state):
         """Updates a single source info based on a program.  This is done
         automatically as part of a build.
         """

--- a/lektor/context.py
+++ b/lektor/context.py
@@ -138,7 +138,8 @@ class Context:
     def push(self):
         _ctx_stack.push(self)
 
-    def pop(self):
+    @staticmethod
+    def pop():
         _ctx_stack.pop()
 
     def __enter__(self):

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -78,7 +78,8 @@ class PaginationConfig:
             return query
         return query.limit(self.per_page).offset((page - 1) * self.per_page)
 
-    def get_record_for_page(self, record, page_num):
+    @staticmethod
+    def get_record_for_page(record, page_num):
         """Given a normal record this one returns the version specific
         for a page.
         """

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -182,6 +182,7 @@ def save_eval(filter, record):
 
 class Expression:
     def __eval__(self, record):
+        # pylint: disable=no-self-use
         return record
 
     def __eq__(self, other):
@@ -1539,7 +1540,8 @@ class Database:
         if is_undefined(data["_template"]):
             data["_template"] = datamodel.get_default_template_name()
 
-    def get_record_class(self, datamodel, raw_data):
+    @staticmethod
+    def get_record_class(datamodel, raw_data):
         """Returns the appropriate record class for a datamodel and raw data."""
         is_attachment = bool(raw_data.get("_attachment_for"))
         if not is_attachment:
@@ -2051,7 +2053,8 @@ class RecordCache:
         self.persistent = {}
         self.ephemeral = LRUCache(ephemeral_cache_size)
 
-    def _get_cache_key(self, record_or_path, alt=PRIMARY_ALT, virtual_path=None):
+    @staticmethod
+    def _get_cache_key(record_or_path, alt=PRIMARY_ALT, virtual_path=None):
         if isinstance(record_or_path, str):
             path = record_or_path.strip("/")
         else:

--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -214,7 +214,8 @@ class Environment:
             return False
         return any_fnmatch(filename, EXCLUDED_ASSETS + proj.excluded_assets)
 
-    def is_ignored_artifact(self, asset_name):
+    @staticmethod
+    def is_ignored_artifact(asset_name):
         """This is used by the prune tool to figure out which files in the
         artifact folder should be ignored.
         """

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -194,6 +194,7 @@ class Publisher:
         self.output_path = os.path.abspath(output_path)
 
     def fail(self, message):
+        # pylint: disable=no-self-use
         raise PublishError(message)
 
     def publish(self, target_url, credentials=None, **extra):
@@ -255,7 +256,8 @@ class FtpConnection:
         self.log_buffer = []
         self._known_folders = set()
 
-    def make_connection(self):
+    @staticmethod
+    def make_connection():
         # pylint: disable=import-outside-toplevel
         from ftplib import FTP
 
@@ -422,7 +424,8 @@ class FtpTlsConnection(FtpConnection):
 class FtpPublisher(Publisher):
     connection_class = FtpConnection
 
-    def read_existing_artifacts(self, con):
+    @staticmethod
+    def read_existing_artifacts(con):
         contents = con.get_file(".lektor/listing")
         if not contents:
             return {}, set()
@@ -472,7 +475,8 @@ class FtpPublisher(Publisher):
                     h.hexdigest(),
                 )
 
-    def get_temp_filename(self, filename):
+    @staticmethod
+    def get_temp_filename(filename):
         dirname, basename = posixpath.split(filename)
         return posixpath.join(dirname, "." + basename + ".tmp")
 
@@ -544,7 +548,8 @@ class FtpTlsPublisher(FtpPublisher):
 
 
 class GithubPagesPublisher(Publisher):
-    def get_credentials(self, url, credentials=None):
+    @staticmethod
+    def get_credentials(url, credentials=None):
         credentials = credentials or {}
         username = credentials.get("username") or url.username
         password = credentials.get("password") or url.password
@@ -618,14 +623,16 @@ class GithubPagesPublisher(Publisher):
                 except OSError:  # Different Filesystems
                     shutil.copy(full_path, dst)
 
-    def write_cname(self, path, target_url):
+    @staticmethod
+    def write_cname(path, target_url):
         params = target_url.decode_query()
         cname = params.get("cname")
         if cname is not None:
             with open(os.path.join(path, "CNAME"), "w") as f:
                 f.write("%s\n" % cname)
 
-    def detect_target_branch(self, target_url):
+    @staticmethod
+    def detect_target_branch(target_url):
         # When pushing to the username.github.io repo we need to push to
         # master, otherwise to gh-pages
         if target_url.host.lower() + ".github.io" == target_url.path.strip("/").lower():

--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -39,7 +39,8 @@ class Generator:
         self.e = click.secho
         self.w = partial(click.wrap_text, width=self.term_width)
 
-    def abort(self, message):
+    @staticmethod
+    def abort(message):
         click.echo("Error: %s" % message, err=True)
         raise click.Abort()
 
@@ -105,7 +106,8 @@ class Generator:
                 )
             os.rmdir(scratch)
 
-    def expand_filename(self, base, ctx, template_filename):
+    @staticmethod
+    def expand_filename(base, ctx, template_filename):
         def _repl(match):
             return ctx[match.group(1)]
 

--- a/lektor/reporter.py
+++ b/lektor/reporter.py
@@ -33,7 +33,8 @@ class Reporter:
     def push(self):
         _reporter_stack.push(self)
 
-    def pop(self):
+    @staticmethod
+    def pop():
         _reporter_stack.pop()
 
     def __enter__(self):

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -44,6 +44,7 @@ class SourceObject:
             yield self.source_filename
 
     def iter_virtual_sources(self):
+        # pylint: disable=no-self-use
         return []
 
     @property
@@ -143,9 +144,11 @@ class VirtualSourceObject(SourceObject):
         raise NotImplementedError()
 
     def get_mtime(self, path_cache):
+        # pylint: disable=no-self-use
         return None
 
     def get_checksum(self, path_cache):
+        # pylint: disable=no-self-use
         return None
 
     @property

--- a/lektor/types/base.py
+++ b/lektor/types/base.py
@@ -74,6 +74,7 @@ class Type:
         }
 
     def value_from_raw(self, raw):
+        # pylint: disable=no-self-use
         return raw
 
     def value_from_raw_with_default(self, raw):

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -43,6 +43,7 @@ class BasicWatcher:
         self.observer.setDaemon(True)
 
     def is_interesting(self, time, event_type, path):
+        # pylint: disable=no-self-use
         return True
 
     def __iter__(self):

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,6 @@ disable =
     missing-docstring,
     unused-argument,
     bad-continuation,
-    no-self-use,
     redefined-outer-name,
     invalid-name,
     protected-access,

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -8,37 +8,39 @@ from lektor.datamodel import DataModel
 from lektor.reporter import BufferReporter
 
 
-class TestDataModel:
-    @pytest.fixture
-    def slug_format(self):
-        return None
+@pytest.fixture
+def slug_format():
+    return None
 
-    @pytest.fixture
-    def datamodel(self, env, slug_format):
-        id_ = "test"
-        name_i18n = {"en": "test"}
-        child_config = ChildConfig(slug_format=slug_format)
-        return DataModel(env, id_, name_i18n, child_config=child_config)
 
-    @pytest.mark.parametrize(
-        "slug_format, expected_slug",
-        [
-            (None, "child-id"),
-            ("fmt-{{ this._id }}", "fmt-child-id"),
-            ("{{ unknown.attr }}", "temp-child-id"),
-        ],
-    )
-    def test_get_default_child_slug(self, datamodel, pad, expected_slug):
-        data = {
-            "_id": "child-id",
-        }
-        assert datamodel.get_default_child_slug(pad, data) == expected_slug
+@pytest.fixture
+def datamodel(env, slug_format):
+    id_ = "test"
+    name_i18n = {"en": "test"}
+    child_config = ChildConfig(slug_format=slug_format)
+    return DataModel(env, id_, name_i18n, child_config=child_config)
 
-    @pytest.mark.parametrize("slug_format", ["{{ unknown.attr }}"])
-    def test_get_default_child_slug_reports_failure(self, datamodel, pad):
-        data = {"_id": "id"}
-        with BufferReporter(pad.env) as reporter:
-            assert datamodel.get_default_child_slug(pad, data) == "temp-id"
-        _, event_data = reporter.buffer[-1]
-        message = event_data["message"]
-        assert re.search(r"failed to expand\b.*\bslug_format\b", message, re.I)
+
+@pytest.mark.parametrize(
+    "slug_format, expected_slug",
+    [
+        (None, "child-id"),
+        ("fmt-{{ this._id }}", "fmt-child-id"),
+        ("{{ unknown.attr }}", "temp-child-id"),
+    ],
+)
+def test_get_default_child_slug(datamodel, pad, expected_slug):
+    data = {
+        "_id": "child-id",
+    }
+    assert datamodel.get_default_child_slug(pad, data) == expected_slug
+
+
+@pytest.mark.parametrize("slug_format", ["{{ unknown.attr }}"])
+def test_get_default_child_slug_reports_failure(datamodel, pad):
+    data = {"_id": "id"}
+    with BufferReporter(pad.env) as reporter:
+        assert datamodel.get_default_child_slug(pad, data) == "temp-id"
+    _, event_data = reporter.buffer[-1]
+    message = event_data["message"]
+    assert re.search(r"failed to expand\b.*\bslug_format\b", message, re.I)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -244,70 +244,65 @@ def test_virtual_path_behavior(pad):
     assert blog_page2.url_to("@3", absolute=True) == "/blog/page/3/"
 
 
-class Test_Pagination_iter_pages:
-    @pytest.fixture
-    def pagination(self, pad, page, pages, monkeypatch):
-        projects = pad.get("/projects", page_num=1)
-        pagination = projects.pagination
-        # hack in the desired page and total
-        monkeypatch.setattr(pagination, "page", page)
-        monkeypatch.setattr(pagination, "total", pages)
-        monkeypatch.setattr(pagination, "per_page", 1)
-        assert pagination.pages == pages
-        return pagination
+@pytest.fixture
+def pagination(pad, page, pages, monkeypatch):
+    projects = pad.get("/projects", page_num=1)
+    pagination = projects.pagination
+    # hack in the desired page and total
+    monkeypatch.setattr(pagination, "page", page)
+    monkeypatch.setattr(pagination, "total", pages)
+    monkeypatch.setattr(pagination, "per_page", 1)
+    assert pagination.pages == pages
+    return pagination
 
-    @pytest.mark.parametrize(
-        (
-            "page",
-            "pages",
-            "left_edge",
-            "left_current",
-            "right_current",
-            "right_edge",
-            "expected",
-        ),
-        [
-            (1, 9, 0, 0, 0, 0, [1, None]),
-            (2, 9, 0, 0, 0, 0, [None, 2, None]),
-            (8, 9, 0, 0, 0, 0, [None, 8, None]),
-            (9, 9, 0, 0, 0, 0, [None, 9]),
-            (1, 9, 1, 0, 0, 1, [1, None, 9]),
-            (2, 9, 1, 0, 0, 1, [1, 2, None, 9]),
-            (3, 9, 1, 0, 0, 1, [1, None, 3, None, 9]),
-            (7, 9, 1, 0, 0, 1, [1, None, 7, None, 9]),
-            (8, 9, 1, 0, 0, 1, [1, None, 8, 9]),
-            (9, 9, 1, 0, 0, 1, [1, None, 9]),
-            (1, 9, 0, 1, 1, 0, [1, 2, None]),
-            (2, 9, 0, 1, 1, 0, [1, 2, 3, None]),
-            (3, 9, 0, 1, 1, 0, [None, 2, 3, 4, None]),
-            (7, 9, 0, 1, 1, 0, [None, 6, 7, 8, None]),
-            (8, 9, 0, 1, 1, 0, [None, 7, 8, 9]),
-            (9, 9, 0, 1, 1, 0, [None, 8, 9]),
-            (1, 9, 1, 1, 1, 1, [1, 2, None, 9]),
-            (2, 9, 1, 1, 1, 1, [1, 2, 3, None, 9]),
-            (3, 9, 1, 1, 1, 1, [1, 2, 3, 4, None, 9]),
-            (4, 9, 1, 1, 1, 1, [1, None, 3, 4, 5, None, 9]),
-            (6, 9, 1, 1, 1, 1, [1, None, 5, 6, 7, None, 9]),
-            (7, 9, 1, 1, 1, 1, [1, None, 6, 7, 8, 9]),
-            (8, 9, 1, 1, 1, 1, [1, None, 7, 8, 9]),
-            (9, 9, 1, 1, 1, 1, [1, None, 8, 9]),
-        ],
+
+@pytest.mark.parametrize(
+    (
+        "page",
+        "pages",
+        "left_edge",
+        "left_current",
+        "right_current",
+        "right_edge",
+        "expected",
+    ),
+    [
+        (1, 9, 0, 0, 0, 0, [1, None]),
+        (2, 9, 0, 0, 0, 0, [None, 2, None]),
+        (8, 9, 0, 0, 0, 0, [None, 8, None]),
+        (9, 9, 0, 0, 0, 0, [None, 9]),
+        (1, 9, 1, 0, 0, 1, [1, None, 9]),
+        (2, 9, 1, 0, 0, 1, [1, 2, None, 9]),
+        (3, 9, 1, 0, 0, 1, [1, None, 3, None, 9]),
+        (7, 9, 1, 0, 0, 1, [1, None, 7, None, 9]),
+        (8, 9, 1, 0, 0, 1, [1, None, 8, 9]),
+        (9, 9, 1, 0, 0, 1, [1, None, 9]),
+        (1, 9, 0, 1, 1, 0, [1, 2, None]),
+        (2, 9, 0, 1, 1, 0, [1, 2, 3, None]),
+        (3, 9, 0, 1, 1, 0, [None, 2, 3, 4, None]),
+        (7, 9, 0, 1, 1, 0, [None, 6, 7, 8, None]),
+        (8, 9, 0, 1, 1, 0, [None, 7, 8, 9]),
+        (9, 9, 0, 1, 1, 0, [None, 8, 9]),
+        (1, 9, 1, 1, 1, 1, [1, 2, None, 9]),
+        (2, 9, 1, 1, 1, 1, [1, 2, 3, None, 9]),
+        (3, 9, 1, 1, 1, 1, [1, 2, 3, 4, None, 9]),
+        (4, 9, 1, 1, 1, 1, [1, None, 3, 4, 5, None, 9]),
+        (6, 9, 1, 1, 1, 1, [1, None, 5, 6, 7, None, 9]),
+        (7, 9, 1, 1, 1, 1, [1, None, 6, 7, 8, 9]),
+        (8, 9, 1, 1, 1, 1, [1, None, 7, 8, 9]),
+        (9, 9, 1, 1, 1, 1, [1, None, 8, 9]),
+    ],
+)
+def test_iter_pages(
+    pagination,
+    page,
+    left_edge,
+    left_current,
+    right_current,
+    right_edge,
+    expected,
+):
+    assert (
+        list(pagination.iter_pages(left_edge, left_current, right_current, right_edge))
+        == expected
     )
-    def test(
-        self,
-        pagination,
-        page,
-        left_edge,
-        left_current,
-        right_current,
-        right_edge,
-        expected,
-    ):
-        assert (
-            list(
-                pagination.iter_pages(
-                    left_edge, left_current, right_current, right_edge
-                )
-            )
-            == expected
-        )


### PR DESCRIPTION
Add disables in classes that are expected to be subclassed and turn the
methods into static methods in the other places.