### PR TITLE
frontend: require at least node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
         node: ["14"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         include:
-          - node: "12"
-            os: "ubuntu-latest"
           - node: "16"
             os: "ubuntu-latest"
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![PyPI version](https://badge.fury.io/py/Lektor.svg)](https://pypi.org/project/Lektor/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/Lektor.svg)](https://pypi.org/project/Lektor/)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-<img alt="node:?" src="https://img.shields.io/badge/node-%3E=8-blue.svg"/>
 [![Join the chat at https://gitter.im/lektor/lektor](https://badges.gitter.im/lektor/lektor.svg)](https://gitter.im/lektor/lektor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Lektor is a static website generator. It builds out an entire project

--- a/lektor/admin/package-lock.json
+++ b/lektor/admin/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "lektor",
-      "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
         "@openfonts/roboto-slab_all": "^1.0.1"
@@ -51,6 +50,9 @@
         "typescript": "^4.1.3",
         "webpack": "^5.21.1",
         "webpack-cli": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/lektor/admin/package.json
+++ b/lektor/admin/package.json
@@ -1,7 +1,10 @@
 {
   "name": "lektor",
-  "version": "0.0.0",
+  "license": "ISC",
   "private": true,
+  "engines": {
+    "node": ">=14"
+  },
   "dependencies": {
     "@openfonts/roboto-slab_all": "^1.0.1"
   },
@@ -93,7 +96,5 @@
     "require": [
       "./babel-require.js"
     ]
-  },
-  "author": "",
-  "license": "ISC"
+  }
 }


### PR DESCRIPTION
Only test on node 14 (and also 16 on linux). The node 12 tests on Windows were disabled a while ago due to some intermittent failures, so it's better to just bump the requirement in general. The `engines` setting in package.json should result in a warning/error on older node versions.

Also, remove the (very outdated) node badge from the README, I find it odd to list it there since it's just a build dependency basically.