### PR TITLE
Make dist and unify CI with local tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
           - os: "ubuntu-latest"
             path: ~/.cache/pip
             python: "3.7"
+          - os: "ubuntu-latest"
+            path: ~/.cache/pip
+            python: "3.8"
     steps:
       - uses: actions/checkout@v2
       - name: Cache pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Install node dependencies
-        run: cd lektor/admin && npm ci
+        run: make lektor/admin/node_modules
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
@@ -67,10 +67,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-      - name: Install node dependencies
-        run: cd lektor/admin && npm ci && npm run webpack
+      - name: Build frontend
+        run: make
       - name: Typecheck and run frontend tests
-        run: cd lektor/admin && npx tsc && npm test
+        run: make test-js
 
   ############################################################################
   # Python tests
@@ -115,6 +115,6 @@ jobs:
       - name: Install python dependencies
         run: python -m pip install codecov tox
       - name: Run python tests
-        run: tox -e coverage
+        run: tox -e py
       - name: Publish coverage
         run: codecov -t 39974034-91d8-48d1-9698-de48e0667a09

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,58 +43,11 @@ jobs:
         run: pre-commit run -a
 
   ############################################################################
-  # Smoke tests
-  ############################################################################
-  linux-smoke-node:
-    name: ubuntu-latest node${{ matrix.node }} smoke test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ["16"]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
-      - name: Install node dependencies
-        run: cd lektor/admin && npm ci && npm run webpack
-      - name: Typecheck and run frontend tests
-        run: cd lektor/admin && npx tsc && npm test
-
-  linux-smoke-py:
-    name: ubuntu-latest py${{ matrix.python }} smoke test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('**/setup.py') }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install python dependencies
-        run: python -m pip install codecov tox
-      - name: Run python tests
-        run: tox -e coverage
-      - name: Publish coverage
-        run: codecov -t 39974034-91d8-48d1-9698-de48e0667a09
-
-  ############################################################################
   # Node tests
   ############################################################################
   node:
     name: ${{ matrix.os}} node${{ matrix.node }}
     runs-on: ${{ matrix.os }}
-    needs: linux-smoke-node
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +55,8 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         include:
           - node: "12"
+            os: "ubuntu-latest"
+          - node: "16"
             os: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -121,7 +76,6 @@ jobs:
   python-tests:
     name: ${{ matrix.os }} py${{ matrix.python }}
     runs-on: ${{ matrix.os }}
-    needs: linux-smoke-py
     strategy:
       fail-fast: false
       matrix:
@@ -137,9 +91,6 @@ jobs:
           - os: "ubuntu-latest"
             path: ~/.cache/pip
             python: "3.7"
-        exclude:
-          - os: "ubuntu-latest"
-            python: "3.9"
     steps:
       - uses: actions/checkout@v2
       - name: Cache pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - master
+      - "*-maintenance"
   pull_request:
     branches:
       - master
+      - "*-maintenance"
 
 jobs:
   ############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install python dependencies
-        run: python -m pip install tox pre-commit
+        run: python -m pip install tox
       - name: Run pylint
         run: tox -e lint
       - name: Run pre-commit
-        run: pre-commit run -a
+        uses: pre-commit/action@v2.0.3
 
   ############################################################################
   # Node tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,9 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install python dependencies
-        run: python -m pip install --editable .[test]
-      - name: Show python environment
-        run: python -m pip list
+        run: python -m pip install tox pre-commit
       - name: Run pylint
-        run: pylint lektor
+        run: tox -e lint
       - name: Run pre-commit
         run: pre-commit run -a
 
@@ -84,11 +82,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install python dependencies
-        run: python -m pip install --editable .[test] codecov
-      - name: Show python environment
-        run: python -m pip list
+        run: python -m pip install codecov tox
       - name: Run python tests
-        run: pytest . --tb=long -svv --cov=lektor
+        run: tox -e coverage
       - name: Publish coverage
         run: codecov -t 39974034-91d8-48d1-9698-de48e0667a09
 
@@ -161,10 +157,8 @@ jobs:
         if: startsWith(runner.os, 'windows')
         run: choco install --no-progress --timeout 600 imagemagick.tool ffmpeg
       - name: Install python dependencies
-        run: python -m pip install --editable .[test] codecov
-      - name: Show python environment
-        run: python -m pip list
+        run: python -m pip install codecov tox
       - name: Run python tests
