### PR TITLE
Fix installation of ImageMagick on Windows test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,20 +113,36 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install macOS system dependencies
         if: startsWith(runner.os, 'macos') && matrix.install-imagemagick
         run: brew install imagemagick ffmpeg
+
       - name: Install Windows system dependencies
         if: startsWith(runner.os, 'windows') && matrix.install-imagemagick
-        run: choco install --no-progress --timeout 600 imagemagick.tool ffmpeg
+        run: |
+          choco install --no-progress --timeout 600 imagemagick.app ffmpeg
+          # The imagemagick.app package, for whatever reason, installs
+          # magick.exe into a directory which is not in the default
+          # search path. Currently, it seems to get installed in a
+          # directory named something like:
+          #
+          # "C:\Program Files\ImageMagick-7.1.0-Q16-HDRI"
+          $ImDirs = (
+            Get-ChildItem $env:ProgramFiles 'ImageMagick*' -Directory
+            | Select-Object -ExpandProperty FullName
+          )
+          if ($ImDirs.Length -eq 0) { Throw "Could not find path to ImageMagick" }
+          $ImDirs | Out-File $env:GITHUB_PATH utf8 -Append
+          $ImDirs | % { "::notice title=ImageMagick::ImageMagick installed at $_" }
         continue-on-error: true
       - name: Workaround for UnicodeDecodeError from tox on Windows
         # Refs:
         #   https://github.com/lektor/lektor/pull/933#issuecomment-923107580
         #   https://github.com/tox-dev/tox/issues/1550
         if: startsWith(runner.os, 'windows')
-        shell: bash
-        run: echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
+        run: Out-File $env:GITHUB_ENV utf8 -Append -InputObject 'PYTHONIOENCODING=utf-8'
+
       - name: Install python dependencies
         run: python -m pip install tox coverage[toml]
       - name: Run python tests


### PR DESCRIPTION
We had been installing the `imagemagick.tool` Chocolatey package. That package seems to be neglected and has not been installing successfully for a few months now.

We switch here to installing the `imagemagick.app` package instead. It installs successfully, but, for whatever reason, it installs to a directory under `\Program Files`, and Chocolatey is unsuccessful in it's attempts to add the install directory to `$PATH`. So we have to manually figure out where ImageMagick was installed and add that to the search path.



Fixes #941

