### PR TITLE
Address DeprecationWarnings from Jinja2

### DIFF
--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -120,7 +120,7 @@ class Environment:
 
         self.jinja_env = CustomJinjaEnvironment(
             autoescape=self.select_jinja_autoescape,
-            extensions=["jinja2.ext.autoescape", "jinja2.ext.with_", "jinja2.ext.do"],
+            extensions=["jinja2.ext.do"],
             loader=jinja2.FileSystemLoader(template_paths),
         )
 

--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -134,11 +134,9 @@ class Environment:
             # By default filters need to be side-effect free.  This is not
             # the case for this one, so we need to make it as a dummy
             # context filter so that jinja2 will not inline it.
-            url=jinja2.contextfilter(lambda ctx, *a, **kw: url_to(*a, **kw)),
-            asseturl=jinja2.contextfilter(
-                lambda ctx, *a, **kw: get_asset_url(*a, **kw)
-            ),
-            markdown=jinja2.contextfilter(lambda ctx, *a, **kw: Markdown(*a, **kw)),
+            url=jinja2.pass_context(lambda ctx, *a, **kw: url_to(*a, **kw)),
+            asseturl=jinja2.pass_context(lambda ctx, *a, **kw: get_asset_url(*a, **kw)),
+            markdown=jinja2.pass_context(lambda ctx, *a, **kw: Markdown(*a, **kw)),
         )
         self.jinja_env.globals.update(
             F=F,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "filetype>=1.0.7",
         "Flask",
         "inifile",
-        "Jinja2>=2.11",
+        "Jinja2>=3.0",
         "mistune>=0.7.0,<2",
         "pip",
         "python-slugify",

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,12 +1,36 @@
 import sys
+from html import unescape
+from pathlib import Path
+
+import pytest
 
 
-def test_jinja2_extensions(env):
-    extensions = env.jinja_env.extensions
+@pytest.fixture
+def compile_template(scratch_env):
+    def compile_template(source, name="tmpl.html"):
+        Path(scratch_env.root_path, "templates", name).write_text(source)
+        return scratch_env.jinja_env.get_template(name)
 
-    assert "jinja2.ext.AutoEscapeExtension" in extensions.keys()
-    assert "jinja2.ext.WithExtension" in extensions.keys()
-    assert "jinja2.ext.ExprStmtExtension" in extensions.keys()
+    return compile_template
+
+
+def test_jinja2_feature_autoescape(compile_template):
+    tmpl = compile_template("{{ value }}", "tmpl.html")
+    rendered = tmpl.render(value="<tag>")
+    assert unescape(rendered) == "<tag>"
+    assert "<" not in rendered
+
+
+def test_jinja2_feature_with(compile_template):
+    tmpl = compile_template("{% with x = 'good' %}{{ x }}{% endwith %}")
+    assert tmpl.render() == "good"
+
+
+def test_jinja2_feature_do(compile_template):
+    tmpl = compile_template(
+        "{% set x = ['a'] %}{% do x.append('b') %}{{ x|join('-') }}"
+    )
+    assert tmpl.render() == "a-b"
 
 
 def test_no_reference_cycle_in_environment(project):


### PR DESCRIPTION
The `autoescape` and `with` extensions have been enabled by default since Jinja2 2.9.  Since we currently require Jinja2>=2.11, there is no need to specify these explicitly.  (Doing so now elicits a deprecation warning.)

As of Jinja2>=3.0, `contextfilter` has been deprecated in favor of the new `pass_context` decorator.

It would be possible to check for `pass_context` and fall back to using `contextfilter` if it is not available, however this PR currently just updates our version pins to require Jinja2>=3.  (If this is a problem, let me know.)