-        run: pytest . --tb=long -svv --cov=lektor
+        run: tox -e coverage
       - name: Publish coverage
         run: codecov -t 39974034-91d8-48d1-9698-de48e0667a09

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install macOS system dependencies
-        if: startsWith(runner.os, 'macos')
+        if: startsWith(runner.os, 'macos') && matrix.python == '3.9'
         run: brew install imagemagick ffmpeg
       - name: Install Windows system dependencies
-        if: startsWith(runner.os, 'windows')
+        if: startsWith(runner.os, 'windows') && matrix.python == '3.9'
         run: choco install --no-progress --timeout 600 imagemagick.tool ffmpeg
       - name: Install python dependencies
         run: python -m pip install codecov tox

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ lint:
 .PHONY: test
 test: lint test-python test-js
 
+.PHONY: test-all
+# Run tests on all supported Python versions.
+test-all: lint test-js
+	tox -e py36
+	tox -e py37
+	tox -e py38
+	tox -e py39
+
 # This creates source distribution and a wheel.
 dist: build-js setup.cfg setup.py MANIFEST.in
 	python setup.py sdist bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test-python:
 # Run tests on the Frontend code.
 test-js: lektor/admin/node_modules
 	@echo "---> running javascript tests"
+	@cd lektor/admin; npx tsc
 	@cd lektor/admin; npm test
 
 .PHONY: lint
@@ -31,11 +32,9 @@ test: lint test-python test-js
 
 .PHONY: test-all
 # Run tests on all supported Python versions.
-test-all: lint test-js
-	tox -e py36
-	tox -e py37
-	tox -e py38
-	tox -e py39
+test-all: test-js
+	pre-commit run -a
+	tox
 
 # This creates source distribution and a wheel.
 dist: build-js setup.cfg setup.py MANIFEST.in

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all: build-js
 
+.PHONY: build-js
 build-js: lektor/admin/node_modules
 	@echo "---> building static files"
 	@cd lektor/admin; npm run webpack
@@ -9,37 +10,19 @@ lektor/admin/node_modules: lektor/admin/package-lock.json
 	@cd lektor/admin; npm install
 	@touch -m lektor/admin/node_modules
 
-pex:
-	virtualenv pex-build-cache
-	pex-build-cache/bin/pip install --upgrade pip
-	pex-build-cache/bin/pip install pex requests wheel
-	pex-build-cache/bin/pip wheel -w pex-build-cache/wheelhouse .
-	pex-build-cache/bin/pex \
-		-v -o lektor.pex -e lektor.cli:cli \
-		-f pex-build-cache/wheelhouse \
-		--disable-cache \
-		--not-zip-safe Lektor
-	rm -rf pex-build-cache
-
+# Lint and run tests on Python files.
 test-python:
 	@echo "---> running python tests"
-	pylint lektor
-	pytest . --tb=long -vv --cov=lektor
+	tox -e lint
+	tox -e coverage
 
-coverage-python: test-python
-	coverage xml
-
-test-js: build-js
+# Lint and run tests on the Frontend code.
+test-js: lektor/admin/node_modules
 	@echo "---> running javascript tests"
 	@cd lektor/admin; npm run lint
 	@cd lektor/admin; npm test
 
-coverage-js: test-js
-	@cd lektor/admin; npm run report-coverage
-
 test: test-python test-js
-
-coverage: coverage-python coverage-js
 
 # This creates source distribution and a wheel.
 dist: build-js setup.cfg setup.py MANIFEST.in

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,13 @@ coverage-js: test-js
 test: test-python test-js
 
 coverage: coverage-python coverage-js
+
+# This creates source distribution and a wheel.
+dist: build-js setup.cfg setup.py MANIFEST.in
+	python setup.py sdist bdist_wheel
+
+# Before making a release, CHANGES.md needs to be updated and
+# a tag should be created (and pushed with `git push --tags`).
+.PHONY: upload
+upload: dist
+	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,25 @@ lektor/admin/node_modules: lektor/admin/package-lock.json
 	@cd lektor/admin; npm install
 	@touch -m lektor/admin/node_modules
 
-# Lint and run tests on Python files.
+# Run tests on Python files.
 test-python:
 	@echo "---> running python tests"
 	tox -e lint
 	tox -e coverage
 
-# Lint and run tests on the Frontend code.
+# Run tests on the Frontend code.
 test-js: lektor/admin/node_modules
 	@echo "---> running javascript tests"
