### PR TITLE
Features/dependencies on files on pyton path

### DIFF
--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -166,7 +166,8 @@ def install_local_package(package_root, path):
 
 
 def requiriements_txt_from_requires_file_in_same_directory(requires_path):
-    "requirex.txt can contain [extras_require] sections wich pip doesn't understand"
+    """Create a sanitized copy of `requires.txt`."""
+    # requires.txt can contain [extras_require] sections wich pip doesn't understand
     requirements_path = os.path.join(os.path.dirname(requires_path), "requirements.txt")
     with open(requirements_path, "w") as requirements, open(
         requires_path, "r"

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -190,11 +190,11 @@ def requirements_txt_from_requires_file(requires_path):
     with open(requirements_path, "w") as requirements, open(
         requires_path, "r"
     ) as requires:
-        for line in requires.readlines():
-            # extra requires section starts here -> not valid requirements.txt syntax
-            if line.strip().startswith("["):
-                break
-            requirements.write(line)
+        section_name, extracted_requirements = next(
+            pkg_resources.split_sections(requires)
+        )
+        if section_name is None:
+            requirements.write("\n".join(extracted_requirements))
 
     return requirements_path
 

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -332,10 +332,9 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
                     package_root, os.path.join(local_package_path, package[1:])
                 )
             else:
-                download_and_install_packages(
-                    package_root,
-                    ["%s%s%s" % (package, version and "==" or "", version or "")],
-                )
+                requirement_spec = f"{package}=={version}" if version else package
+                download_and_install_packages(package_root, [requirement_spec])
+
         write_manifest(manifest_file, all_packages)
 
 

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -75,34 +75,8 @@ def remove_package_from_project(project, name):
     return None
 
 
-def download_and_install_package(
-    package_root, package=None, version=None, requirements_file=None
-):
-    """This downloads and installs a specific version of a package."""
-    # XXX: windows
-    env = dict(os.environ)
-
-    args = [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--target",
-        package_root,
-    ]
-
-    if package is not None:
-        args.append("%s%s%s" % (package, version and "==" or "", version or ""))
-    if requirements_file is not None:
-        args.extend(("-r", requirements_file))
-
-    rv = portable_popen(args, env=env).wait()
-    if rv != 0:
-        raise RuntimeError("Failed to install dependency package.")
-
-
 def download_and_install_packages(package_root, packages_with_versions):
-    """This downloads and installs a specific version of a package."""
+    """This downloads and installs a specific version of packages."""
     # XXX: windows
     env = dict(os.environ)
 
@@ -352,7 +326,10 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
                     package_root, os.path.join(local_package_path, package[1:])
                 )
             else:
-                download_and_install_package(package_root, package, version)
+                download_and_install_packages(
+                    package_root,
+                    ["%s%s%s" % (package, version and "==" or "", version or "")],
+                )
         write_manifest(manifest_file, all_packages)
 
 

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -104,7 +104,7 @@ def download_and_install_package(
 def install_local_package(package_root, path):
     """This installs a local dependency of a package."""
 
-    # Becaus of these bugs:
+    # Because of these bugs:
     # - pip https://github.com/pypa/pip/issues/4390
     # - setuptools https://github.com/pypa/setuptools/issues/392
     # we cannot just call `pip install --target $folder --editable $package`.

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -144,7 +144,6 @@ def install_local_package(package_root, path):
 
     editable_install_without_dependencies(package_root, path)
 
-    # using a for loop syntax here so the generator can clean up the tempdir after the loop
     requirements = requirements_from_unfinished_editable_install_at_path(path)
     if requirements is not None:
         download_and_install_packages(package_root, requirements)

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -75,7 +75,7 @@ def remove_package_from_project(project, name):
     return None
 
 
-def download_and_install_packages(package_root, packages_with_versions):
+def download_and_install_packages(package_root, requirement_specifiers):
     """This downloads and installs a specific version of packages."""
     # XXX: windows
     env = dict(os.environ)
@@ -89,7 +89,7 @@ def download_and_install_packages(package_root, packages_with_versions):
         package_root,
     ]
 
