### PR TITLE
devserver: use daemon property instead of deprecated setDaemon

### DIFF
--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -15,11 +15,6 @@ from lektor.utils import process_extra_flags
 from lektor.watcher import Watcher
 
 
-_os_alt_seps = list(
-    sep for sep in [os.path.sep, os.path.altsep] if sep not in (None, "/")
-)
-
-
 class SilentWSGIRequestHandler(WSGIRequestHandler):
     def log(self, type, message, *args):
         pass
@@ -160,9 +155,9 @@ def run_server(
             use_debugger=True,
             threaded=True,
             use_reloader=lektor_dev,
-            request_handler=not lektor_dev
-            and SilentWSGIRequestHandler
-            or WSGIRequestHandler,
+            request_handler=WSGIRequestHandler
+            if lektor_dev
+            else SilentWSGIRequestHandler,
         )
     finally:
         if dt is not None:

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -99,7 +99,7 @@ def browse_to_address(addr):
         webbrowser.open("http://%s:%s" % addr)
 
     t = threading.Thread(target=browse)
-    t.setDaemon(True)
+    t.daemon = True
     t.start()
 
 
@@ -129,7 +129,7 @@ def run_server(
             verbosity=verbosity,
             extra_flags=extra_flags,
         )
-        background_builder.setDaemon(True)
+        background_builder.daemon = True
         background_builder.start()
         env.plugin_controller.emit(
             "server-spawn", bindaddr=bindaddr, extra_flags=extra_flags


### PR DESCRIPTION
threading.setDaemon is deprecated since Python 3.10