### PR TITLE
Use python's json.load instead of flask.json.load

### DIFF
--- a/lektor/i18n.py
+++ b/lektor/i18n.py
@@ -1,6 +1,5 @@
+import json
 import os
-
-from flask import json
 
 
 translations_path = os.path.join(
@@ -13,8 +12,6 @@ KNOWN_LANGUAGES = list(
 
 translations = {}
 for _lang in KNOWN_LANGUAGES:
-    # We use flask.json here which can deal with bytes unlike the stdlib
-    # json module which barfs on bytes on 3.x
     with open(os.path.join(translations_path, _lang + ".json"), "rb") as f:
         translations[_lang] = json.load(f)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,8 @@
+import json
 import os
 from operator import itemgetter
 
 import pytest
-from flask import json
 
 from lektor.admin import WebAdmin
 from lektor.admin.utils import eventstream

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,10 @@
+import importlib
+
+import lektor.i18n
+
+
+def test_loading_i18n_triggers_no_warnings(recwarn):
+    importlib.reload(lektor.i18n)
+    for warning in recwarn.list:
+        print(warning)  # debugging: display warnings on stdout
+    assert len(recwarn) == 0


### PR DESCRIPTION
### Issue(s) Resolved

`Flask.json.load` has a buglet which causes python to issue "unclosed file" ResourceWarnings.  The first commit in this PR has a test which demonstrates this.

It appears that the only reason `flask.json.load` was used in `lektor.i18n` was for its ability to read from binary files.  Python's `json.load` supports reading from binary files since python 3.6.
(Note that there are two other places where Lektor uses `json.load` — in `buildfailures.py` and `databags.py`.  In both of those cases it is already using Python's `json.load`.)

This PR replaces the use of `flask.json.load` with `json.load`.  This eliminates the unclosed file warnings.

### Still to be investigated

Can/should Lektor's other uses of `flask.json` be replaced by `json`?

