### PR TITLE
Windows: Fix check for symlinks and misc test fix

### DIFF
--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -383,7 +383,13 @@ def theme_quickstart(defaults=None, project=None):
             "../../../lektor-theme-{}".format(theme_id),
             "lektor-theme-{}".format(theme_id),
         )
-    except AttributeError:
+    except OSError as exc:
+        # Windows, by default, only allows members of the "Administrators" group
+        # to create symlinks. For users who are not allowed to create symlinks,
+        # error Code 1314 - "A required privilege is not held by the client"
+        # is raised.
+        if getattr(exc, "winerror", None) != 1314:
+            raise
         g.warn(
             "Could not automatically make a symlink to have your example-site"
             "easily pick up your theme."

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import warnings
 import weakref
 
@@ -13,7 +14,7 @@ def test_Command_triggers_no_warnings():
 
     with pytest.warns(None) as record:
         # This is essentially how RsyncPublisher runs rsync.
-        with Command(["echo"]) as client:
+        with Command([sys.executable, "-c", "print()"]) as client:
             for _ in client:
                 pass
 


### PR DESCRIPTION
This PR fixes a few tests that were failing under a plain vanilla Windows 10 installation, and py3-izes Lektor's detection of the ability to create symlinks under Windows.



### Issue(s) Resolved

- Windows, though it now supports symlinks, by default [does not allow][1] regular users to create them.
- As of python 3.2, `os.symlink` exists under Windows.  (It will, of course, raise `OSError` if the user does not have sufficient privs to create symlinks.)  Lektor was checking for symlink support by checking (effectively) `hasattr(os, "symlnk")` — that no longer works.
- The `echo` command (used by one test) is not necessarily available under Windows.

[1]: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links

