### PR TITLE
Fix two i18n buglets/typos

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -410,7 +410,7 @@ class Record(SourceObject):
                 label = self.get_fallback_record_label(lang)
             rv[lang] = label
         # Fill in english if missing
-        if not rv:
+        if "en" not in rv:
             rv["en"] = self.get_fallback_record_label("en")
         return rv
 

--- a/lektor/sourcesearch.py
+++ b/lektor/sourcesearch.py
@@ -58,7 +58,7 @@ def _build_parent_path(path, mapping, alt, lang):
     rv = []
     for parent in _iter_parents(path):
         info = _find_best_info(mapping.get(parent) or [], alt, lang)
-        id = _id_from_path(info["path"])
+        id = _id_from_path(parent)
         if info is None:
             title = id or "(Index)"
         else:


### PR DESCRIPTION
In looking into #895, two apparent typos were discovered.  Both of these result in edge-case bugs.  This fixes them.

### Issue(s) Resolved

Fixes #895

It's clear from inspection that there's something not quite right about the code around [line 61 & 62][so61] of `sourceobj.py` — the `if` branch is not reachable, since if `info is None`, the exception reported in #895 will occur before the if statement is executed.
(After further digging, I believe that it *should* never come to be that `info` is `None`. That is was happening was due to another buglet. More on that later.)

Note `mapping` is a dict which maps from `path` to a list of `info`s.  Inspection of [`_mapping_from_cursor`][mfc] makes it clear that all the `info`s in `mapping.get(parent)` (if any) will have `info["path"] == parent`.  The fix here is to use `parent` in place of `info["path"]`.

[so61]: <https://github.com/lektor/lektor/blob/5a2895c1b683c1df98beed2ad970f8ebdab26a75/lektor/sourcesearch.py#L61>
[mfc]: <https://github.com/lektor/lektor/blob/5a2895c1b683c1df98beed2ad970f8ebdab26a75/lektor/sourcesearch.py#L28>

### Related Issues / Links

There's another typo in [`Record.get_record_label_i18n`][grl] in `db.py`.  The comment says "Fill in english if missing", but the code current does "fill in english if there are no other labels in any language".  In this case, the comment is right, the code is wrong.

Other [comments][] and [code][] spell out that `"en"` is the hard-coded fallback for internationalizations. There should always be an `en` entry in the i18n mappings.

[grl]: <https://github.com/lektor/lektor/blob/5a2895c1b683c1df98beed2ad970f8ebdab26a75/lektor/db.py#L413>
[comments]: <https://github.com/lektor/lektor/blob/5a2895c1b683c1df98beed2ad970f8ebdab26a75/lektor/i18n.py#L61>
[code]: <https://github.com/lektor/lektor/blob/5a2895c1b683c1df98beed2ad970f8ebdab26a75/lektor/admin/static/js/i18n.tsx#L46>

You can exercise this bug as follows:
1. Create a new quickstart Lektor project
2. Edit `models/page.ini` and change it so that it has a localized label, but no default label defined.  E.g.
```ini
[model]
name = Page
label[de] = Auf Deutsch: {{ this.title }}
[fields.title]
...
```
3. Run the admin GUI, setting the language to something that is neither English nor the one the label is localized for.
```sh
lektor --language fr server
```
4. Note that the page titles are screwy/blank in various places.
![Screenshot from 2021-03-01 09-07-26](https://user-images.githubusercontent.com/495018/109532418-f5df2d00-7a6d-11eb-8bfc-6ad32a582577.png)