-    args.extend(packages_with_versions)
+    args.extend(requirement_specifiers)
     rv = portable_popen(args, env=env).wait()
     if rv != 0:
         raise RuntimeError("Failed to install dependency package.")

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -165,14 +165,14 @@ def requirements_from_unfinished_editable_install_at_path(path):
 
         if os.path.isfile(requires_path):
             # We have dependencies, install them!
-            requirements_path = requiriements_txt_from_requires_file(requires_path)
+            requirements_path = requirements_txt_from_requires_file(requires_path)
             yield requirements_path
 
     finally:
         shutil.rmtree(tmp)
 
 
-def requiriements_txt_from_requires_file(requires_path):
+def requirements_txt_from_requires_file(requires_path):
     """Create a sanitized copy of `requires.txt`."""
     # requires.txt can contain [extras_require] sections wich pip doesn't understand
     requirements_path = os.path.join(os.path.dirname(requires_path), "requirements.txt")

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -110,8 +110,19 @@ def install_local_package(package_root, path):
     # we cannot just call `pip install --target $folder --editable $package`.
     # Hence the workaround of first installing only the package and then it's dependencies
 
+    # Because pip can resolve dependencies differently when it is called with them individually,
+    # it is important to call it with all of them together. Also
+
+    # requires.txt is specified here:
+    # https://setuptools.readthedocs.io/en/latest/deprecated/python_eggs.html#requires-txt
+    # requirementx.txt is specified here:
+    # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+    # What can be part of the dependencies is specified here:
+    # https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#id4
+
     editable_install_without_dependencies(package_root, path)
 
+    # using a for loop syntax here so the generator can clean up the tempdir after the loop
     for requirements_path in requirements_from_unfinished_editable_install_at_path(
         path
     ):

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -129,6 +129,8 @@ def install_local_package(package_root, path):
     # - setuptools https://github.com/pypa/setuptools/issues/392
     # we cannot just call `pip install --target $folder --editable $package`.
     # Hence the workaround of first installing only the package and then it's dependencies
+    # TODO Once https://github.com/pypa/pip/pull/9636 is released, this can all go away
+    # and the normal install will just work
 
     # Because pip can resolve dependencies differently when it is called with them individually,
     # it is important to call it with all of them together. Also

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -188,6 +188,9 @@ def requirements_from_requires_file(requires_path):
         if section_name is None:
             return extracted_requirements
 
+    # no dependencies to install
+    return None
+
 
 def get_package_info(path):
     """Returns the name of a package at a path."""

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -174,6 +174,9 @@ def requirements_from_unfinished_editable_install_at_path(path):
     finally:
         shutil.rmtree(tmp)
 
+    # no dependencies to install
+    return None
+
 
 def requirements_from_requires_file(requires_path):
     """Create a sanitized copy of `requires.txt`."""

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -154,24 +154,31 @@ def install_local_package(package_root, path):
 
         if os.path.isfile(requires_path):
             # We have dependencies, install them!
-            requirements_path = \
-                requiriements_txt_from_requires_file_in_same_directory(requires_path)
-            download_and_install_package(package_root, requirements_file=requirements_path)
+            requirements_path = requiriements_txt_from_requires_file_in_same_directory(
+                requires_path
+            )
+            download_and_install_package(
+                package_root, requirements_file=requirements_path
+            )
 
     finally:
         shutil.rmtree(tmp)
 
+
 def requiriements_txt_from_requires_file_in_same_directory(requires_path):
     "requirex.txt can contain [extras_require] sections wich pip doesn't understand"
     requirements_path = os.path.join(os.path.dirname(requires_path), "requirements.txt")
-    with open(requirements_path, "w") as requirements, open(requires_path, 'r') as requires:
+    with open(requirements_path, "w") as requirements, open(
+        requires_path, "r"
+    ) as requires:
         for line in requires.readlines():
             # extra requires section starts here -> not valid requirements.txt syntax
