### PR TITLE
Mark test that requires internet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,10 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+norecursedirs = ["venv", ".tox", ".git", "node_modules"]
+addopts = "--strict-markers"
+markers = [
+    "requiresinternet: marks tests requiring an internet connection",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 norecursedirs = venv
+addopts = --strict-markers
+markers =
+    requiresinternet: marks tests requiring an internet connection

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs = venv
+norecursedirs = venv .tox .git node_modules
 addopts = --strict-markers
 markers =
     requiresinternet: marks tests requiring an internet connection

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-norecursedirs = venv .tox .git node_modules
-addopts = --strict-markers
-markers =
-    requiresinternet: marks tests requiring an internet connection

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -155,6 +155,7 @@ class TestPlugin:
     def test_path(self, dummy_plugin):
         assert dummy_plugin.path == str(Path(__file__).parent)
 
+    @pytest.mark.requiresinternet
     @pytest.mark.usefixtures("save_sys_path")
     def test_path_installed_plugin_is_none(self, scratch_project):
         # XXX: this test is slow and fragile. (It won't run

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     # tests (using `tox -p`)
     COVERAGE_FILE=.coverage.{envname}
 deps =
-    pytest
+    pytest>=6
     pytest-click
     pytest-cov
     pytest-mock
@@ -26,7 +26,7 @@ paths =
 [testenv:lint]
 deps =
     pylint==2.11.1
-    pytest
+    pytest>=6
 commands =
     pylint {posargs:lektor tests}
 


### PR DESCRIPTION
Apply a pytest mark (`requiresinternet`) to the one test that requires a working internet connection to complete successfully.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #982

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

This PR also adds some potentially large subdirectories (`.git`, `.tox`, and `node_modules`) that do not contain interesting tests to pytest's `norecursedirs` config option.

And it moves pytest's configuration from `pytest.ini` to `pyproject.toml`.  (The future is now.)

<!--- Thanks for your help making Lektor better for everyone! --->