-	@cd lektor/admin; npm run lint
 	@cd lektor/admin; npm test
 
-test: test-python test-js
+.PHONY: lint
+# Lint code.
+lint:
+	pre-commit run -a
+	tox -e lint
+
+.PHONY: test
+test: lint test-python test-js
 
 # This creates source distribution and a wheel.
 dist: build-js setup.cfg setup.py MANIFEST.in

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ lektor/admin/node_modules: lektor/admin/package-lock.json
 # Run tests on Python files.
 test-python:
 	@echo "---> running python tests"
-	tox -e lint
-	tox -e coverage
+	tox -e py
 
 # Run tests on the Frontend code.
 test-js: lektor/admin/node_modules

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import os
 import re
 import warnings
 
+from markers import imagemagick
+
 from lektor.cli import cli
 
 
@@ -14,6 +16,7 @@ def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
     assert result.exit_code == 1
 
 
+@imagemagick
 def test_build_continue_in_existing_nonempty_dir(project_cli_runner):
     os.mkdir("build_dir")
     with open("build_dir/test", "w"):
@@ -55,6 +58,7 @@ def test_build_no_project(isolated_cli_runner):
     assert "Could not automatically discover project." in result.output
 
 
+@imagemagick
 def test_build(project_cli_runner):
     result = project_cli_runner.invoke(cli, ["build"])
     assert (

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,6 +5,7 @@ from hashlib import md5
 from io import BytesIO
 
 import pytest
+from markers import imagemagick
 
 from lektor.imagetools import compute_dimensions
 from lektor.imagetools import get_image_info
@@ -154,6 +155,7 @@ def test_thumbnail_dimensions_reported(builder):
         assert '<img src="%s" width="%s" height="%s">' % (t, w, h) in html
 
 
+@imagemagick
 def test_thumbnail_dimensions_real(builder):
     builder.build_all()
     for t, dimensions in _THUMBNAILS.items():
@@ -163,6 +165,7 @@ def test_thumbnail_dimensions_real(builder):
             assert (width, height) == dimensions
 
 
+@imagemagick
 def test_thumbnails_similar(builder):
     builder.build_all()
     hashes = []
@@ -174,6 +177,7 @@ def test_thumbnails_similar(builder):
         assert hashes[i] == hashes[0]
 
 
+@imagemagick
 def test_thumbnails_differing(builder):
     builder.build_all()
     hashes = []
@@ -185,6 +189,7 @@ def test_thumbnails_differing(builder):
         assert hashes[i] != hashes[0]
 
 
+@imagemagick
 def test_thumbnail_quality(builder):
     builder.build_all()
     image_file = os.path.join(builder.destination_path, "test@192x256_q20.jpg")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3
-envlist = lint,py
+envlist = lint,py36,py37,py38,py39
 
 [testenv]
 commands = pytest --cov={envsitepackagesdir}/lektor {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,26 @@
 [tox]
 minversion = 3
-envlist = lint, py
+envlist = lint,py
 
 [testenv]
-extras = test
-commands = pytest {posargs:tests}
+commands = pytest --cov={envsitepackagesdir}/lektor {posargs:tests}
 passenv = USERNAME
-
-[testenv:coverage]
-deps = coverage
-commands =
-	pytest --cov={envsitepackagesdir}/lektor tests
+deps =
+    pytest
+    pytest-click
+    pytest-cov
+    pytest-mock
 
 [coverage:paths]
 # Coverage is picked on the code in the virtual env created by tox.
 # This setting declares that path equivalent to the one in the src dir.
 paths =
 	lektor
-	.tox/coverage/*/lektor
+	.tox/py/*/lektor
 
 [testenv:lint]
-# NB: (Pinned) pylint is installed as part of the lektor[test] extras
+deps =
+    pylint==2.7
+    pytest
 commands =
     pylint {posargs:lektor setup.py tests}

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = lint, py
 [testenv]
 extras = test
 commands = pytest {posargs:tests}
+passenv = USERNAME
 
 [testenv:coverage]
 deps = coverage


### PR DESCRIPTION
This adds a `dist`  make target which will build both a source distribution and a wheel to automate most of the distribution-creating part of the release process.

I'll also try to unify local tests (with tox) and the tests that are run in CI (to now also use tox), so that reproducing CI failures should be more reproducible.