### PR TITLE
Pin pytest-click<1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ tests_require = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
-    "pytest-click",
+    "pytest-click<1",
 ]
 
 setup(


### PR DESCRIPTION
This is a PR for the 3.2-maintenance branch.

I'm not sure whether anyone still cares about the 3.2 branch, but just in case...

Pytest-click>=1.0 does not support python 2.7, so this new pin is needed.

