### PR TITLE
Clean up `lektor.admin.modules.api`

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1897,15 +1897,15 @@ class TreeItem:
             return None
         return self._primary_record.datamodel
 
-    @property
-    def label_i18n(self):
-        """Translations for the item's label."""
-        if self._primary_record is None:
+    def get_record_label_i18n(self, alt=PRIMARY_ALT):
+        """Get record label translations for specific alt."""
+        record = self.alts[alt].record
+        if record is None:
             # generate a reasonable fallback
             # ("en" is the magical fallback lang)
             label = self.id.replace("-", " ").replace("_", " ").title()
             return {"en": label or "(Index)"}
-        return self._primary_record.get_record_label_i18n()
+        return record.get_record_label_i18n()
 
     @property
     def can_have_children(self):
@@ -1913,6 +1913,12 @@ class TreeItem:
         if self._primary_record is None or self.is_attachment:
             return False
         return self._datamodel.has_own_children
+
+    @property
+    def implied_child_datamodel(self):
+        """The name of the default datamodel for children of this page, if any."""
+        datamodel = self._datamodel
+        return datamodel.child_config.model if datamodel else None
 
     @property
     def can_have_attachments(self):

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -7,9 +7,10 @@ import operator
 import os
 import posixpath
 import warnings
+from collections import OrderedDict
 from datetime import timedelta
-from itertools import chain
 from itertools import islice
+from operator import methodcaller
 
 from jinja2 import is_undefined
 from jinja2 import Undefined
@@ -993,7 +994,7 @@ class Query:
         h.update(str(self.alt))
         h.update(str(self._include_pages))
         h.update(str(self._include_attachments))
-        h.update("(%s)" % u"|".join(self._order_by or ()).encode("utf-8"))
+        h.update("(%s)" % "|".join(self._order_by or ()).encode("utf-8"))
         h.update(str(self._limit))
         h.update(str(self._offset))
         h.update(str(self._include_hidden))
@@ -1347,7 +1348,7 @@ class Database:
                         rv_type = is_attachment
                     for key, lines in metaformat.tokenize(f, encoding="utf-8"):
                         if key not in rv:
-                            rv[key] = u"".join(lines)
+                            rv[key] = "".join(lines)
             except IOError as e:
                 if e.errno not in (errno.ENOTDIR, errno.ENOENT):
                     raise
@@ -1843,36 +1844,92 @@ class Pad:
 class TreeItem:
     """Represents a single tree item and all the alts within it."""
 
-    def __init__(
-        self,
-        tree,
-        path,
-        alts,
-        exists=True,
-        is_attachment=False,
-        attachment_type=None,
-        can_have_children=False,
-        can_have_attachments=False,
-        can_be_deleted=False,
-        is_visible=True,
-        label_i18n=None,
-    ):
+    def __init__(self, tree, path, alts, primary_record):
         self.tree = tree
         self.path = path
         self.alts = alts
-        self.exists = exists
-        self.is_attachment = is_attachment
-        self.attachment_type = attachment_type
-        self.can_have_children = can_have_children
-        self.can_have_attachments = can_have_attachments
-        self.can_be_deleted = can_be_deleted
-        self.is_visible = is_visible
-        self.label_i18n = label_i18n
+        self._primary_record = primary_record
 
     @property
     def id(self):
         """The local ID of the item."""
         return posixpath.basename(self.path)