-            if line.strip().startswith('['):
+            if line.strip().startswith("["):
                 break
             requirements.write(line)
 
     return requirements_path
+
 
 def get_package_info(path):
     """Returns the name of a package at a path."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -268,3 +268,9 @@ def test_slug_contains_slash(pad, builder):
     prog, _ = builder.build(record)
     (artifact,) = prog.artifacts
     assert artifact.artifact_name == "extra/long/path/index.html"
+
+
+def test_path_cache_allows_paths_on_pythonpath(env):
+    # cache = PathCache(env)
+    # FIXME no idea yet how to test this
+    pass

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -109,3 +109,29 @@ def test_install_local_package_with_only_extras_require(tmp_path):
 
     assert (install_dir / "extras-require.egg-link").is_file()
     assert not (install_dir / "pyexpect").is_dir()
+
+
+def test_install_local_package_with_extravagant_requires(tmp_path):
+    packages_dir = tmp_path / "packages"
+    plugin_dir = create_plugin(
+        packages_dir,
+        "extras_require",
+        setup="""
+        from setuptools import setup
+
+        setup(
+            name='extras_require',
+            install_requires=[
+                'watching_testrunner;python_version>="3.6"',
+            ]
+        )
+        """,
+    )
+
+    install_dir = tmp_path / "target"
+    install_dir.mkdir()
+
+    packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
+
+    assert (install_dir / "extras-require.egg-link").is_file()
+    assert (install_dir / "watching_testrunner.py").is_file()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -11,6 +11,28 @@ def create_plugin(package_dir, plugin_name, setup):
     return plugin_dir
 
 
+def test_install_local_package_without_dependency(tmp_path):
+    packages_dir = tmp_path / "packages"
+    plugin_dir = create_plugin(
+        packages_dir,
+        "dependency",
+        setup="""
+        from setuptools import setup
+
+        setup(
+            name='dependency',
+        )
+        """,
+    )
+
+    install_dir = tmp_path / "target"
+    install_dir.mkdir()
+
+    packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
+
+    assert (install_dir / "dependency.egg-link").is_file()
+
+
 def test_install_local_package_with_dependency(tmp_path):
     packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,91 @@
+import os
+import shutil
+import tempfile
+import textwrap
+import pathlib
+
+import pytest
+
+from lektor import packages
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield pathlib.Path(temp_dir)
+
+
+def create_plugin(package_dir, plugin_name, setup):
+    plugin_dir = package_dir / plugin_name
+    plugin_dir.mkdir(parents=True)
+    setup_py = plugin_dir / 'setup.py'
+    setup_py.write_text(textwrap.dedent(setup))
+    return plugin_dir
+
+
+def test_install_local_package_with_dependency(temp_dir):
+    packages_dir = temp_dir / 'packages'
+    plugin_dir = create_plugin(packages_dir, 'dependency', setup="""
+        from setuptools import setup
+
+        setup(
+            name='dependency',
+            install_requires=['fluentpy']
+        )
+        """
+    )
+    
+    install_dir = temp_dir / 'target'
+    install_dir.mkdir()
+    
+    packages.install_local_package(install_dir, plugin_dir)
+    
+    assert (install_dir / 'dependency.egg-link').is_file()
+    assert (install_dir / 'fluentpy').is_dir()
+
+
+def test_install_local_package_with_dependency_and_extras_require(temp_dir):
+    packages_dir = temp_dir / 'packages'
+    plugin_dir = create_plugin(packages_dir, 'dependency', setup="""
+        from setuptools import setup
+
+        setup(
+            name='dependency',
+            install_requires=['fluentpy'],
+            extras_require={
+                'test': ['pyexpect']
+            }
+        )
+        """
+    )
+    
+    install_dir = temp_dir / 'target'
+    install_dir.mkdir()
+    
+    packages.install_local_package(install_dir, plugin_dir)
+    
+    assert (install_dir / 'dependency.egg-link').is_file()
+    assert (install_dir / 'fluentpy').is_dir()
+    assert not (install_dir / 'pyexpect').is_dir()
+
+
+def test_install_local_package_with_only_extras_require(temp_dir):
+    packages_dir = temp_dir / 'packages'
+    plugin_dir = create_plugin(packages_dir, 'extras_require', setup="""
+        from setuptools import setup
+
+        setup(
+            name='extras_require',
+            extras_require={
+                'test': ['pyexpect']
+            }
+        )
+        """
+    )
+    
+    install_dir = temp_dir / 'target'
+    install_dir.mkdir()
+    
+    packages.install_local_package(install_dir, plugin_dir)
+    
+    assert (install_dir / 'extras-require.egg-link').is_file()
+    assert not (install_dir / 'pyexpect').is_dir()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,16 +1,6 @@
-import pathlib
-import tempfile
 import textwrap
 
-import pytest
-
 from lektor import packages
-
-
-@pytest.fixture
-def temp_dir():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        yield pathlib.Path(temp_dir)
 
 
 def create_plugin(package_dir, plugin_name, setup):
@@ -21,8 +11,8 @@ def create_plugin(package_dir, plugin_name, setup):
     return plugin_dir
 
 
-def test_install_local_package_with_dependency(temp_dir):
-    packages_dir = temp_dir / "packages"
+def test_install_local_package_with_dependency(tmp_path):
+    packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(
         packages_dir,
         "dependency",
@@ -36,7 +26,7 @@ def test_install_local_package_with_dependency(temp_dir):
         """,
     )
 
