### PR TITLE
GithubPagesPublisher refactor

### DIFF
--- a/lektor/compat.py
+++ b/lektor/compat.py
@@ -1,0 +1,53 @@
+import os
+import stat
+import sys
+import tempfile
+from functools import partial
+from itertools import chain
+
+
+def _ensure_tree_writeable(path: str) -> None:
+    """Attempt to ensure that all files in the tree rooted at path are writeable."""
+    dirscans = []
+
+    def fix_mode(path, statfunc):
+        try:
+            # paranoia regarding symlink attacks
+            current_mode = statfunc(follow_symlinks=False).st_mode
+            if not stat.S_ISLNK(current_mode):
+                isdir = stat.S_ISDIR(current_mode)
+                fixed_mode = current_mode | (0o700 if isdir else 0o200)
+                if current_mode != fixed_mode:
+                    os.chmod(path, fixed_mode)
+                if isdir:
+                    dirscans.append(os.scandir(path))
+        except FileNotFoundError:
+            pass
+
+    fix_mode(path, partial(os.stat, path))
+    for entry in chain.from_iterable(dirscans):
+        fix_mode(entry.path, entry.stat)
+
+
+class FixedTemporaryDirectory(tempfile.TemporaryDirectory):
+    """A version of tempfile.TemporaryDirectory that works if dir contains read-only files.
+
+    On python < 3.8 under Windows, if any read-only files are created
+    in a TemporaryDirectory, TemporaryDirectory will throw an
+    exception when it tries to remove them on cleanup. See
+    https://bugs.python.org/issue26660
+
+    This can create issues, e.g., with temporary git repositories since
+    git creates read-only files in its object store.
+
+    """
+
+    def cleanup(self) -> None:
+        _ensure_tree_writeable(self.name)
+        super().cleanup()
+
+
+if sys.version_info >= (3, 8):
+    TemporaryDirectory = tempfile.TemporaryDirectory
+else:
+    TemporaryDirectory = FixedTemporaryDirectory

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -13,7 +13,6 @@ from subprocess import CompletedProcess
 from subprocess import DEVNULL
 from subprocess import PIPE
 from subprocess import STDOUT
-from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Callable
 from typing import ContextManager
@@ -30,6 +29,7 @@ from typing import TYPE_CHECKING
 
 from werkzeug import urls
 
+from lektor.compat import TemporaryDirectory
 from lektor.exception import LektorException
 from lektor.utils import locate_executable
 from lektor.utils import portable_popen

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from lektor.environment import Environment
 from lektor.environment.expressions import Expression
 from lektor.project import Project
 from lektor.reporter import BufferReporter
+from lektor.utils import locate_executable
 
 
 @pytest.fixture(scope="session")
@@ -231,3 +232,15 @@ def project_cli_runner(isolated_cli_runner, project, save_sys_path):
         else:
             shutil.copy2(entry_path, entry)
     return isolated_cli_runner
+
+
+@pytest.fixture
+def no_utils(monkeypatch):
+    """Monkeypatch $PATH to hide any installed external utilities
+    (e.g. git, imagemagick)."""
+    monkeypatch.setitem(os.environ, "PATH", "/dev/null")
+    locate_executable.cache_clear()
+    try:
+        yield
+    finally:
+        locate_executable.cache_clear()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from lektor.compat import _ensure_tree_writeable
+from lektor.compat import FixedTemporaryDirectory
+from lektor.compat import TemporaryDirectory
+
+
+def test_ensure_tree_writeable(tmp_path):
+    topdir = tmp_path / "topdir"
+    subdir = topdir / "subdir"
+    regfile = subdir / "regfile"
+    subdir.mkdir(parents=True)
+    regfile.touch(mode=0)
+    subdir.chmod(0)
+    topdir.chmod(0)
+
+    _ensure_tree_writeable(topdir)
+
+    for p in topdir, subdir, regfile:
+        assert os.access(p, os.W_OK)
+
+
+@pytest.mark.parametrize("tmpdir_class", [FixedTemporaryDirectory, TemporaryDirectory])
+def test_TemporaryDirectory(tmpdir_class):
+    with tmpdir_class() as tmpdir:
+        file = Path(tmpdir, "test-file")
+        file.touch(mode=0)
+        os.chmod(tmpdir, 0)
+    assert not os.path.exists(tmpdir)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,11 +1,9 @@
-import textwrap
 from os.path import dirname
 from os.path import join
 
 import pytest
 from werkzeug.urls import url_parse
 
