### PR TITLE
Pin pylint version in an attempt to prevent future spontaneous breakage of CI tests

### DIFF
--- a/lektor/buildfailures.py
+++ b/lektor/buildfailures.py
@@ -52,6 +52,7 @@ class FailureController:
         except IOError as e:
             if e.errno != errno.ENOENT:
                 raise
+            return None
 
     def clear_failure(self, artifact_name):
         """Clears a stored failure."""

--- a/lektor/databags.py
+++ b/lektor/databags.py
@@ -24,6 +24,7 @@ def load_databag(filename):
     except (OSError, IOError) as e:
         if e.errno != errno.ENOENT:
             raise
+        return None
 
 
 class Databags:

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -39,7 +39,7 @@ class ThumbnailMode(IntEnum):
         """
         name = label.upper().replace("-", "_")
         try:
-            return cls.__members__[name]  # pylint: disable=no-member
+            return cls.__members__[name]  # pylint: disable=unsubscriptable-object
         except KeyError as error:
             raise ValueError("Invalid thumbnail mode '%s'." % label) from error
 

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -316,7 +316,7 @@ def locate_executable(exe_file, cwd=None, include_bundle_path=True):
                     return path + ext
         return None
     except OSError:
-        pass
+        return None
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -356,6 +356,7 @@ def safe_call(func, args=None, kwargs=None):
     except Exception:
         # XXX: logging
         traceback.print_exc()
+        return None
 
 
 class Worker(Thread):
@@ -600,6 +601,9 @@ def get_relative_path(source, target):
         else:
             # prepend the distance to the common ancestor
             return distance / relpath
+    # We should never get here.  (The last ancestor in source.parents will
+    # be '.' — target.relative_to('.') will always succeed.)
+    raise AssertionError("This should not happen")
 
 
 def get_structure_hash(params):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with io.open("README.md", "rt", encoding="utf8") as f:
 
 tests_require = [
     "pre-commit",
-    "pylint",
+    "pylint==2.7.0",
     "pytest",
     "pytest-cov",
     "pytest-mock",

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 3
 envlist = lint, py
 
 [testenv]
@@ -18,7 +19,6 @@ paths =
 	.tox/coverage/*/lektor
 
 [testenv:lint]
-deps =
-    pylint
+# NB: (Pinned) pylint is installed as part of the lektor[test] extras
 commands =
     pylint {posargs:lektor setup.py tests}


### PR DESCRIPTION

### Issue(s) Resolved

The release of pylint==2.7.0 caused the CI tests to spontaneously start failing.

References:
- [pylint changelog](https://github.com/PyCQA/pylint/blob/5e04ce74faa0142fe3ff99eec08479cfaeb9584c/ChangeLog#L104)
- PyCQA/pylint#3468


### Related Issues / Links

There are multiple outstanding PRs which are currently failing CI tests due to no fault of their own.


### Description of Changes

Fixed the new warnings ("inconsistent-return-statements").

Pinned the version of pylint used for CI tests to 2.7.0.

