### PR TITLE
Exclude .eslintrc.js from packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include lektor/quickstart-templates *
 recursive-include lektor/translations *
 recursive-include lektor/admin *
 recursive-exclude lektor/admin/node_modules *
-global-exclude *.py[cdo] __pycache__ *.so *.pyd .DS_Store
+global-exclude *.py[cdo] __pycache__ *.so *.pyd .DS_Store .eslintrc.js
 include LICENSE
 include README.md
 include CHANGES.md


### PR DESCRIPTION
Lektor packages probably shouldn't ship this file.