+
+    @property
+    def exists(self):
+        """True iff metadata exists for the item.
+
+        If metadata exists for any alt, including the fallback (PRIMARY_ALT).
+
+        Note that for attachments without metadata, this is currently False.
+        But note that if is_attachment is True, the attachment file does exist.
+        """
+        # FIXME: this should probably be changed to return True for attachments,
+        # even those without metadata.
+        return self._primary_record is not None
+
+    @property
+    def is_attachment(self):
+        """True iff item is an attachment."""
+        if self._primary_record is None:
+            return False
+        return self._primary_record.is_attachment
+
+    @property
+    def is_visible(self):
+        """True iff item is not hidden."""
+        # XXX: This is send out from /api/recordinfo but appears to be
+        # unused by the React app
+        if self._primary_record is None:
+            return True
+        return self._primary_record.is_visible
+
+    @property
+    def can_be_deleted(self):
+        """True iff item can be deleted."""
+        if self.path == "/" or not self.exists:
+            return False
+        return self.is_attachment or not self._datamodel.protected
+
+    @property
+    def _datamodel(self):
+        if self._primary_record is None:
+            return None
+        return self._primary_record.datamodel
+
+    @property
+    def label_i18n(self):
+        """Translations for the item's label."""
+        if self._primary_record is None:
+            # generate a reasonable fallback
+            # ("en" is the magical fallback lang)
+            label = self.id.replace("-", " ").replace("_", " ").title()
+            return {"en": label or "(Index)"}
+        return self._primary_record.get_record_label_i18n()
+
+    @property
+    def can_have_children(self):
+        """True iff the item can contain subpages."""
+        if self._primary_record is None or self.is_attachment:
+            return False
+        return self._datamodel.has_own_children
+
+    @property
+    def can_have_attachments(self):
+        """True iff the item can contain attachments."""
+        if self._primary_record is None or self.is_attachment:
+            return False
+        return self._datamodel.has_own_attachments
+
+    @property
+    def attachment_type(self):
+        """The type of an attachment.
+
+        E.g. "image", "video", or None if type is unknown.
+        """
+        if self._primary_record is None or not self.is_attachment:
+            return None
+        return self._primary_record["_attachment_type"] or None
 
     def get_parent(self):
         """Returns the parent item."""
@@ -1882,25 +1939,89 @@ class TreeItem:
 
     def get(self, path):
         """Returns a child within this item."""
-        if self.exists:
-            return self.tree.get(posixpath.join(self.path, path))
-        return None
+        # XXX: Unused?
+        return self.tree.get(posixpath.join(self.path, path))
 
-    def iter_children(self, include_attachments=True, include_pages=True):
-        """Iterates over all children."""
-        if not self.exists:
-            return iter(())
-        return self.tree.iter_children(self.path, include_attachments, include_pages)
+    def _get_child_ids(self, include_attachments=True, include_pages=True):
+        """Returns a sorted list of just the IDs of existing children."""
+        db = self.tree.pad.db
+        keep_attachments = include_attachments and self.can_have_attachments
+        keep_pages = include_pages and self.can_have_children
+        names = set(
+            name
+            for name, _, is_attachment in db.iter_items(self.path, alt=None)
+            if (keep_attachments if is_attachment else keep_pages)
+        )
+        return sorted(names, key=lambda name: name.lower())
+
+    def iter_children(
+        self, include_attachments=True, include_pages=True, order_by=None
+    ):
+        """Iterates over all children"""
+        children = (
+            self.tree.get(posixpath.join(self.path, name), persist=False)
+            for name in self._get_child_ids(include_attachments, include_pages)
+        )
+        if order_by is not None:
+            children = sorted(children, key=methodcaller("get_sort_key", order_by))
+        return children
 
     def get_children(
-        self, offset=0, limit=None, include_attachments=True, include_pages=True
+        self,
+        offset=0,
+        limit=None,
+        include_attachments=True,
+        include_pages=True,
+        order_by=None,
     ):
