### PR TITLE
Use shutil.get_terminal_size instead of click.get_terminal_size`

### DIFF
--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -35,7 +35,7 @@ class Generator:
         )
         self.options = {}
         # term width in [1, 78]
-        self.term_width = min(max(click.get_terminal_size()[0], 1), 78)
+        self.term_width = min(max(shutil.get_terminal_size()[0], 1), 78)
         self.e = click.secho
         self.w = partial(click.wrap_text, width=self.term_width)
 


### PR DESCRIPTION
`Shutil.get_terminal_size` has been supported since Python 3.3. Since we no longer support Python 2, there's no reason not to use it directly.

`Click.get_terminal_size` has been deprecated (and elicits deprecation warnings) since `click==8.0.0`