-from lektor.publisher import GithubPagesPublisher
 from lektor.publisher import RsyncPublisher
 
 
@@ -17,131 +15,26 @@ def test_get_server(env):
     assert server.extra == {"extra_field": "extra_value"}
 
 
-def test_ghpages_update_git_config(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    repo_path = tmpdir.mkdir("repo")
-    repo_config = repo_path.mkdir(".git").join("config").ensure(file=True)
-    target_url = url_parse("ghpages://user/repo")
-    branch = "master"
-    publisher.update_git_config(str(repo_path), target_url, branch)
-    expected = textwrap.dedent(
-        """
-        [remote "origin"]
-        url = git@github.com:user/repo.git
-        fetch = +refs/heads/master:refs/remotes/origin/master
-    """
-    ).strip()
-    assert repo_config.read().strip() == expected
-
-
-def test_ghpages_update_git_config_https(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    repo_path = tmpdir.mkdir("repo")
-    repo_config = repo_path.mkdir(".git").join("config").ensure(file=True)
-    target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
-    branch = "lektor"
-    publisher.update_git_config(str(repo_path), target_url, branch)
-    expected = textwrap.dedent(
-        """
-        [remote "origin"]
-        url = https://github.com/pybee/pybee.github.io.git
-        fetch = +refs/heads/lektor:refs/remotes/origin/lektor
-    """
-    ).strip()
-    assert repo_config.read().strip() == expected
-
-
-def test_ghpages_update_git_config_https_credentials(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    repo_path = tmpdir.mkdir("repo")
-    repo_config = repo_path.mkdir(".git").join("config").ensure(file=True)
-    target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
-    branch = "lektor"
-    credentials_file = repo_path.join(".git", "credentials")
-    credentials = {
-        "username": "fakeuser",
-        "password": "fakepass",
-    }
-    publisher.update_git_config(
-        str(repo_path), target_url, branch, credentials=credentials
-    )
-    expected = (
-        textwrap.dedent(
-            """
-        [remote "origin"]
-        url = https://github.com/pybee/pybee.github.io.git
-        fetch = +refs/heads/lektor:refs/remotes/origin/lektor
-        [credential]
-        helper = store --file "{}"
-    """
-        )
-        .format(credentials_file)
-        .strip()
-    )
-    assert repo_config.read().strip() == expected
-
-    assert (
-        credentials_file.read().strip()
-        == "https://fakeuser:fakepass@github.com".strip()
-    )
-
-
-def test_ghpages_write_cname(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    target_url = url_parse("ghpages+https://pybee/pybee.github.io?cname=pybee.org")
-    publisher.write_cname(str(output_path), target_url)
-    assert (output_path / "CNAME").read() == "pybee.org\n"
-
-
-def test_ghpages_detect_branch_username(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    target_url = url_parse("ghpages+https://MacDownApp/MacDownApp.github.io")
-    branch = publisher.detect_target_branch(target_url)
-    assert branch == "master"
-
-
-def test_ghpages_detect_branch_username_case_insensitive(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    target_url = url_parse("ghpages+https://MacDownApp/macdownapp.github.io")
-    branch = publisher.detect_target_branch(target_url)
-    assert branch == "master"
-
-
-def test_ghpages_detect_branch_project(tmpdir, env):
-    output_path = tmpdir.mkdir("output")
-    publisher = GithubPagesPublisher(env, str(output_path))
-    target_url = url_parse("ghpages+https://MacDownApp/MacDownApp.github.io/macdown")
-    branch = publisher.detect_target_branch(target_url)
-    assert branch == "gh-pages"
-
-
 def test_rsync_command_credentials(tmpdir, mocker, env):
     output_path = tmpdir.mkdir("output")
     publisher = RsyncPublisher(env, str(output_path))
     target_url = url_parse("http://example.com")
-    ssh_path = tmpdir.mkdir("ssh")
     credentials = {
         "username": "fakeuser",
         "password": "fakepass",
     }
     mock_popen = mocker.patch("lektor.publisher.portable_popen")
-    publisher.get_command(target_url, str(ssh_path), credentials)
-    assert mock_popen.called
-    assert mock_popen.call_args[0] == (
-        [
-            "rsync",
-            "-rclzv",
-            "--exclude=.lektor",
-            str(output_path) + "/",
-            "fakeuser@example.com:/",
-        ],
-    )
+    with publisher.get_command(target_url, credentials):
+        assert mock_popen.called
+        assert mock_popen.call_args[0] == (
+            [
+                "rsync",
+                "-rclzv",
+                "--exclude=.lektor",
+                str(output_path) + "/",
+                "fakeuser@example.com:/",
+            ],
+        )
 
 
 output_path = join(dirname(__file__), "OUTPUT_PATH")
@@ -267,8 +160,7 @@ output_path = join(dirname(__file__), "OUTPUT_PATH")
 def test_rsync_publisher(target_url, called_command, tmpdir, mocker, env):
     publisher = RsyncPublisher(env, str(output_path))
     target_url = url_parse(target_url)
-    ssh_path = join(output_path, "ssh")
     mock_popen = mocker.patch("lektor.publisher.portable_popen")
-    publisher.get_command(target_url, str(ssh_path), credentials=None)
-    assert mock_popen.called
-    assert mock_popen.call_args[0] == (called_command,)
+    with publisher.get_command(target_url, credentials=None):
+        assert mock_popen.called
+        assert mock_popen.call_args[0] == (called_command,)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,14 +1,147 @@
 import gc
 import os
+import re
 import sys
 import warnings
 import weakref
+from pathlib import Path
 from shutil import which
+from subprocess import CalledProcessError
+from subprocess import DEVNULL
+from subprocess import PIPE
+from subprocess import run
 
 import pytest
+from werkzeug.urls import url_parse
 
+from lektor.publisher import _ssh_command
+from lektor.publisher import _ssh_key_file
 from lektor.publisher import Command
+from lektor.publisher import GithubPagesPublisher
+from lektor.publisher import GitRepo
 from lektor.publisher import publish
+from lektor.publisher import PublishError
+from lektor.utils import locate_executable
+
+
+def test_ssh_key_file():
+    credentials = {"key_file": "/some/id", "key": "rsa:ignored"}
+    with _ssh_key_file(credentials) as key_file:
+        assert key_file == "/some/id"
+
+
+def test_ssh_key_file_returns_none():
+    with _ssh_key_file({}) as key_file:
+        assert key_file is None
+
+
+@pytest.mark.parametrize("prefix, key_type", [("test:", "TEST"), ("", "RSA")])
+def test_ssh_key_file_creates_key(prefix, key_type):
+    credentials = {"key": prefix + "".join(["1234567890abcdef"] * 7)}
+    with _ssh_key_file(credentials) as key_file:
+        assert Path(key_file).read_text() == (  # pylint: disable=unspecified-encoding
+            f"-----BEGIN {key_type} PRIVATE KEY-----\n"
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\n"
+            "1234567890abcdef1234567890abcdef1234567890abcdef\n"
+            f"-----END {key_type} PRIVATE KEY-----\n"
+        )
+    assert not Path(key_file).exists()
+
+
+@pytest.mark.parametrize(
+    "credentials, port, expected",
+    [
+        ({}, None, None),
+        ({}, 42, "ssh -p 42"),
+        ({"key_file": "/keyfile"}, None, 'ssh -i "/keyfile" -o IdentitiesOnly=yes'),
+    ],
+)
+def test_ssh_command(credentials, port, expected):
+    with _ssh_command(credentials, port) as key_file:
+        assert key_file == expected
+
+
+@pytest.mark.parametrize(
+    "cmd, input, expect_rc, expected",
+    [
+        ("echo xxx", None, 0, ["xxx"]),
+        ("echo yyy 1>&2", None, 0, ["yyy"]),
+        ("exit 42", None, 42, []),
+        ("sort", "foo\nbar\n", 0, ["bar", "foo"]),
+    ],
+)
+def test_Command_capture(cmd, input, expect_rc, expected):
+    command = Command(("sh", "-c", cmd), input=input)
+
+    def iter_output():
+        proc = yield from command
+        assert proc.returncode == expect_rc
+        assert proc.stdout is None
+
+    assert list(iter_output()) == expected
+
+
+def test_Command_env():
+    command = Command(("sh", "-c", "echo $TESTVAR"), env={"TESTVAR": "boo"})
+    assert list(command) == ["boo"]
+
+
+def test_Command_raises_CalledProcessError():
+    command = Command(("sh", "-c", "echo x && exit 42"), check=True)
+
+    def iter_output():
+        with pytest.raises(CalledProcessError) as exc_info:
+            yield from command
+        assert exc_info.value.returncode == 42
+
+    assert list(iter_output()) == ["x"]
+
+
+@pytest.mark.parametrize(
+    "capture_stdout, silent, stdout, out_err",
+    [
+        (False, False, None, ("foo\n", "bar\n")),
+        (True, False, "foo\n", ("", "bar\n")),
+        (False, True, None, ("", "")),
+        (True, True, "foo\n", ("", "")),
+    ],
+)
+def test_Command_no_capture(capture_stdout, silent, stdout, out_err, capfd):
+    command = Command(
+        ("sh", "-c", "echo foo && echo bar 1>&2"),
+        capture=False,
+        silent=silent,
+        capture_stdout=capture_stdout,
+    )
+    assert command.wait() == 0
+    assert command.result().stdout == stdout
+    assert capfd.readouterr() == out_err
+
+
+def test_Command_iter_raises_if_not_capturing():
+    command = Command(("sh", "-c", "exit 0"), capture=False)
+    with pytest.raises(RuntimeError) as exc_info:
+        next(iter(command))
+    assert "Not capturing" in str(exc_info.value)
+    assert command.wait() == 0
+
+
+def test_Command_SIGINT():
+    with pytest.raises(KeyboardInterrupt):
+        command = Command(("bash", "-c", f"kill -2 {os.getpid()}"), capture_stdout=True)
+        list(command)
+
+
+def test_Command_returncode():
+    command = Command(("sh", "-c", "exit 42"))
+    assert command.returncode is None
+    list(command)
+    assert command.returncode == 42
+
+
+def test_Command_output():
+    command = Command(("sh", "-c", "echo foo"))
+    assert list(command.output) == ["foo"]
 
 
 def test_Command_triggers_no_warnings():
@@ -64,3 +197,339 @@ def test_RsyncPublisher_integration(env, tmp_path, delete):
         for _ in target_path.iterdir()
     }
     assert target_files == files
+
+
+@pytest.fixture
+def work_tree(tmp_path):
+    work_tree = tmp_path / "work_tree"
+    work_tree.mkdir()
+    return work_tree
+
+
+@pytest.fixture
+def clean_git_environ(monkeypatch):
+    """Delete any GIT_ configuration in the current environment.
+
+    This unsets any existing GIT_SSH_COMMAND, among other things.
+
+    Of note, if one runs tests using git rebase exec, git sets all kinds
+    of GIT_* environment variables.
+    """
+    for key in list(os.environ):
+        if key.startswith("GIT_"):
+            monkeypatch.delitem(os.environ, key)
+
+
+@pytest.fixture
+def gitrepo(work_tree, clean_git_environ):
+    if not locate_executable("git"):
+        pytest.skip("no git")
+    with GitRepo(work_tree) as repo:
+        yield repo
+
+
+def test_GitRepo_popen(gitrepo):
+    assert "No commits yet" in list(gitrepo.popen("status"))
+
+
+def test_GitRepo_run(gitrepo):
+    proc = gitrepo.run("status", capture_stdout=True)
+    assert "No commits yet" in proc.stdout
+
+
+@pytest.mark.usefixtures("clean_git_environ")
+def test_GitRepo_set_ssh_credentials(gitrepo):
+    gitrepo.set_ssh_credentials({"key_file": "/id_foo"})
+    assert gitrepo.environ["GIT_SSH_COMMAND"].startswith('ssh -i "/id_foo"')
+
+
+@pytest.mark.usefixtures("clean_git_environ")
+def test_GitRepo_set_ssh_credentials_no_creds(gitrepo):
+    gitrepo.set_ssh_credentials({})
+    assert "GIT_SSH_COMMAND" not in gitrepo.environ
+
+
+def test_GitRepo_set_https_credentials(gitrepo):
+    gitrepo.set_https_credentials({"username": "user", "password": "pw"})
+    with gitrepo.popen("config", "--local", "--list") as output:
+        for line in output:
+            m = re.match(r'credential\.helper=store\s+--file\s+"(\S+)"', line)
+            if m:
+                cred_file = m.group(1)
+                break
+    # pylint: disable=unspecified-encoding
+    assert Path(cred_file).read_text().rstrip() == "https://user:pw@github.com"
+
+
+def test_GitRepo_set_https_credentials_no_cred(gitrepo):
+    gitrepo.set_https_credentials({})
+    assert not any(
+        line.startswith("credential.helper")
+        for line in gitrepo.popen("config", "--local", "--list")
+    )
+
+
+def test_GitRepo_add_to_index(gitrepo):
+    gitrepo.add_to_index("testfile", "testcontent\n")
+    proc = gitrepo.run("diff", "--cached", capture_stdout=True)
+    assert "+testcontent" in proc.stdout
+
+
+class DummyUpstreamRepo:
+    def __init__(self, git_dir):
+        run(("git", "init", "--bare", git_dir), check=True, stdout=DEVNULL)
+        self.git_dir = git_dir
+
+    @property
+    def url(self):
+        return self.git_dir
+
+    def run(self, args, **kwargs):
+        cmd = ("git", "--bare", "--git-dir", self.git_dir) + args
+        # XXX: Use text=True instead of encoding for py>3.6
+        return run(cmd, stdout=PIPE, encoding="utf-8", check=False)
+
+    def count_commits(self, branch):
+        proc = self.run(("log", "--pretty=oneline", branch))
+        return len(proc.stdout.splitlines())
+
+    def ls_files(self, treeish):
+        return set(self.iter_files(treeish))
+
+    def iter_files(self, treeish, prefix=""):
+        # Currently only lists top-level files
+        for line in self.run(("ls-tree", treeish)).stdout.splitlines():
+            _, typ, oid, name = line.split(maxsplit=3)
+            if typ == "blob":
+                yield prefix + name
+            else:
+                assert typ == "tree"
+                yield from self.iter_files(oid, prefix=f"{prefix}{name}/")
+
+
+@pytest.fixture
+def upstream_repo(tmp_path, clean_git_environ):
+    return DummyUpstreamRepo(tmp_path / "upstream.git")
+
+
+def test_GitRepo_publish_ghpages(gitrepo, upstream_repo, work_tree):
+    test_file = work_tree / "new-file"
+    test_file.write_text("test\n")
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages"):
+        print(line)
+    assert upstream_repo.count_commits("gh-pages") == 1
+    assert upstream_repo.ls_files("gh-pages") == {"new-file"}
+
+    test_file.rename(work_tree / "renamed-file")
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages"):
+        print(line)
+    assert upstream_repo.count_commits("gh-pages") == 2
+    assert upstream_repo.ls_files("gh-pages") == {"renamed-file"}
+
+
+def test_GitRepo_publish_ghpages_cname(gitrepo, upstream_repo, work_tree):
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages", "example.org"):
+        print(line)
+    assert upstream_repo.count_commits("gh-pages") == 1
+    assert upstream_repo.ls_files("gh-pages") == {"CNAME"}
+
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages"):
+        print(line)
+    assert upstream_repo.count_commits("gh-pages") == 2
+    assert upstream_repo.ls_files("gh-pages") == set()
+
+
+def test_GitRepo_publish_ghpages_ignores_lektor_dir(gitrepo, upstream_repo, work_tree):
+    lektor_dir = work_tree / ".lektor"
+    lektor_dir.mkdir()
+    lektor_dir.joinpath("ignored").write_text("should not be published")
+    work_tree.joinpath("included").write_text("should be published")
+
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages"):
+        print(line)
+    assert upstream_repo.count_commits("gh-pages") == 1
+    assert upstream_repo.ls_files("gh-pages") == {"included"}
+
+
+def test_GitRepo_publish_ghpages_no_changes(gitrepo, upstream_repo):
+    for line in gitrepo.publish_ghpages(upstream_repo.url, "gh-pages", "example.com"):
+        print(line)
+    assert upstream_repo.ls_files("gh-pages") == {"CNAME"}
+    assert any(
+        "No changes" in line
+        for line in gitrepo.publish_ghpages(
+            upstream_repo.url, "gh-pages", "example.com"
+        )
+    )
+
+
+@pytest.fixture
+def output_path(tmp_path):
+    return str(tmp_path / "output_path")
+
+
+@pytest.fixture
+def ghp_publisher(env, output_path):
+    return GithubPagesPublisher(env, output_path)
+
+
+@pytest.mark.parametrize(
+    "target_url, publish_args, warns",
+    [
+        (
+            "ghpages://owner/project?cname=example.com",
+            ("ssh://git@github.com/owner/project.git", "gh-pages", "example.com"),
+            False,
+        ),
+        (
+            "ghpages+https://owner/owner.github.io",
+            ("https://github.com/owner/owner.github.io.git", "master", None),
+            True,
+        ),
+    ],
+)
+@pytest.mark.skipif(not locate_executable("git"), reason="no git")
+def test_GithubPagesPublisher_publish(
+    ghp_publisher, output_path, mocker, target_url, publish_args, warns
+):
+    GitRepo = mocker.patch("lektor.publisher.GitRepo", spec_set=True)
+    repo = mocker.Mock(spec_set=GitRepo)
+    repo.publish_ghpages.return_value = iter(["Published!"])
+    GitRepo.return_value.__enter__.return_value = repo
+
+    url = url_parse(target_url)
+    output = list(ghp_publisher.publish(url))
+
+    GitRepo.assert_called_once_with(output_path)
+    if "+https:" in target_url:
+        repo.set_https_credentials.assert_called_once_with({})
+    else:
+        repo.set_ssh_credentials.assert_called_once_with({})
+    repo.publish_ghpages.assert_called_once_with(*publish_args)
+    if warns:
+        assert output[0].startswith("WARNING")
+        output = output[1:]
+    assert output == ["Published!"]
+
+
+@pytest.mark.usefixtures("no_utils")
+def test_GithubPagesPublisher_publish_fails_if_no_git(ghp_publisher):
+    url = url_parse("ghpages://owner/project")
+    with pytest.raises(PublishError) as exc_info:
+        list(ghp_publisher.publish(url))
+    assert re.search(r"git.*not found", str(exc_info.value))
+
+
+@pytest.mark.parametrize(
+    "target_url, expected",
+    [
+        (
+            "ghpages://owner/project",
+            ("ssh://git@github.com/owner/project.git", "gh-pages", None, []),
+        ),
+        (
+            "ghpages://owner/owner.github.io?branch=main",
+            ("ssh://git@github.com/owner/owner.github.io.git", "main", None, []),
+        ),
+        (
+            "ghpages://owner/project?branch=brnch&cname=example.com",
+            ("ssh://git@github.com/owner/project.git", "brnch", "example.com", []),
+        ),
+        (
+            "ghpages+ssh://own/proj",
+            ("ssh://git@github.com/own/proj.git", "gh-pages", None, []),
+        ),
+        (
+            "ghpages+https://own/proj",
+            ("https://github.com/own/proj.git", "gh-pages", None, []),
+        ),
+        (
+            "ghpages+ssh://own:22/proj",
+            ("ssh://git@github.com/own/proj.git", "gh-pages", None, []),
+        ),
+        (
+            "ghpages+https://own:443/proj",
+            ("https://github.com/own/proj.git", "gh-pages", None, []),
+        ),
+    ],
+)
+def test_GithubPagesPublisher_parse_url(ghp_publisher, target_url, expected):
+    url = url_parse(target_url)
+    assert ghp_publisher._parse_url(url) == expected
+
+
+def test_GithubPagesPublisher_parse_url_warns_on_default_master_branch(ghp_publisher):
+    url = url_parse("ghpages://owner/owner.github.io")
+    push_url, branch, cname, warnings = ghp_publisher._parse_url(url)
+    assert (push_url, branch, cname) == (
+        "ssh://git@github.com/owner/owner.github.io.git",
+        "master",
+        None,
+    )
+    assert len(warnings) == 1
+    assert re.match(r"WARNING:.*default branch.*is.*main", warnings[0])
+
+
+@pytest.mark.parametrize(
+    "target_url, expected",
+    [
+        ("ghpages:///project", "owner missing"),
+        ("ghpages://owner", "project missing"),
+        ("ghpages://owner:2222/project", "non-standard port"),
+        ("ghpages+https://owner:4430/project", "non-standard port"),
+    ],
+)
+def test_GithubPagesPublisher_parse_url_failures(ghp_publisher, target_url, expected):
+    url = url_parse(target_url)
+    with pytest.raises(PublishError) as exc_info:
+        ghp_publisher._parse_url(url)
+    assert expected in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "target_url, credentials, expected",
+    [
+        ("ghpages://owner/proj", None, {}),
+        (
+            "ghpages://owner/proj",
+            {"username": "user", "password": "pw"},
+            {"username": "user", "password": "pw"},
+        ),
+        ("ghpages://user:pw@owner/proj", None, {"username": "user", "password": "pw"}),
+        (
+            "ghpages://user:pw@owner/proj",
+            {"arbi": "trary"},
+            {"username": "user", "password": "pw", "arbi": "trary"},
+        ),
+        ("ghpages://user:pw@owner/proj", None, {"username": "user", "password": "pw"}),
+        (
+            "ghpages://user:pw@owner/proj",
+            {"password": "secret"},
+            {"username": "user", "password": "secret"},
+        ),
+    ],
+)
+def test_GithubPagesPublisher_parse_credentials(
+    ghp_publisher, credentials, target_url, expected
+):
+    url = url_parse(target_url)
+    assert ghp_publisher._parse_credentials(credentials, url) == expected
+
+
+def test_publish(env, output_path, mocker):
+    Publisher = mocker.Mock()
+    env.add_publisher("publishtest", Publisher)
+    credentials = {"foo": "bar"}
+    rv = publish(env, "publishtest://host/path", output_path, credentials)
+    url = url_parse("publishtest://host/path")
+    assert Publisher.mock_calls == [
+        mocker.call(env, output_path),
+        mocker.call().publish(url, credentials),
+    ]
+    assert rv is Publisher.return_value.publish.return_value
+
+
+def test_publish_unknown_scheme(env, output_path):
+    with pytest.raises(PublishError) as exc_info:
+        publish(env, "unknownscheme://host/path", output_path)
+    assert "unknown scheme" in str(exc_info.value)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -128,7 +128,8 @@ def test_Command_no_capture(capture_stdout, silent, stdout, out_err, capfd):
     )
     assert command.wait() == 0
     assert command.result().stdout == stdout
-    assert capfd.readouterr() == out_err
+    captured = tuple(_.replace(os.linesep, "\n") for _ in capfd.readouterr())
+    assert captured == out_err
 
 
 def test_Command_iter_raises_if_not_capturing():

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -19,13 +19,6 @@ class struct_passwd(NamedTuple):
 
 
 @pytest.fixture
-def no_utils(monkeypatch):
-    """Monkeypatch $PATH to hide any installed external utilities (e.g. git)."""
-    monkeypatch.setitem(os.environ, "PATH", "/dev/null")
-    locate_executable.cache_clear()
-
-
-@pytest.fixture
 def git_config_file(tmp_path, monkeypatch):
     """Create a temporary git config file, and monkeypatch $GIT_CONFIG to point to it."""
     config_file = tmp_path / "git_config"


### PR DESCRIPTION
What started out as work to support explicitly specifying a branch to push to (#978) has turned into this.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #978

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->
Associated doc PR: lektor/lektor-website#340

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
- [x] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

- Add support for specifying which branch to push to by specifying a `branch` query param on the target URL.
- Issues a warning when defaulting to pushing to the `master` branch for a _user_ or _organization_ pages site.  (Recently created _user_ or _organization_ pages repositories default to using the `main` branch.)
- [Optimization] Do a shallow fetch when fetching the current target branch from upstream.
- [Optimization] Avoid copying the HTML output files to a new scratch directory.
- Refactor/cleanup of some code in `lektor.publisher`.


## Question

Is it worth adding an option that would prevent keeping any git history of the deployed site?

If one doesn't care about preserving the history of the deployed gh-pages site, one can just force-push the new
content to the target branch.  This avoids having to fetch the existing branch from upstream, saving network bandwidth.

In general, I'm not sure how useful it is to keep a history of the deployed site anyway.

_Of pertinence_, I just noticed that [our docs](https://www.getlektor.com/docs/deployment/ghpages/) currently say: "_The way this is implemented in Lektor currently is that Lektor will force-push a website into a repository of choice._"
This appears _not to be_ what our current code does.  Current code appears to alway creates a new commit (with the previous branch head as its parent) preserving all previously published version of the site's HTML in the git history.  (No force push involved.)
Later on the same page, our docs say: "_The way this deployment support works is that it commits a new commit into a temporary location and pushes it into the gh-pages or master branch depending on the name of the repository._" (which is not quite the same thing.)

<!--- Thanks for your help making Lektor better for everyone! --->
