### PR TITLE
Port to Werkzeug 2.x

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from itertools import chain
 
 import click
-from werkzeug.posixemulation import rename
 
 from lektor.build_programs import builtin_build_programs
 from lektor.buildfailures import FailureController
@@ -929,7 +928,7 @@ class Artifact:
                 op(con)
 
             if self._new_artifact_file is not None:
-                rename(self._new_artifact_file, self.dst_filename)
+                os.replace(self._new_artifact_file, self.dst_filename)
                 self._new_artifact_file = None
 
             if con is not None:

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -25,7 +25,6 @@ from markupsafe import Markup
 from slugify import slugify as _slugify
 from werkzeug import urls
 from werkzeug.http import http_date
-from werkzeug.posixemulation import rename
 from werkzeug.urls import url_parse
 
 
@@ -481,7 +480,7 @@ def atomic_open(filename, mode="r"):
     else:
         f.close()
         if tmp_filename is not None:
-            rename(tmp_filename, filename)
+            os.replace(tmp_filename, filename)
 
 
 def portable_popen(cmd, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "requests[security]",
         "setuptools",
         "watchdog",
-        "Werkzeug<2",
+        "Werkzeug<3",
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
Make Lektor compatible with Werkzeug 2.x.

### Issue(s) Resolved

* Closes: https://github.com/lektor/lektor/issues/910

### Related Issues / Links

* https://github.com/lektor/lektor/issues/909

### Description of Changes

* Replaces `werkzeug.posixemulation.rename` with `os.replace`
* Changes dep to `Werkzeug<3`