-    install_dir = temp_dir / "target"
+    install_dir = tmp_path / "target"
     install_dir.mkdir()
 
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
@@ -45,8 +35,8 @@ def test_install_local_package_with_dependency(temp_dir):
     assert (install_dir / "watching_testrunner.py").is_file()
 
 
-def test_install_local_package_with_dependency_and_extras_require(temp_dir):
-    packages_dir = temp_dir / "packages"
+def test_install_local_package_with_dependency_and_extras_require(tmp_path):
+    packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(
         packages_dir,
         "dependency",
@@ -63,7 +53,7 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
         """,
     )
 
-    install_dir = temp_dir / "target"
+    install_dir = tmp_path / "target"
     install_dir.mkdir()
 
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
@@ -73,8 +63,8 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
     assert not (install_dir / "pyexpect").is_dir()
 
 
-def test_install_local_package_with_only_extras_require(temp_dir):
-    packages_dir = temp_dir / "packages"
+def test_install_local_package_with_only_extras_require(tmp_path):
+    packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(
         packages_dir,
         "extras_require",
@@ -90,7 +80,7 @@ def test_install_local_package_with_only_extras_require(temp_dir):
         """,
     )
 
-    install_dir = temp_dir / "target"
+    install_dir = tmp_path / "target"
     install_dir.mkdir()
 
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -39,7 +39,7 @@ def test_install_local_package_with_dependency(temp_dir):
     install_dir = temp_dir / "target"
     install_dir.mkdir()
 
-    packages.install_local_package(install_dir, plugin_dir)
+    packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
     assert (install_dir / "fluentpy").is_dir()
@@ -66,7 +66,7 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
     install_dir = temp_dir / "target"
     install_dir.mkdir()
 
-    packages.install_local_package(install_dir, plugin_dir)
+    packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
     assert (install_dir / "fluentpy").is_dir()
@@ -93,7 +93,7 @@ def test_install_local_package_with_only_extras_require(temp_dir):
     install_dir = temp_dir / "target"
     install_dir.mkdir()
 
-    packages.install_local_package(install_dir, plugin_dir)
+    packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "extras-require.egg-link").is_file()
     assert not (install_dir / "pyexpect").is_dir()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -42,7 +42,7 @@ def test_install_local_package_with_dependency(temp_dir):
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
-    assert (install_dir / "watching_testrunner").is_dir()
+    assert (install_dir / "watching_testrunner.py").is_file()
 
 
 def test_install_local_package_with_dependency_and_extras_require(temp_dir):
