### PR TITLE
[jinja_debug] Add jinja debug extension when LEKTOR_DEV=1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,15 @@ These are all the changes in Lektor since the first public release.
   This fixes problems with the "edit" pencil when using alternatives ([#975][]),
   and issues when page ids include colons ([#610][]).
 
+### Command Line
+
+- Enabled the [Jinja debug extension](https://jinja.palletsprojects.com/en/latest/extensions/#debug-extension) when the `LEKTOR_DEV` env var is set to 1 and `lektor server` is used. [#984][]
+
 [#610]: https://github.com/lektor/lektor/issues/610
 [#964]: https://github.com/lektor/lektor/pull/964
 [#975]: https://github.com/lektor/lektor/issues/975
 [#976]: https://github.com/lektor/lektor/pull/976
+[#984]: https://github.com/lektor/lektor/pull/984
 
 ## 3.3.1 (2022-01-09)
 

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -115,6 +115,8 @@ def run_server(
     wz_as_main = os.environ.get("WERKZEUG_RUN_MAIN") == "true"
     in_main_process = not lektor_dev or wz_as_main
     extra_flags = process_extra_flags(extra_flags)
+    if lektor_dev:
+        env.jinja_env.add_extension("jinja2.ext.debug")
 
     if in_main_process:
         background_builder = BackgroundBuilder(


### PR DESCRIPTION
### Description of Changes

This enables the Jinja debug extension when the LEKTOR_DEV env var is set to `1` and `lektor server` is used. This can be useful during template development.

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [x] Link to corresponding documentation branch for [getlektor.com](https://github.com/lektor/lektor-website) https://github.com/lektor/lektor-website/tree/jinja_debug - only missing an active version note.