### PR TITLE
Another Flask>=2 deprecation

### DIFF
--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -4,7 +4,7 @@ import sys
 from flask import abort
 from flask import Flask
 from flask import request
-from flask.helpers import safe_join
+from werkzeug.security import safe_join
 from werkzeug.utils import append_slash_redirect
 
 from lektor.admin.modules import register_modules


### PR DESCRIPTION
Use `werkzeug.security.safe_join` in place of `flask.helpers.safe_join`.

`Werkzeug.security.safe_join` has been around for years.  It does the same thing as the flask version except that the Flask version checks for a null return value (indicating unsafe path components) and raises a 404 error.  We already do an equivalent check ([here](https://github.com/lektor/lektor/blob/e197acaed59d44d3cae91e699d00b7ecf8b66500/lektor/admin/modules/serve.py#L154)) so there's no loss at all in switching.