@@ -69,7 +69,7 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
-    assert (install_dir / "watching_testrunner").is_dir()
+    assert (install_dir / "watching_testrunner.py").is_file()
     assert not (install_dir / "pyexpect").is_dir()
 
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,12 +1,11 @@
-import os
-import shutil
+import pathlib
 import tempfile
 import textwrap
-import pathlib
 
 import pytest
 
 from lektor import packages
+
 
 @pytest.fixture
 def temp_dir():
@@ -17,35 +16,41 @@ def temp_dir():
 def create_plugin(package_dir, plugin_name, setup):
     plugin_dir = package_dir / plugin_name
     plugin_dir.mkdir(parents=True)
-    setup_py = plugin_dir / 'setup.py'
+    setup_py = plugin_dir / "setup.py"
     setup_py.write_text(textwrap.dedent(setup))
     return plugin_dir
 
 
 def test_install_local_package_with_dependency(temp_dir):
-    packages_dir = temp_dir / 'packages'
-    plugin_dir = create_plugin(packages_dir, 'dependency', setup="""
+    packages_dir = temp_dir / "packages"
+    plugin_dir = create_plugin(
+        packages_dir,
+        "dependency",
+        setup="""
         from setuptools import setup
 
         setup(
             name='dependency',
             install_requires=['fluentpy']
         )
-        """
+        """,
     )
-    
-    install_dir = temp_dir / 'target'
+
+    install_dir = temp_dir / "target"
     install_dir.mkdir()
-    
+
     packages.install_local_package(install_dir, plugin_dir)
-    
-    assert (install_dir / 'dependency.egg-link').is_file()
-    assert (install_dir / 'fluentpy').is_dir()
+
+    assert (install_dir / "dependency.egg-link").is_file()
+    assert (install_dir / "fluentpy").is_dir()
 
 
 def test_install_local_package_with_dependency_and_extras_require(temp_dir):
-    packages_dir = temp_dir / 'packages'
-    plugin_dir = create_plugin(packages_dir, 'dependency', setup="""
+    packages_dir = temp_dir / "packages"
+    plugin_dir = create_plugin(
+        packages_dir,
+        "dependency",
+        setup="""
         from setuptools import setup
 
         setup(
@@ -55,22 +60,25 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
                 'test': ['pyexpect']
             }
         )
-        """
+        """,
     )
-    
-    install_dir = temp_dir / 'target'
+
+    install_dir = temp_dir / "target"
     install_dir.mkdir()
-    
+
     packages.install_local_package(install_dir, plugin_dir)
-    
-    assert (install_dir / 'dependency.egg-link').is_file()
-    assert (install_dir / 'fluentpy').is_dir()
-    assert not (install_dir / 'pyexpect').is_dir()
+
+    assert (install_dir / "dependency.egg-link").is_file()
+    assert (install_dir / "fluentpy").is_dir()
+    assert not (install_dir / "pyexpect").is_dir()
 
 
 def test_install_local_package_with_only_extras_require(temp_dir):
-    packages_dir = temp_dir / 'packages'
-    plugin_dir = create_plugin(packages_dir, 'extras_require', setup="""
+    packages_dir = temp_dir / "packages"
+    plugin_dir = create_plugin(
+        packages_dir,
+        "extras_require",
+        setup="""
         from setuptools import setup
 
         setup(
@@ -79,13 +87,13 @@ def test_install_local_package_with_only_extras_require(temp_dir):
                 'test': ['pyexpect']
             }
         )
-        """
+        """,
     )
-    
-    install_dir = temp_dir / 'target'
+
+    install_dir = temp_dir / "target"
     install_dir.mkdir()
-    
+
     packages.install_local_package(install_dir, plugin_dir)
