### PR TITLE
Fix codecov reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,13 @@ jobs:
         shell: bash
         run: echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
       - name: Install python dependencies
-        run: python -m pip install tox codecov coverage[toml]
+        run: python -m pip install tox coverage[toml]
       - name: Run python tests
         run: tox -e py
-      - name: Publish coverage
-        run: codecov -t 39974034-91d8-48d1-9698-de48e0667a09
+      - name: Generate coverage.xml
+        shell: bash
+        run: |
+          coverage combine --append || true
+          coverage xml
+      - name: Publish coverage data to codecov
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         shell: bash
         run: echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
       - name: Install python dependencies
-        run: python -m pip install codecov tox
+        run: python -m pip install tox codecov coverage[toml]
       - name: Run python tests
         run: tox -e py
       - name: Publish coverage


### PR DESCRIPTION
I broke this in #990, moving the coverage configuration to pyproject.toml.

I've also updated the workflow to use the [codecov github action](https://github.com/marketplace/actions/codecov).  The python codecov uploader which we were using is deprecated and [slated to become non-functional](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) on February 1, 2022.

Finally, I deleted the codecov token from `ci.yml` and have reset the token for the repo in the codecov settings. Apparently, no token is necessary to upload coverage data from github actions running for public repos. (If we do in fact need a token, it should be stored in a project secret — otherwise, what's the point?)