### PR TITLE
Remove deprecated thumbnailing features

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -6,7 +6,6 @@ import hashlib
 import operator
 import os
 import posixpath
-import warnings
 from collections import OrderedDict
 from datetime import timedelta
 from itertools import islice
@@ -828,20 +827,8 @@ class Image(Attachment):
             return rv
         return Undefined("The format of the image could not be determined.")
 
-    def thumbnail(
-        self, width=None, height=None, crop=None, mode=None, upscale=None, quality=None
-    ):
+    def thumbnail(self, width=None, height=None, mode=None, upscale=None, quality=None):
         """Utility to create thumbnails."""
-
-        # `crop` exists to preserve backward-compatibility, and will be removed.
-        if crop is not None and mode is not None:
-            raise ValueError("Arguments `crop` and `mode` are mutually exclusive.")
-
-        if crop is not None:
-            warnings.warn(
-                'The `crop` argument is deprecated. Use `mode="crop"` instead.'
-            )
-            mode = "crop"
 
         if mode is None:
             mode = ThumbnailMode.DEFAULT

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -593,16 +593,6 @@ def make_image_thumbnail(
 
     would_upscale = computed_width > source_width or computed_height > source_height
 
-    # this part needs to be removed once backward-compatibility period passes
-    if would_upscale and upscale is None:
-        warnings.warn(
-            "Your image is being scaled up since the requested thumbnail "
-            "size is larger than the source. This default will change "
-            "in the future. If you want to preserve the current behaviour, "
-            "use `upscale=True`."
-        )
-        upscale = True
-
     if would_upscale and not upscale:
         return Thumbnail(source_url_path, source_width, source_height)
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -329,12 +329,11 @@ class Test_make_image_thumbnail:
         assert rv.url_path != source_url_path
         assert len(ctx.sub_artifacts) == 1
 
-    def test_implicit_upscale(self, ctx, test_jpg, source_url_path):
-        with pytest.warns(UserWarning, match=r"image is being scaled up"):
-            rv = make_image_thumbnail(ctx, test_jpg, source_url_path, 512)
-        assert (rv.width, rv.height) == (512, 683)
-        assert rv.url_path == "test@512.jpg"
-        assert len(ctx.sub_artifacts) == 1
+    def test_no_implicit_upscale(self, ctx, test_jpg, source_url_path):
+        rv = make_image_thumbnail(ctx, test_jpg, source_url_path, 512)
+        assert (rv.width, rv.height) == (384, 512)
+        assert rv.url_path == "test.jpg"
+        assert len(ctx.sub_artifacts) == 0
 
     @pytest.mark.parametrize("mode", iter(ThumbnailMode))
     def test_upscale_false(self, ctx, test_jpg, source_url_path, mode):


### PR DESCRIPTION
This PR does two things:
- It removes the deprecated `crop` argument from the `Image.thumbnail()` method.
- It disables implicit thumbnail upscaling.

Currently, warnings are emitted when either of those deprecated features are used.  They have been deprecated since the 3.2.0 release.

When the time is right, here is the PR to remove those features.

### Issue(s) Resolved

Fixes #930

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