-    
-    assert (install_dir / 'extras-require.egg-link').is_file()
-    assert not (install_dir / 'pyexpect').is_dir()
+
+    assert (install_dir / "extras-require.egg-link").is_file()
+    assert not (install_dir / "pyexpect").is_dir()

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -31,7 +31,7 @@ def test_install_local_package_with_dependency(temp_dir):
 
         setup(
             name='dependency',
-            install_requires=['fluentpy']
+            install_requires=['watching_testrunner']
         )
         """,
     )
@@ -42,7 +42,7 @@ def test_install_local_package_with_dependency(temp_dir):
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
-    assert (install_dir / "fluentpy").is_dir()
+    assert (install_dir / "watching_testrunner").is_dir()
 
 
 def test_install_local_package_with_dependency_and_extras_require(temp_dir):
@@ -55,7 +55,7 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
 
         setup(
             name='dependency',
-            install_requires=['fluentpy'],
+            install_requires=['watching_testrunner'],
             extras_require={
                 'test': ['pyexpect']
             }
@@ -69,7 +69,7 @@ def test_install_local_package_with_dependency_and_extras_require(temp_dir):
     packages.install_local_package(install_dir.as_posix(), plugin_dir.as_posix())
 
     assert (install_dir / "dependency.egg-link").is_file()
-    assert (install_dir / "fluentpy").is_dir()
+    assert (install_dir / "watching_testrunner").is_dir()
     assert not (install_dir / "pyexpect").is_dir()
 
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,5 +1,7 @@
 import textwrap
 
+import pytest
+
 from lektor import packages
 
 
@@ -111,6 +113,7 @@ def test_install_local_package_with_only_extras_require(tmp_path):
     assert not (install_dir / "pyexpect").is_dir()
 
 
+@pytest.mark.xfail
 def test_install_local_package_with_environment_markers_in_requires(tmp_path):
     # See https://www.python.org/dev/peps/pep-0508/#environment-markers
     # This test is bad news, as it seems that setuptools internally transforms the more exotic specifiers to
@@ -120,6 +123,8 @@ def test_install_local_package_with_environment_markers_in_requires(tmp_path):
     # This seems contrary to what
     # https://setuptools.readthedocs.io/en/latest/pkg_resources.html?highlight=parse_requirements#requirements-parsing
     # specifies - not sure what is going on here
+    # This will start to work as soon as we can remove the workarounds that where neccessary until
+    # https://github.com/pypa/pip/pull/9636 is released
 
     packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -111,16 +111,25 @@ def test_install_local_package_with_only_extras_require(tmp_path):
     assert not (install_dir / "pyexpect").is_dir()
 
 
-def test_install_local_package_with_extravagant_requires(tmp_path):
+def test_install_local_package_with_environment_markers_in_requires(tmp_path):
+    # See https://www.python.org/dev/peps/pep-0508/#environment-markers
+    # This test is bad news, as it seems that setuptools internally transforms the more exotic specifiers to
+    # [:python_version >= "3.6"]
+    # watching_testrunner
+    # Which is then of course incompatible with a pip requirements.txt
+    # This seems contrary to what
+    # https://setuptools.readthedocs.io/en/latest/pkg_resources.html?highlight=parse_requirements#requirements-parsing
+    # specifies - not sure what is going on here
+
     packages_dir = tmp_path / "packages"
     plugin_dir = create_plugin(
         packages_dir,
-        "extras_require",
+        "environment_markers",
         setup="""
         from setuptools import setup
 
         setup(
-            name='extras_require',
+            name='environment_markers',
             install_requires=[
                 'watching_testrunner;python_version>="3.6"',
             ]


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #499 - or at least makes it much more manageable.

### Description of Changes

None of this has happened yet, because this is a draft pull request to spark discussion.

* [ ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
* [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)


<!--- Explain what you've done and why --->
I have relaxed the requirement for the path cache that every file be below the `env.root_path` but can also be below any of the paths in `sys.path`. This allows source files in plugins to work, even if the plugin is not a source install, but instead a normal dependency.


What do you think? I am kind of surprised that this worked at all. Also I have no ideas about the ramifications. 

So - what do you guys think, what would be a better way to support source files that are not below `env.root_path` and what ramifications does a change like this have?

One thing I don't like about this, is that before this AFAIK no absolute paths where stored in the build-state, making the entire project eminently relocatable (even between machines). Not sure if that is actually a design goal though.