### PR TITLE
Fix the 3.2.x branch under python 2.7

### DIFF
--- a/lektor/_compat.py
+++ b/lektor/_compat.py
@@ -37,6 +37,8 @@ if PY2:
         "def reraise(tp, value, tb=None):\n raise tp, value, tb"
     )
 
+    from werkzeug.posixemulation import rename as os_replace  # noqa
+
 
 else:
     unichr = chr
@@ -58,6 +60,8 @@ else:
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
         raise value
+
+    from os import replace as os_replace  # noqa
 
 
 def python_2_unicode_compatible(klass):

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -14,6 +14,7 @@ from itertools import chain
 import click
 
 from lektor._compat import iteritems
+from lektor._compat import os_replace
 from lektor._compat import PY2
 from lektor._compat import text_type
 from lektor.build_programs import builtin_build_programs
@@ -928,7 +929,7 @@ class Artifact(object):
                 op(con)
 
             if self._new_artifact_file is not None:
-                os.replace(self._new_artifact_file, self.dst_filename)
+                os_replace(self._new_artifact_file, self.dst_filename)
                 self._new_artifact_file = None
 
             if con is not None:

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -41,6 +41,7 @@ from lektor._compat import (
     string_types,
     text_type,
     range_type,
+    os_replace,
 )
 from lektor.uilink import BUNDLE_BIN_PATH, EXTRA_PATHS
 
@@ -498,7 +499,7 @@ def atomic_open(filename, mode="r"):
     else:
         f.close()
         if tmp_filename is not None:
-            os.replace(tmp_filename, filename)
+            os_replace(tmp_filename, filename)
 
 
 def portable_popen(cmd, *args, **kwargs):


### PR DESCRIPTION
### Issue(s) Resolved

Release 3.2.2 does not run under python 2.7.  (It was broken by commit e9c9b546b.)
The issue is that  `os.replace` does not exist for python < 3.3.

### Description of Changes

This patch continues to use `os.replace` (as done in e9c9b546b) for py3, but falls back to using `werkzeug.posixemulation.rename` for py2. `Werkzeug.posixemulation` does not exist in the latest (2.x) werkzeug, however, since werkzeug 2.x is py3k-only, we're guarateed werkzeug<2 when running under py2.