### PR TITLE
Use setuptools-scm to deduce distribution version and PEP-517-ify the packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
         if: startsWith(runner.os, 'windows') && matrix.python == '3.9'
         run: choco install --no-progress --timeout 600 imagemagick.tool ffmpeg
         continue-on-error: true
+      - name: Workaround for UnicodeDecodeError from tox on Windows
+        # Refs:
+        #   https://github.com/lektor/lektor/pull/933#issuecomment-923107580
+        #   https://github.com/tox-dev/tox/issues/1550
+        if: startsWith(runner.os, 'windows')
+        shell: bash
+        run: echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
       - name: Install python dependencies
         run: python -m pip install codecov tox
       - name: Run python tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,71 @@
+[metadata]
+name = Lektor
+description = A static content management system.
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = BSD
+platforms = any
+author = Armin Ronacher
+author_email = armin.ronacher@active-4.com
+url = http://github.com/lektor/lektor/
+classifiers =
+    Framework :: Lektor
+    Environment :: Web Environment
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Internet :: WWW/HTTP :: Dynamic Content
+    Topic :: Software Development :: Libraries :: Python Modules
+requires = setuptools_scm
+
+[options]
+packages = find:
+include_package_data = True
+zip_safe = False
+python_requires = >=3.6
+install_requires =
+    Babel
+    click>=6.0
+    EXIFRead
+    filetype>=1.0.7
+    Flask
+    inifile
+    Jinja2>=3.0
+    mistune>=0.7.0,<2
+    pip
+    python-slugify
+    requests[security]
+    setuptools
+    watchdog
+    Werkzeug<3
+setup_requires =
+    # XXX: b/c: This duplicates config in pyproject.toml and is only
+    # used when running the stub setup.py directly
+    setuptools >= 45
+    setuptools_scm >= 6
+
+[options.extras_require]
+ipython =
+    ipython
+# XXX: the [test] extras is deprecated
+# Ref: https://github.com/lektor/lektor/pull/931#issuecomment-911879538
+test =
+    pre-commit
+    pylint==2.7.0
+    pytest
+    pytest-cov
+    pytest-mock
+    pytest-click
+
+[options.entry_points]
+console_scripts = 
+    lektor = lektor.cli:main
+
 [flake8]
 ignore=E203,F403,E128,E126,E123,E121,E265,E501,N802,N803,N806,C901,D100,D102,D102,D10,W503,E731,E402,E741

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,3 @@ test =
 [options.entry_points]
 console_scripts = 
     lektor = lektor.cli:main
-
-[flake8]
-ignore=E203,F403,E128,E126,E123,E121,E265,E501,N802,N803,N806,C901,D100,D102,D102,D10,W503,E731,E402,E741

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,15 +52,6 @@ setup_requires =
 [options.extras_require]
 ipython =
     ipython
-# XXX: the [test] extras is deprecated
-# Ref: https://github.com/lektor/lektor/pull/931#issuecomment-911879538
-test =
-    pre-commit
-    pylint==2.7.0
-    pytest
-    pytest-cov
-    pytest-mock
-    pytest-click
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.9
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
-requires = setuptools_scm
 
 [options]
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -1,74 +1,18 @@
-import io
-
-from setuptools import find_packages
+# Stub setup.py.
+#
+# XXX: This is deprecated in favor of PEP-517-aware tools and should probably be deleted.
+#
+# The canonical way to build an sdist and wheel is now:
+#
+#     pip install build
+#     python -m build
+#
+# NB: Recent versions of pip are PEP-517-aware so that:
+#
+#     pip install -e .
+#
+# will work fine without this stub.
+#
 from setuptools import setup
 
