### PR TITLE
Avoid editable installs

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -549,7 +549,7 @@ class FileInfo:
             if os.path.isdir(self.filename):
                 h.update(b"DIR\x00")
                 for filename in sorted(os.listdir(self.filename)):
-                    if self.env.is_uninteresting_source_name(filename):
+                    if self.env and self.env.is_uninteresting_source_name(filename):
                         continue
                     if isinstance(filename, str):
                         filename = filename.encode("utf-8")

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -182,9 +182,9 @@ def write_manifest(filename, packages):
     with open(filename, "w", encoding="utf-8") as f:
         for package, version in sorted(packages.items()):
             if package[:1] == "@":
-                f.write("%s\n" % package)
+                f.write(f"{package}\n")
             else:
-                f.write("%s=%s\n" % (package, version))
+                f.write(f"{package}={version}\n")
 
 
 def list_local_packages(path):
@@ -240,7 +240,7 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
         to_install = all_packages.items()
 
     if to_install:
-        click.echo("Updating packages in %s for project" % package_root)
+        click.echo(f"Updating packages in {package_root} for project.")
         try:
             os.makedirs(package_root)
         except OSError:

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -74,22 +74,12 @@ def remove_package_from_project(project, name):
     return None
 
 
-def download_and_install_package(package_root, package=None, version=None):
+def download_and_install_package(package_root, package):
     """This downloads and installs a specific version of a package."""
     # XXX: windows
     env = dict(os.environ)
 
-    args = [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--target",
-        package_root,
-    ]
-
-    if package is not None:
-        args.append("%s%s%s" % (package, version and "==" or "", version or ""))
+    args = [sys.executable, "-m", "pip", "install", "--target", package_root, package]
 
     rv = portable_popen(args, env=env).wait()
     if rv != 0:
@@ -259,7 +249,8 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
                     package_root, os.path.join(local_package_path, package[1:])
                 )
             else:
-                download_and_install_package(package_root, package, version)
+                requirement_spec = f"{package}=={version}" if version else package
+                download_and_install_package(package_root, requirement_spec)
         write_manifest(manifest_file, all_packages)
 
 

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -99,9 +99,10 @@ def install_local_package(package_root, path):
             "-m",
             "pip",
             "install",
-            path,
             "--target",
             package_root,
+            "--upgrade",
+            path,
         ],
         env=env,
     ).wait()
@@ -226,8 +227,9 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
 
     # step 2: figure out which local packages to install
     for package in local_packages:
-        if old_manifest.pop(package, False) is False:
-            to_install.append((package, None))
+        old_manifest.pop(package, False)
+        # TODO: only install local package if necessary.
+        to_install.append((package, None))
 
     # Bad news, we need to wipe everything
     if requires_wipe or old_manifest:
@@ -245,9 +247,8 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
             pass
         for package, version in to_install:
             if package[:1] == "@":
-                install_local_package(
-                    package_root, os.path.join(local_package_path, package[1:])
-                )
+                requirement_spec = os.path.join(local_package_path, package[1:])
+                install_local_package(package_root, requirement_spec)
             else:
                 requirement_spec = f"{package}=={version}" if version else package
                 download_and_install_package(package_root, requirement_spec)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -9,12 +9,17 @@ from lektor.packages import write_manifest
 
 def test_read_write_manifest(tmp_path: Path):
     manifest_path = tmp_path / "manifest"
-    packages = {"@test": None, "pypi-package": "0.2"}
+    packages = {
+        "@test": None,
+        "@test-with-checksum": "asdfasdfasdfadsf",
+        "pypi-package": "0.2",
+    }
     write_manifest(manifest_path, packages)
     contents = manifest_path.read_text()
     assert contents == dedent(
         """\
         @test
+        @test-with-checksum=asdfasdfasdfadsf
         pypi-package=0.2
         """
     )

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from textwrap import dedent
+
+from lektor.packages import load_manifest
+from lektor.packages import write_manifest
+
+
+def test_read_write_manifest(tmp_path: Path):
+    manifest_path = tmp_path / "manifest"
+    packages = {"@test": None, "pypi-package": "0.2"}
+    write_manifest(manifest_path, packages)
+    contents = manifest_path.read_text()
+    assert contents == dedent(
+        """\
+        @test
+        pypi-package=0.2
+        """
+    )
+    loaded = load_manifest(manifest_path)
+    assert loaded == packages

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+from lektor.packages import list_local_packages
 from lektor.packages import load_manifest
 from lektor.packages import write_manifest
 
@@ -18,3 +19,10 @@ def test_read_write_manifest(tmp_path: Path):
     )
     loaded = load_manifest(manifest_path)
     assert loaded == packages
+
+
+def test_list_local_packages(tmp_path: Path):
+    (tmp_path / "nopackage").mkdir()
+    (tmp_path / "package").mkdir()
+    (tmp_path / "package" / "setup.py").touch()
+    assert list_local_packages(tmp_path) == ["@package"]

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+from lektor.packages import hash_directory
 from lektor.packages import list_local_packages
 from lektor.packages import load_manifest
 from lektor.packages import write_manifest
@@ -26,3 +27,15 @@ def test_list_local_packages(tmp_path: Path):
     (tmp_path / "package").mkdir()
     (tmp_path / "package" / "setup.py").touch()
     assert list_local_packages(tmp_path) == ["@package"]
+
+
+def test_hash_directory(tmp_path: Path):
+    before = hash_directory(tmp_path)
+    (tmp_path / "dir").mkdir()
+    with_dir = hash_directory(tmp_path)
+    assert with_dir != before
+    (tmp_path / "dir" / "file.test").touch()
+    with_dir_and_file = hash_directory(tmp_path)
+    assert with_dir_and_file != with_dir
+    (tmp_path / "dir").touch()
+    assert hash_directory(tmp_path) == with_dir_and_file


### PR DESCRIPTION
This would fix (among others) #865 and is an alternative to PR #877.

Some problems due to our use of editable installs:
- Packages with extra_requires fail to install (#865) - this might be fixed at some point in pip
- Due to the same pip bug, these editable installs currently end up polluting the global Python `sys.path`
- Packages that use something other than setuptools won't install - this probably won't ever be fixed, PEP517 has no notion of editable installs.

The main advantage of editable installs currently is that one gets instant reloads on code changes when running lektor server in dev mode. However, since we only do editable once, updates to the dependencies or entry points (really anything but the code) of a local package would never get picked up. So we'd really have to do reinstalls on changes to the package.

What this PR does instead of doing only an (editable) install once, is to compute a checksum of local packages and to write that checksum to the manifest on install. That way, we are sure to do a reinstall on any package change but not more often than that.

Once #886 is merged, I'll add the packages path to the watcher to ensure that changes to the packages are picked up and reinstalls can be triggered in dev mode.