-        """Returns a list of all children."""
-        if not self.exists:
-            return []
-        return self.tree.get_children(
-            self.path, offset, limit, include_attachments, include_pages
-        )
+        """Returns a slice of children."""
+        # XXX: this method appears unused?
+        end = None
+        if limit is not None:
+            end = offset + limit
+        children = self.iter_children(include_attachments, include_pages, order_by)
+        return list(islice(children, offset, end))
+
+    def iter_attachments(self, order_by=None):
+        """Return an iterable of this records attachments.
+
+        By default, the attachments are sorted as specified by
+        ``[attachments]order_by`` in this records datamodel.
+        """
+        if order_by is None:
+            dm = self._datamodel
+            if dm is not None:
+                order_by = dm.attachment_config.order_by
+        return self.iter_children(include_pages=False, order_by=order_by)
+
+    def iter_subpages(self, order_by=None):
+        """Return an iterable of this records sub-pages.
+
+        By default, the records are sorted as specified by
+        ``[children]order_by`` in this records datamodel.
+
+        NB: This method should probably be called ``iter_children``,
+        but that name was already taken.
+        """
+        if order_by is None:
+            dm = self._datamodel
+            if dm is not None:
+                order_by = dm.child_config.order_by
+        return self.iter_children(include_attachments=False, order_by=order_by)
+
+    def get_sort_key(self, order_by):
+        if self._primary_record is None:
+
+            def sort_key(fieldspec):
+                if fieldspec.startswith("-"):
+                    field, reverse = fieldspec[1:], True
+                else:
+                    field, reverse = fieldspec.lstrip("+"), False
+                value = self.id if field == "_id" else None
+                return _CmpHelper(value, reverse)
+
+            return [sort_key(fieldspec) for fieldspec in order_by]
+        return self._primary_record.get_sort_key(order_by)
 
     def __repr__(self):
         return "<TreeItem %r%s>" % (
@@ -1910,9 +2031,11 @@ class TreeItem:
 
 
 class Alt:
-    def __init__(self, id, record):
+    def __init__(self, id, record, is_primary_overlay, name_i18n):
         self.id = id
         self.record = record
+        self.is_primary_overlay = is_primary_overlay
+        self.name_i18n = name_i18n
         self.exists = record is not None and os.path.isfile(record.source_filename)
 
     def __repr__(self):
@@ -1932,86 +2055,60 @@ class Tree:
     """
 
     def __init__(self, pad):
+        # Note that in theory different alts can disagree on what
+        # datamodel they use but this is something that is really not
+        # supported.  This cannot happen if you edit based on the admin
+        # panel and if you edit it manually and screw up that part, we
+        # cannot really do anything about it.
+        #
+        # We will favor the datamodel from the fallback record
+        # (alt=PRIMARY_ALT) if it exists. If it does not, we will
+        # use the data for the primary alternative. If data does not exist
+        # for either of those, we will pick from among the other
+        # existing alts quasi-randomly.
+        #
+        # Here we construct a list of configured alts in preference order
+        config = pad.db.config
+        alts = [PRIMARY_ALT]
+        if config.primary_alternative:
+            alts.append(config.primary_alternative)
+            alts.extend(
+                alt
+                for alt in config.list_alternatives()
+                if alt != config.primary_alternative
+            )
+
+        alt_info = OrderedDict()
+        for alt in alts:
+            alt_info[alt] = {
+                "is_primary_overlay": alt == config.primary_alternative,
+                "name_i18n": config.get_alternative(alt)["name"],
+            }
+
         self.pad = pad
+        self._alt_info = alt_info
 
     def get(self, path=None, persist=True):
         """Returns a path item at the given node."""
         path = "/" + (path or "").strip("/")
         alts = {}
-        exists = False
-        first_record = None
-        label_i18n = None
-
-        for alt in chain([PRIMARY_ALT], self.pad.db.config.list_alternatives()):
+        primary_record = None
+        for alt, alt_info in self._alt_info.items():
             record = self.pad.get(path, alt=alt, persist=persist, allow_virtual=False)
-            if first_record is None:
-                first_record = record
-            if record is not None:
-                exists = True
-            alts[alt] = Alt(alt, record)
+            if primary_record is None:
+                primary_record = record
+            alts[alt] = Alt(alt, record, **alt_info)
+        return TreeItem(self, path, alts, primary_record)
 
-        # These flags only really make sense if we found an existing
-        # record, otherwise we fall back to some sort of sane default.
-        # Note that in theory different alts can disagree on what
-        # datamodel they use but this is something that is really not
-        # supported.  This cannot happen if you edit based on the admin
-        # panel and if you edit it manually and screw up the part, we
-        # cannot really do anything about it.
-        #
-        # More importantly we genreally assume that first_record is the
-        # primary alt.  There are some situations in which case this is
-        # not true, for instance if no primary alt exists.  In this case
-        # we just go with any record.
-        is_visible = True
-        is_attachment = False
-        attachment_type = None
-        can_have_children = False
-        can_have_attachments = False
-        can_be_deleted = exists and path != "/"
-
-        if first_record is not None:
-            is_attachment = first_record.is_attachment
-            is_visible = first_record.is_visible
-            dm = first_record.datamodel
-            if not is_attachment:
-                can_have_children = dm.has_own_children
-                can_have_attachments = dm.has_own_attachments
-                if dm.protected:
-                    can_be_deleted = False
-            else:
-                attachment_type = first_record["_attachment_type"] or None
-            label_i18n = first_record.get_record_label_i18n()
-
-        return TreeItem(
-            self,
-            path,
-            alts,
-            exists,
-            is_attachment=is_attachment,
-            attachment_type=attachment_type,
-            can_have_children=can_have_children,
-            can_have_attachments=can_have_attachments,
-            can_be_deleted=can_be_deleted,
-            is_visible=is_visible,
-            label_i18n=label_i18n,
+    def iter_children(
+        self, path=None, include_attachments=True, include_pages=True, order_by=None
+    ):
+        """Iterates over all children below a path"""
+        # XXX: this method is unused?
+        path = "/" + (path or "").strip("/")
+        return self.get(path, persist=False).iter_children(
+            include_attachments, include_pages, order_by
         )
-
-    def _get_child_ids(self, path=None, include_attachments=True, include_pages=True):
-        """Returns a sorted list of just the IDs of children below a path."""
-        path = "/" + (path or "").strip("/")
-        names = set()
-        for name, _, is_attachment in self.pad.db.iter_items(path, alt=None):
-            if (is_attachment and include_attachments) or (
-                not is_attachment and include_pages
-            ):
-                names.add(name)
-        return sorted(names, key=lambda x: x.lower())
-
-    def iter_children(self, path=None, include_attachments=True, include_pages=True):
-        """Iterates over all children below a path."""
-        path = "/" + (path or "").strip("/")
-        for name in self._get_child_ids(path, include_attachments, include_pages):
-            yield self.get(posixpath.join(path, name), persist=False)
 
     def get_children(
         self,
@@ -2020,18 +2117,14 @@ class Tree:
         limit=None,
         include_attachments=True,
         include_pages=True,
+        order_by=None,
     ):
         """Returns a slice of children."""
+        # XXX: this method is unused?
         path = "/" + (path or "").strip("/")
-        end = None
-        if limit is not None:
-            end = offset + limit
-        return [
-            self.get(posixpath.join(path, name), persist=False)
-            for name in self._get_child_ids(path, include_attachments, include_pages)[
-                offset:end
-            ]
-        ]
+        return self.get(path, persist=False).get_children(
+            offset, limit, include_attachments, include_pages, order_by
+        )
 
     def edit(self, path, is_attachment=None, alt=PRIMARY_ALT, datamodel=None):
         """Edits a record by path."""

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -348,6 +348,8 @@ class EditorSession:
             raise BadEdit("Record does not exist.")
         if self.is_attachment:
             raise BadEdit("Cannot attach something to an attachment.")
+        if not self.datamodel.has_own_attachments:
+            raise BadEdit("Attachments are disabled for this page.")
         directory = self.pad.db.to_fs_path(self.path)
 
         safe_filename = secure_filename(filename)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,6 +74,18 @@ def test_children_sorting_via_api(scratch_project, scratch_env, children_records
     )
 
 
+def test_recordinfo_children_sort_limited_alts(project, env):
+    # This excercises the bug described in #962, namely that
+    # if a page has a child that only has content in a subset of the
+    # configured alts, get_record_info throws an exception.
+    webadmin = WebAdmin(env, output_path=project.tree)
+    data = json.loads(
+        webadmin.test_client().get("/admin/api/recordinfo?path=/projects").data
+    )
+    child_data = data["children"]
+    assert list(sorted(child_data, key=itemgetter("label"))) == child_data
+
+
 def test_eventstream_yield_bytes():
     count = 0
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,312 @@
+# Tests for lektor.db.Tree and related classes.
+import pytest
+
+from lektor.constants import PRIMARY_ALT
+from lektor.db import Tree
+
+
+@pytest.fixture
+def tree(pad):
+    return Tree(pad)
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", ""),
+        ("/blog", "blog"),
+        ("/this/is/missing", "missing"),
+    ],
+)
+def test_tree_item_id(tree, path, expect):
+    item = tree.get(path)
+    assert item.path == path
+    assert item.id == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", True),
+        ("/test.jpg", True),
+        ("/missing", False),
+    ],
+)
+def test_tree_item_exists(tree, path, expect):
+    item = tree.get(path)
+    assert item.exists is expect
+    if not item.exists:
+        assert item._datamodel is None
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", False),
+        ("/test.jpg", True),
+        ("/missing", False),
+    ],
+)
+def test_tree_item_can_be_deleted(tree, path, expect):
+    item = tree.get(path)
+    assert item.can_be_deleted == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", True),
+        ("/test.jpg", True),
+        ("/missing", True),
+        ("/extra/container", False),
+    ],
+)
+def test_tree_item_is_visible(tree, path, expect):
+    item = tree.get(path)
+    assert item.is_visible == expect
+
+
+@pytest.mark.parametrize(
+    "path, is_attachment, attachment_type",
+    [
+        ("/", False, None),
+        ("/test.jpg", True, "image"),
+        ("/missing", False, None),
+    ],
+)
+def test_tree_item_is_attachment(tree, path, is_attachment, attachment_type):
+    item = tree.get(path)
+    assert item.is_attachment is is_attachment
+    assert item.attachment_type == attachment_type
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", True),
+        ("/test.jpg", False),
+        ("/missing", False),
+    ],
+)
+def test_tree_item_can_have_children(tree, path, expect):
+    item = tree.get(path)
+    assert item.can_have_children == expect
+    # NB: currently in the demo-project, can_have_children ==
+    # can_have_attachments
+    assert item.can_have_attachments == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", {"en": "Welcome"}),
+        ("/test.jpg", {"en": "test.jpg"}),
+        ("/missing/gone", {"en": "Gone"}),
+        ("/projects/bagpipe", {"en": "Bagpipe"}),
+    ],
+)
+def test_tree_item_label_i18n(tree, path, expect):
+    item = tree.get(path)
+    assert item.label_i18n == expect
+
+
+@pytest.mark.parametrize(
+    "path, parent_path",
+    [
+        ("/", None),
+        ("/test.jpg", "/"),
+        ("/missing/gone", "/missing"),
+        ("/projects/bagpipe", "/projects"),
+    ],
+)
+def test_get_parent(tree, path, parent_path):
+    item = tree.get(path)
+    parent = item.get_parent()
+    assert (parent and parent.path) == parent_path
+
+
+@pytest.mark.parametrize(
+    "path, name",
+    [
+        ("/", "a"),
+        ("/missing/gone", "foo"),
+    ],
+)
+def test_get(tree, path, name):
+    item = tree.get(path)
+    assert item.get(name).id == name
+
+
+@pytest.mark.parametrize(
+    "path, offset, limit, order_by, expect",
+    [
+        ("/extra/container", 0, None, None, ["a", "hello.txt"]),
+        ("/extra/container", 1, None, None, ["hello.txt"]),
+        ("/extra/container", 0, 1, None, ["a"]),
+        ("/projects", 0, 2, ("seq",), ["attachment.txt", "zaun"]),
+        ("/projects", 1, 1, ("seq",), ["zaun"]),
+        ("/projects", 0, 2, None, ["attachment.txt", "bagpipe"]),
+        ("/projects", 9, None, None, ["wolf", "zaun"]),
+    ],
+)
+def test_tree_item_get_children(tree, path, offset, limit, order_by, expect):
+    item = tree.get(path)
+    children = item.get_children(offset, limit, order_by=order_by)
+    assert list(child.id for child in children) == expect
+
+
+@pytest.mark.parametrize(
+    "path, order_by, expect",
+    [
+        ("/", None, ["blog", "extra", "projects"]),
+        ("/blog", ("-pub_date",), ["post2", "post1", "dummy.xml"]),
+        (
+            "/projects",
+            ("seq",),
+            [
+                "zaun",
+                "wolf",
+                "slave",
+                "secret",
+                "postage",
+                "oven",
+                "master",
+                "filtered",
+                "bagpipe",
+                "coffee",
+            ],
+        ),
+        (
+            "/projects",
+            None,
+            [
+                "bagpipe",
+                "coffee",
+                "filtered",
+                "master",
+                "oven",
+                "postage",
+                "secret",
+                "slave",
+                "wolf",
+                "zaun",
+            ],
+        ),
+    ],
+)
+def test_tree_item_iter_subpages(tree, path, order_by, expect):
+    item = tree.get(path)
+    assert list(child.id for child in item.iter_subpages(order_by)) == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        (
+            "/",
+            [
+                "hello.txt",
+                "test-progressive.jpg",
+                "test-sof-last.jpg",
+                "test.jpg",
+                "test.mp4",
+            ],
+        ),
+    ],
+)
+def test_tree_item_iter_attachments(tree, path, expect):
+    item = tree.get(path)
+    assert list(child.id for child in item.iter_attachments()) == expect
+
+
+@pytest.mark.parametrize(
+    "path, order_by, expect",
+    [
+        ("/", ("title",), [("Welcome", False)]),
+        ("/extra", ("title", "+_id"), [("Hello", False), ("extra", False)]),
+        ("/missing", ("title", "-_id"), [(None, False), ("missing", True)]),
+    ],
+)
+def test_tree_item_get_order_by(tree, path, order_by, expect):
+    item = tree.get(path)
+    sort_key = item.get_sort_key(order_by)
+    assert [(_.value, _.reverse) for _ in sort_key] == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", "<TreeItem '/'>"),
+        ("/hello.txt", "<TreeItem '/hello.txt' attachment>"),
+    ],
+)
+def test_tree_item_repr(tree, path, expect):
+    item = tree.get(path)
+    assert repr(item) == expect
+
+
+def test_tree_item_alts(tree):
+    item = tree.get("/")
+    assert set(item.alts) == {PRIMARY_ALT, "en", "de"}
+
+
+@pytest.mark.parametrize(
+    "path, alt, expect",
+    [
+        ("/", PRIMARY_ALT, True),
+        ("/", "en", False),
+        ("/", "de", False),
+        ("/hello.txt", PRIMARY_ALT, False),
+        ("/hello.txt", "en", False),
+        ("/hello.txt", "de", False),
+        ("/missing", PRIMARY_ALT, False),
+        ("/missing", "en", False),
+        ("/missing", "de", False),
+        ("/projects/zaun", PRIMARY_ALT, False),
+        ("/projects/zaun", "en", False),
+        ("/projects/zaun", "de", True),
+    ],
+)
+def test_alt_exists(tree, path, alt, expect):
+    item = tree.get(path)
+    assert item.alts[alt].exists == expect
+
+
+@pytest.mark.parametrize(
+    "alt, expect",
+    [
+        (PRIMARY_ALT, False),
+        ("en", True),
+        ("de", False),
+    ],
+)
+def test_alt_is_primary_overlay(tree, alt, expect):
+    item = tree.get("/")
+    assert item.alts[alt].is_primary_overlay == expect
+
+
+@pytest.mark.parametrize(
+    "alt, expect",
+    [
+        (PRIMARY_ALT, {"en": "English", "de": "Englisch"}),
+        ("en", {"en": "English", "de": "Englisch"}),
+        ("de", {"en": "German", "de": "Deutsch"}),
+    ],
+)
+def test_alt_name_i18n(tree, alt, expect):
+    item = tree.get("/")
+    assert item.alts[alt].name_i18n == expect
+
+
+@pytest.mark.parametrize(
+    "path, alt, expect",
+    [
+        ("/", PRIMARY_ALT, "<Alt '_primary'*>"),
+        ("/", "en", "<Alt 'en'>"),
+        ("/", "de", "<Alt 'de'>"),
+        ("/projects/zaun", "de", "<Alt 'de'*>"),
+    ],
+)
+def test_alt_repr(tree, path, alt, expect):
+    item = tree.get(path)
+    assert repr(item.alts[alt]) == expect

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -97,17 +97,30 @@ def test_tree_item_can_have_children(tree, path, expect):
 
 
 @pytest.mark.parametrize(
-    "path, expect",
+    "path, alt, expect",
     [
-        ("/", {"en": "Welcome"}),
-        ("/test.jpg", {"en": "test.jpg"}),
-        ("/missing/gone", {"en": "Gone"}),
-        ("/projects/bagpipe", {"en": "Bagpipe"}),
+        ("/", PRIMARY_ALT, {"en": "Welcome"}),
+        ("/test.jpg", PRIMARY_ALT, {"en": "test.jpg"}),
+        ("/missing/gone", PRIMARY_ALT, {"en": "Gone"}),
+        ("/projects/bagpipe", PRIMARY_ALT, {"en": "Bagpipe"}),
+        ("/projects/bagpipe", "de", {"en": "Dudelsack"}),
     ],
 )
-def test_tree_item_label_i18n(tree, path, expect):
+def test_tree_item_get_record_label_i18n(tree, path, alt, expect):
     item = tree.get(path)
-    assert item.label_i18n == expect
+    assert item.get_record_label_i18n(alt) == expect
+
+
+@pytest.mark.parametrize(
+    "path, expect",
+    [
+        ("/", None),
+        ("/blog", "blog-post"),
+    ],
+)
+def test_tree_implied_child_datamodel(tree, path, expect):
+    item = tree.get(path)
+    assert item.implied_child_datamodel == expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

This PR fixes the issue described in #962 wherein the admin API throws an exception when editing a page that has a child which does not exist in the system alternative.

It also refactors the API code to move a bunch of logic that deals with interfacing with the db out of the `api` module and back into the `Tree` and `TreeItem` classes.  This restores better delineation of responsibility between components: `Tree` is responsible for providing a view of the Lektor database adapted for convenient use by editors; the API code has to do with hooking the `Tree` up to HTTP views.


### Related Issues / Links

<strike>In the refactored `Tree` code, we prefer the record corresponding to the `primary alternative` (e.g. `" en"`) rather than `PRIMARY_ALT` (`"_primary"`) when picking a record from which to pull various metadata. The record with `alt=PRIMARY_ALT` does not correspond to any actually built output page.  See #965 for discussion.</strike>
[Edit: The record we pick in `Tree.get` is used only to determine aspects that apply to the page regardless of _alt_.  Though it is possible that alt-specific records for a given page may disagree on these aspects, we should probably consider the fallback data (alt=PRIMARY_ALT) to be authoritative.]


### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
