### PR TITLE
Fix sneaky import cycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,17 @@ These are all the changes in Lektor since the first public release.
 
 ### Bugs Fixed
 
+- Fixed an import cycle which caused in `ImportError` if
+  `lektor.types` was imported before `lektor.environemnt`. [#974][]
+
 #### CI Tests
 
 - Increased timeout in `test_watcher.IterateInThread` to prevent
   random spurious failures during CI testing.
 - Fix `tests/test_prev_next_sibling.py` so as to allow running
   multiple test runs in parallel.
+
+[#974]: https://github.com/lektor/lektor/pull/974
 
 ## 3.3.0 (2021-12-14)
 

--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -25,7 +25,6 @@ from lektor.packages import load_packages
 from lektor.pluginsystem import initialize_plugins
 from lektor.pluginsystem import PluginController
 from lektor.publisher import builtin_publishers
-from lektor.types import builtin_types
 from lektor.utils import format_lat_long
 from lektor.utils import tojson_filter
 
@@ -152,6 +151,9 @@ class Environment:
             dateformat=_pass_locale(dates.format_date),
             timeformat=_pass_locale(dates.format_time),
         )
+
+        # pylint: disable=import-outside-toplevel
+        from lektor.types import builtin_types
 
         self.types = builtin_types.copy()
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,28 @@
+"""Test that all modules/packages in the lektor tree are importable in any order
+
+Here we import each module by itself, one at a time, each in a new
+python interpreter.
+
+"""
+import pkgutil
+import sys
+from subprocess import run
+
+import pytest
+
+import lektor
+
+
+def iter_lektor_modules():
+    for module in pkgutil.walk_packages(lektor.__path__, f"{lektor.__name__}."):
+        yield module.name
+
+
+@pytest.fixture(params=iter_lektor_modules())
+def module(request):
+    return request.param
+
+
+def test_import(module):
+    python = sys.executable
+    assert run([python, "-c", f"import {module}"], check=False).returncode == 0


### PR DESCRIPTION
There is a sneaky import cycle that is exposed by running:
```sh
$ python -c "import lektor.types"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/dairiki/git/web/lektor-packages/lektor/lektor/types/__init__.py", line 11, in <module>
    from lektor.types.multi import CheckboxesType
  File "/home/dairiki/git/web/lektor-packages/lektor/lektor/types/multi.py", line 4, in <module>
    from lektor.environment.expressions import Expression
  File "/home/dairiki/git/web/lektor-packages/lektor/lektor/environment/__init__.py", line 28, in <module>
    from lektor.types import builtin_types
ImportError: cannot import name 'builtin_types' from partially initialized module 'lektor.types' (most likely due to a circular import) (/home/dairiki/git/web/lektor-packages/lektor/lektor/types/__init__.py)
```

This is import-order dependent. If one imports `lektor.environment` _before_ importing `lektor.types` all is well.


(It appears this cycle was introduced in lektor/lektor@7c68f3f78.)


### Description of Changes

- [x] Added a unit test that exercises the bug
- [x] Fixed the problem
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
