### PR TITLE
Fixup coverage configuration, move to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,10 @@ addopts = "--strict-markers"
 markers = [
     "requiresinternet: marks tests requiring an internet connection",
 ]
+
+
+[tool.coverage.paths]
+paths = [
+    "lektor",
+    ".tox/py*/*/lektor",
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 # This setting declares that path equivalent to the one in the src dir.
 paths =
 	lektor
-	.tox/py/*/lektor
+	.tox/py*/*/lektor
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,7 @@ deps =
     pytest-click
     pytest-cov
     pytest-mock
-
-[coverage:paths]
-# Coverage is picked on the code in the virtual env created by tox.
-# This setting declares that path equivalent to the one in the src dir.
-paths =
-	lektor
-	.tox/py*/*/lektor
+    coverage[toml]
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This fixes a buglet in the `[coverage:paths]` so that it works with tox environments other than just `py` (e.g. `py39`).

Also, it moves the configuration for *coverage* to `pyproject.toml`.

