### PR TITLE
Problems with `Page.source_filename`, `Page.iter_source_filenames` with alternatives are enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,12 +25,9 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
 
 ##### Dependency Tracking
 
-- Add new `_source_alts` system field. This contains a `stringlist` of
-  all alts for which there is an actually existing `.lr`
-  file. [#959][]
-- Deprecate the `_source_alt` system field. (Use `_source_alts`
-  instead — the value of `_source_alt` should always be equal to the
-  first entry in `_source_alts`.) [#959][]
+- Add new `_source_filenames` system field. This contains a `stringlist` of
+  the filesystem paths to all of the `.lr` files which are contributing to this
+  data record. (This only lists existing files.) [#959][]
 - Fix `Page.source_filename` so
   that it always returns the name of an actually existing source
   file. Previously, for a page with an _alt_ set, `source_filename`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
   of those pages. [#959][]
 - Fix `VirtualSourceObject.iter_source_filenames`
   to return the source filenames of the underlying record. [#959][]
+- Change `VirtualSourceObject.get_checksum` return value. It used to
+  return a concatenation of all the source filenames and their
+  checksums. Now we return the SHA1 hash of that
+  concatenation. [#959][]
 
 #### Data Modelling
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,31 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
   upscaling behavior in cases that do not involve upscaling. [#885][]
 - Fix bug with translation fallback of record label. [#897][]
 
+##### Dependency Tracking
+
+- Add new `_source_alts` system field. This contains a `stringlist` of
+  all alts for which there is an actually existing `.lr`
+  file. [#959][]
+- Deprecate the `_source_alt` system field. (Use `_source_alts`
+  instead — the value of `_source_alt` should always be equal to the
+  first entry in `_source_alts`.) [#959][]
+- Fix `Page.source_filename` so
+  that it always returns the name of an actually existing source
+  file. Previously, for a page with an _alt_ set, `source_filename`
+  was returning the name corresponding to the alt-specific `.lr` file
+  (e.g. `contents+de.lr`) even if no such file existed. [#959][]
+- Fix `Page.iter_source_filenames` so
+  that it only returns the names of actually existing source
+  files. [#959][]
+- Similarly, fix `Attachment.source_filename` and
+  `Attachment.iter_source_filenames` to only return the names of
+  existing source files. [#959][]
+- Fix `Siblings.iter_source_filenames` so that it returns all
+  sources of the previous and next pages, not just the primary sources
+  of those pages. [#959][]
+- Fix `VirtualSourceObject.iter_source_filenames`
+  to return the source filenames of the underlying record. [#959][]
+
 #### Data Modelling
 
 - Fixed pagination issue which caused child-less paginated pages to
@@ -214,6 +239,7 @@ It has been rewritten in Typescript, and updated to use v5 of the Bootstrap CSS 
 [#942]: https://github.com/lektor/lektor/pull/942
 [#945]: https://github.com/lektor/lektor/pull/945
 [#952]: https://github.com/lektor/lektor/pull/952
+[#959]: https://github.com/lektor/lektor/pull/959
 
 ## 3.2.3 (2021-12-11)
 

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -42,6 +42,9 @@ class Asset(SourceObject):
         self.name = name
         self.parent = parent
 
+    def iter_source_filenames(self):
+        yield self.source_filename
+
     @property
     def url_name(self):
         name = self.name

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -704,7 +704,12 @@ add_system_field("_gid", type="string")
 # The alt key that identifies this record
 add_system_field("_alt", type="string")
 
+# The alt keys for the .lr files that were actually referenced.
+add_system_field("_source_alts", type="strings")
+
 # The alt key for the file that was actually referenced.
+# Deprecated: This is equal to the first string in the _source_alts field,
+# or `None` if _source_alts is empty.
 add_system_field("_source_alt", type="string")
 
 # the model that defines the data of the record

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -704,12 +704,10 @@ add_system_field("_gid", type="string")
 # The alt key that identifies this record
 add_system_field("_alt", type="string")
 
-# The alt keys for the .lr files that were actually referenced.
-add_system_field("_source_alts", type="strings")
+# The filenames for the .lr files that contain the record's data
+add_system_field("_source_filenames", type="strings")
 
 # The alt key for the file that was actually referenced.
-# Deprecated: This is equal to the first string in the _source_alts field,
-# or `None` if _source_alts is empty.
 add_system_field("_source_alt", type="string")
 
 # the model that defines the data of the record

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -101,14 +101,6 @@ def _require_ctx(record):
     return ctx
 
 
-def _is_content_file(filename, alt=PRIMARY_ALT):
-    if filename == "contents.lr":
-        return True
-    if alt != PRIMARY_ALT and filename == "contents+%s.lr" % alt:
-        return True
-    return False
-
-
 class _CmpHelper:
     def __init__(self, value, reverse):
         self.value = value

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -521,16 +521,14 @@ class Siblings(VirtualSourceObject):  # pylint: disable=abstract-method
         )
 
     def _file_infos(self, path_cache):
-        for source_filename in self.iter_source_filenames():
-            yield path_cache.get_file_info(source_filename)
+        return map(path_cache.get_file_info, self.iter_source_filenames())
 
     def get_mtime(self, path_cache):
-        mtimes = [i.mtime for i in self._file_infos(path_cache)]
-        return max(mtimes) if mtimes else None
+        return max((i.mtime for i in self._file_infos(path_cache)), default=None)
 
     def get_checksum(self, path_cache):
         sums = "|".join(i.filename_and_checksum for i in self._file_infos(path_cache))
-        return sums or None
+        return hashlib.sha1(sums.encode("utf-8")).hexdigest() if sums else None
 
 
 def siblings_resolver(node, url_path):

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1912,7 +1912,7 @@ class Alt:
     def __init__(self, id, record):
         self.id = id
         self.record = record
-        self.exists = record is not None and os.path.isfile(record.source_filename)
+        self.exists = record is not None and record["_source_alt"] == record.alt
 
     def __repr__(self):
         return "<Alt %r%s>" % (self.id, self.exists and "*" or "")

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -11,7 +11,9 @@ from lektor.utils import is_valid_id
 from lektor.utils import secure_filename
 
 
-implied_keys = set(["_id", "_path", "_gid", "_alt", "_source_alt", "_attachment_for"])
+implied_keys = set(
+    ["_id", "_path", "_gid", "_alt", "_source_alt", "_source_alts", "_attachment_for"]
+)
 possibly_implied_keys = set(["_model", "_template", "_attachment_type"])
 
 

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -12,7 +12,15 @@ from lektor.utils import secure_filename
 
 
 implied_keys = set(
-    ["_id", "_path", "_gid", "_alt", "_source_alt", "_source_alts", "_attachment_for"]
+    [
+        "_id",
+        "_path",
+        "_gid",
+        "_alt",
+        "_source_alt",
+        "_source_filenames",
+        "_attachment_for",
+    ]
 )
 possibly_implied_keys = set(["_model", "_template", "_attachment_type"])
 

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -23,7 +23,17 @@ class SourceObject:
 
     @property
     def source_filename(self):
-        """The primary source filename of this source object."""
+        """The primary source filename of this source object.
+
+        XXX: This is here for backword compatibility.  The default implementation
+        returns the first value returned by ``iter_source_filenames``.
+
+        (In most/all cases where one is concerned about the source files,
+        one should be interested in all the source files, not just one.)
+
+        """
+        source_filenames = self.iter_source_filenames()
+        return next(iter(source_filenames), None)
 
     is_hidden = False
     is_discoverable = True
@@ -39,9 +49,12 @@ class SourceObject:
         return not self.is_discoverable
 
     def iter_source_filenames(self):
-        fn = self.source_filename
-        if fn is not None:
-            yield self.source_filename
+        """An iterable of the source filenames for this source object.
+
+        The first returned filename should be the "primary" one.
+        """
+        # pylint: disable=no-self-use
+        return []
 
     def iter_virtual_sources(self):
         # pylint: disable=no-self-use
@@ -162,6 +175,9 @@ class VirtualSourceObject(SourceObject):
     @property
     def source_filename(self):
         return self.record.source_filename
+
+    def iter_source_filenames(self):
+        return self.record.iter_source_filenames()
 
     def iter_virtual_sources(self):
         yield self

--- a/tests/demo-project/content/projects/english/contents+en.lr
+++ b/tests/demo-project/content/projects/english/contents+en.lr
@@ -1,0 +1,7 @@
+name: English
+---
+website: http://en.example.org/
+---
+description: A page that only exists in English
+---
+seq: 10


### PR DESCRIPTION
In playing around to look at another issue, I noticed that when building the example project, the blog pages are always rebuilt, even if they have not been changed.

I.e.
```sh
$ cd example
$ lektor build
Started build
U de/index.html
[... lots of other pages ...]
U static/css/nix.css
Finished build in 1.07 sec
Started prune
Finished prune in 0.00 sec
```

Then, do it again.  Since no source has been changed, nothing should be rebuilt.  But:
```sh
$ lektor build
Started build
U de/blog/blog-post-5/index.html
U de/blog/blog-post-4/index.html
U de/blog/blog-post-3/index.html
U de/blog/blog-post-2/index.html
U de/blog/first-post/index.html
U blog/blog-post-5/index.html
U blog/blog-post-4/index.html
U blog/blog-post-3/index.html
U blog/blog-post-2/index.html
U blog/first-post/index.html
U fr/blog/blog-post-5/index.html
U fr/blog/blog-post-4/index.html
U fr/blog/blog-post-3/index.html
U fr/blog/blog-post-2/index.html
U fr/blog/first-post/index.html
Finished build in 0.32 sec
Started prune
Finished prune in 0.01 sec
```

The blog posts are always rebuilt.


### Issue(s) Resolved

I believe the root cause of this is that `Page.source_filename` is, in some cases, returning bogus values — specifically
the name of non-existing files.  E.g. if only a `contents.lr` exists, `.source_filename` still returns `contents+de.lr` for the `alt="de"` version of the page.  Since this is used for dependency tracking, things break if this points to a non-existing file.

Looking further, I think that `SourceObject.source_filename` is, or should be deprecated in favor of `SourceObject.iter_source_filenames`.  Again, since this is used for dependency tracking, we usually (always?) care about all the source files, not just the "primary" one.

### Related Issues / Links

Not sure.

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
