### PR TITLE
Paginated pages should have at least one page, even when childless

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
   upscaling behavior in cases that do not involve upscaling. [#885][]
 - Fix bug with translation fallback of record label. [#897][]
 
+#### Data Modelling
+
+- Fixed pagination issue which caused child-less paginated pages to
+  not be built. [#952][]
+
 #### Publisher
 
 - Allow rsync deployment to a local path. [#830][]
@@ -196,6 +201,7 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
 [#926]: https://github.com/lektor/lektor/pull/926
 [#927]: https://github.com/lektor/lektor/pull/927
 [#934]: https://github.com/lektor/lektor/pull/934
+[#952]: https://github.com/lektor/lektor/pull/952
 
 ## 3.2.2 (2021-09-18)
 

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -1,5 +1,4 @@
 import errno
-import math
 import os
 
 from inifile import IniFile
@@ -69,7 +68,9 @@ class PaginationConfig:
     def count_pages(self, record):
         """Returns the total number of pages for the children of a record."""
         total = self.count_total_items(record)
-        return int(math.ceil(total / float(self.per_page)))
+        npages = (total + self.per_page - 1) // self.per_page
+        # Even when there are no children, we want at least one page
+        return max(npages, 1)
 
     def slice_query_for_page(self, record, page):
         """Slices the query so it returns the children for a given page."""

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -54,6 +54,11 @@ class PaginationConfig:
         self.enabled = enabled
         if per_page is None:
             per_page = 20
+        elif not isinstance(per_page, int):
+            raise TypeError(f"per_page must be an int or None, not {per_page!r}")
+        if per_page <= 0:
+            raise ValueError("per_page must be positive, not {per_page}")
+
         self.per_page = per_page
         if url_suffix is None:
             url_suffix = "page"

--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -1,6 +1,3 @@
-from math import ceil
-
-
 class Pagination:
     def __init__(self, record, pagination_config):
         #: the pagination config
@@ -22,11 +19,13 @@ class Pagination:
     @property
     def pages(self):
         """The total number of pages."""
-        if self.per_page == 0:
+        if self.per_page <= 0:
+            # XXX: What does per_page = 0 mean? Should this trigger an error?
             pages = 0
         else:
-            pages = int(ceil(self.total / float(self.per_page)))
-        return pages
+            pages = (self.total + self.per_page - 1) // self.per_page
+        # Even when there are no children, we want at least one page
+        return max(pages, 1)
 
     @property
     def prev_num(self):

--- a/lektor/pagination.py
+++ b/lektor/pagination.py
@@ -19,11 +19,7 @@ class Pagination:
     @property
     def pages(self):
         """The total number of pages."""
-        if self.per_page <= 0:
-            # XXX: What does per_page = 0 mean? Should this trigger an error?
-            pages = 0
-        else:
-            pages = (self.total + self.per_page - 1) // self.per_page
+        pages = (self.total + self.per_page - 1) // self.per_page
         # Even when there are no children, we want at least one page
         return max(pages, 1)
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -5,6 +5,7 @@ import pytest
 
 from lektor.datamodel import ChildConfig
 from lektor.datamodel import DataModel
+from lektor.datamodel import PaginationConfig
 from lektor.reporter import BufferReporter
 
 
@@ -19,6 +20,19 @@ def datamodel(env, slug_format):
     name_i18n = {"en": "test"}
     child_config = ChildConfig(slug_format=slug_format)
     return DataModel(env, id_, name_i18n, child_config=child_config)
+
+
+@pytest.mark.parametrize(
+    "per_page, expected",
+    [
+        (-1, ValueError),
+        (-1.5, TypeError),
+        ("5", TypeError),
+    ],
+)
+def test_PaginationConfig_init_raises_on_invalid_per_page(env, per_page, expected):
+    with pytest.raises(expected):
+        PaginationConfig(env, per_page=per_page)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_410.py
+++ b/tests/test_issue_410.py
@@ -1,0 +1,45 @@
+"""Test for issue `#410`_.
+
+This tests for at least one of the bugs reported in `#410`_, namely
+ that paginated pages were not being built if they had no children.
+
+.. _#410: https://github.com/lektor/lektor/issues/410
+
+"""
+import os
+
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(True, id="paginated"),
+        pytest.param(False, id="non-paginated"),
+    ]
+)
+def scratch_project_data(scratch_project_data, request):
+    # Specialize the inherited scratch project (from conftest.py)
+    # by (possibly) enabling pagination for models/page.ini.
+    is_paginated = request.param
+    page_ini = scratch_project_data.join("models", "page.ini")
+    if is_paginated:
+        page_ini.write_text(
+            "\n".join(
+                [
+                    page_ini.read_text("utf-8"),
+                    "[pagination]",
+                    "enabled = yes",
+                    "",
+                ]
+            ),
+            "utf-8",
+        )
+    return scratch_project_data
+
+
+def test_build_childless_page(scratch_builder):
+    # Test that a basic childless page gets built (whether it is
+    # paginated or not)
+    scratch_builder.build_all()
+    index_html = os.path.join(scratch_builder.destination_path, "index.html")
+    assert os.path.exists(index_html)


### PR DESCRIPTION
### Issue(s) Resolved

Pages with pagination enabled that do not have children are not being generated.

Fixes at least part of what's reported on #410.

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

The current pagination logic for determining the number of pages of a paginated page that are required reports that zero pages are required if the page has no children.  This causes zero pages of the paginated page to be generated.

This fixes the page-counting logic so that it always returns, at minimum, a page count of one, even when there are no children.

### Tasks (still to do)

- [x] Added a unit test exercising the bug that is being fixed
- [x] Added unit test(s) covering the changes (if testable)