-with io.open("README.md", "rt", encoding="utf8") as f:
-    readme = f.read()
-
-tests_require = [
-    "pre-commit",
-    "pylint==2.7.0",
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-click",
-]
-
-setup(
-    name="Lektor",
-    use_scm_version=True,
-    url="http://github.com/lektor/lektor/",
-    description="A static content management system.",
-    long_description=readme,
-    long_description_content_type="text/markdown",
-    license="BSD",
-    author="Armin Ronacher",
-    author_email="armin.ronacher@active-4.com",
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    platforms="any",
-    python_requires=">=3.6",
-    setup_requires=["setuptools_scm"],
-    install_requires=[
-        "Babel",
-        "click>=6.0",
-        "EXIFRead",
-        "filetype>=1.0.7",
-        "Flask",
-        "inifile",
-        "Jinja2>=3.0",
-        "mistune>=0.7.0,<2",
-        "pip",
-        "python-slugify",
-        "requests[security]",
-        "setuptools",
-        "watchdog",
-        "Werkzeug<3",
-    ],
-    tests_require=tests_require,
-    extras_require={
-        "ipython": ["ipython"],
-        "test": tests_require,
-    },
-    classifiers=[
-        "Framework :: Lektor",
-        "Environment :: Web Environment",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    entry_points="""
-        [console_scripts]
-        lektor=lektor.cli:main
-    """,
-)
+setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ tests_require = [
 
 setup(
     name="Lektor",
-    version="4.0.dev",
+    use_scm_version=True,
     url="http://github.com/lektor/lektor/",
     description="A static content management system.",
     long_description=readme,
@@ -30,6 +30,7 @@ setup(
     zip_safe=False,
     platforms="any",
     python_requires=">=3.6",
+    setup_requires=["setuptools_scm"],
     install_requires=[
         "Babel",
         "click>=6.0",

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,11 @@ commands =
     pylint {posargs:lektor setup.py tests}
 
 [flake8]
+max-line-length = 100
 ignore =
     # E203: Whitespace before ':'
     E203,
     # E402: Module level import not at top of file
     E402,
-    # E501: Line too long
-    E501,
     # W503: Line break occurred before a binary operator
     W503

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,48 @@ deps =
     pytest
 commands =
     pylint {posargs:lektor setup.py tests}
+
+[flake8]
+ignore =
+    # C901: Function is too complex
+    C901,
+    # E121: Continuation line under-indented for hanging indent
+    E121,
+    # E123: Closing bracket does not match indentation of opening bracket's line
+    E123,
+    # E126: Continuation line over-indented for hanging indent
+    E126,
+    # E128: Continuation line under-indented for visual indent
+    E128,
+    # E203: Whitespace before ':'
+    E203,
+    # E265: Block comment should start with '# ' 
+    E265,
+    # E402: Module level import not at top of file
+    E402,
+    # E501: Line too long
+    E501,
+    # E731: Do not assign a lambda expression, use a def
+    E731,
+    # E741: Do not use variables named 'I', 'O', or 'l'
+    E741,
+    # F403: 'from module import *' used; unable to detect undefined names
+    F403,
+    # W503: Line break occurred before a binary operator
+    W503,
+
+    # D*** are from flake8-docstrings (pydocstyle) plugin
+    # D100: Missing docstring in public module
+    D100,
+    # D102: Missing docstring in public method
+    D102,
+    # D10??  I think this is a typo
+    D10,
+    
+    # N*** are from pep8-naming plugin
+    # N802: function name should be lowercase
+    N802,
+    # N803: argument name should be lowercase
+    N803,
+    # N806: variable in function should be lowercase
+    N806

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     pylint {posargs:lektor setup.py tests}
 
 [flake8]
-max-line-length = 100
+max-line-length = 91
 extend-ignore =
     # E203: Whitespace before ':'
     E203,

--- a/tox.ini
+++ b/tox.ini
@@ -27,29 +27,11 @@ commands =
 
 [flake8]
 ignore =
-    # C901: Function is too complex
-    C901,
-    # E121: Continuation line under-indented for hanging indent
-    E121,
-    # E123: Closing bracket does not match indentation of opening bracket's line
-    E123,
-    # E126: Continuation line over-indented for hanging indent
-    E126,
-    # E128: Continuation line under-indented for visual indent
-    E128,
     # E203: Whitespace before ':'
     E203,
-    # E265: Block comment should start with '# ' 
-    E265,
     # E402: Module level import not at top of file
     E402,
     # E501: Line too long
     E501,
-    # E731: Do not assign a lambda expression, use a def
-    E731,
-    # E741: Do not use variables named 'I', 'O', or 'l'
-    E741,
-    # F403: 'from module import *' used; unable to detect undefined names
-    F403,
     # W503: Line break occurred before a binary operator
     W503

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,8 @@ commands =
 
 [flake8]
 max-line-length = 100
-ignore =
+extend-ignore =
     # E203: Whitespace before ':'
     E203,
     # E402: Module level import not at top of file
-    E402,
-    # W503: Line break occurred before a binary operator
-    W503
+    E402

--- a/tox.ini
+++ b/tox.ini
@@ -54,14 +54,6 @@ ignore =
     # W503: Line break occurred before a binary operator
     W503,
 
-    # D*** are from flake8-docstrings (pydocstyle) plugin
-    # D100: Missing docstring in public module
-    D100,
-    # D102: Missing docstring in public method
-    D102,
-    # D10??  I think this is a typo
-    D10,
-    
     # N*** are from pep8-naming plugin
     # N802: function name should be lowercase
     N802,

--- a/tox.ini
+++ b/tox.ini
@@ -52,12 +52,4 @@ ignore =
     # F403: 'from module import *' used; unable to detect undefined names
     F403,
     # W503: Line break occurred before a binary operator
-    W503,
-
-    # N*** are from pep8-naming plugin
-    # N802: function name should be lowercase
-    N802,
-    # N803: argument name should be lowercase
-    N803,
-    # N806: variable in function should be lowercase
-    N806
+    W503


### PR DESCRIPTION
Instead of hardcoding the distribution version in `setup.py`, use [setuptools-scm](https://github.com/pypa/setuptools_scm/) to deduce the version automatically (from git tags).

This will help with our move towards automatic tag-to-release CI (per discussion in #724.)

## Questions

Should we PEP-517ize, too?  (I.e. add a `pyproject.toml` and convert `setup.py` to `setup.cfg`?)
(I think we should.  I will work on that...)
