### PR TITLE
Support newer mistune versions in addition to older ones

### DIFF
--- a/lektor/markdown.py
+++ b/lektor/markdown.py
@@ -11,7 +11,7 @@ from lektor.context import get_ctx
 
 _markdown_cache = threading.local()
 
-_old_mistune = int(mistune.__version__.split('.')[0]) < 2
+_old_mistune = int(mistune.__version__.split('.', maxsplit=1)[0]) < 2
 
 if _old_mistune:
     from mistune import Renderer as BaseRenderer
@@ -20,7 +20,7 @@ else:
 
 
 class ImprovedRenderer(BaseRenderer):
-    def link(self, link, text=None, title=None):  # pylint: disable=arguments-differ
+    def link(self, link, text=None, title=None):  # pylint: disable=arguments-differ, arguments-renamed
         if _old_mistune:
             (title, text) = (text, title)
         if self.record is not None:
@@ -33,7 +33,7 @@ class ImprovedRenderer(BaseRenderer):
         title = escape(title)
         return '<a href="%s" title="%s">%s</a>' % (link, title, text)
 
-    def image(self, src, alt="", title=None):  # pylint: disable=arguments-differ
+    def image(self, src, alt="", title=None):  # pylint: disable=arguments-differ, arguments-renamed
         if _old_mistune:
             (title, alt) = (alt, title)
         if self.record is not None:

--- a/lektor/markdown.py
+++ b/lektor/markdown.py
@@ -16,11 +16,11 @@ _old_mistune = int(mistune.__version__.split('.')[0]) < 2
 if _old_mistune:
     from mistune import Renderer as BaseRenderer
 else:
-    from mistune import HTMLRenderer as BaseRenderer
+    from mistune import HTMLRenderer as BaseRenderer  # pylint: disable=no-name-in-module
 
 
 class ImprovedRenderer(BaseRenderer):
-    def link(self, link, text=None, title=None):
+    def link(self, link, text=None, title=None):  # pylint: disable=arguments-differ
         if _old_mistune:
             (title, text) = (text, title)
         if self.record is not None:
@@ -33,7 +33,7 @@ class ImprovedRenderer(BaseRenderer):
         title = escape(title)
         return '<a href="%s" title="%s">%s</a>' % (link, title, text)
 
-    def image(self, src, alt="", title=None):
+    def image(self, src, alt="", title=None):  # pylint: disable=arguments-differ
         if _old_mistune:
             (title, alt) = (alt, title)
         if self.record is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     Flask
     inifile>=0.4.1
     Jinja2>=3.0
-    mistune<3.0
+    mistune>=0.7.0,<3.0
     pip
     python-slugify
     requests[security]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     Flask
     inifile>=0.4.1
     Jinja2>=3.0
-    mistune>=0.7.0,<2
+    mistune<3.0
     pip
     python-slugify
     requests[security]


### PR DESCRIPTION
### Description of Changes

It looks like lepture has been busy and mistune 2.0.0 is about to be
released, there is already some software that depends on its alpha/rc
versions and rather than backporting that, it makes more sense to
prepare Lektor to be compatible with the newer version.

This patch aims to introduce minimal changes to achieve that while
keeping compatibility with mistune 0.8.X.


As a curiosity and the reason why I personally am interested in upstreaming these changes is being able to use [md2gemini](https://github.com/makeworld-the-better-one/md2gemini/) from Lektor with a plugin I just published today: https://pypi.org/project/lektor-gemini-capsule/ which effectively turns Lektor into a dual format (HTML and Gemini) publishing software.

With this patch it works wonders!
