### PR TITLE
Cache directory can be set using the "LEKTOR_CACHE" environment variable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ UNRELEASED - in development
 - Fix the toggling of flow widgets in the admin UI to not mark the content as changed.
 - Fix the handling of the URLs when opening the admin UI from the pencil button.
 - Allow rsync deployment to a local path.
+- Allow cache directory to be set using the environment variable LEKTOR_CACHE.
 - Relax the checking of URL fields and allow FTP and mailto URLs.
 - Correctly track the page URL on the admin preview page.
 - Rename a CSS class in the admin UI so that it is not blocked by the EasyList FR adblock list.

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -694,6 +694,9 @@ def get_app_dir():
 
 
 def get_cache_dir():
+    if "LEKTOR_CACHE" in os.environ:
+        return os.environ.get("LEKTOR_CACHE")
+
     if is_windows:
         folder = os.environ.get("LOCALAPPDATA")
         if folder is None:


### PR DESCRIPTION
Corresponding documentation pull request: https://github.com/lektor/lektor-website/pull/323

### Description of Changes

If environment variable `LEKTOR_CACHE` is set, use it as the cache directory. Example:

~~~sh
# Uses default ~/.cache/lektor directory
$ lektor build
…

# Uses custom ~/foo/bar/cache/lektor to store cache
$ export LEKTOR_CACHE="~/foo/bar/cache/lektor"
$ lektor build
…
~~~

### What problem does it solve?

The documentation explains [how to keep cache between build with Travis-CI](https://www.getlektor.com/docs/deployment/travisci/). But this is not possible on Gitlab, since one cannot refer to the home directory in the `.gitlab-ci.yaml` ([example with nodejs](https://docs.gitlab.com/ee/ci/caching/#cache-nodejs-dependencies)). With this feature, this is now possible (see page `glpages` in the corresponding pull request for the documentation: https://github.com/lektor/lektor-website/pull/323).


