### PR TITLE
Fixes for #998 — tests fail when git is not installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,11 @@ jobs:
         run: Out-File $env:GITHUB_ENV utf8 -Append -InputObject 'PYTHONIOENCODING=utf-8'
 
       - name: Install python dependencies
-        run: python -m pip install tox coverage[toml]
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions coverage[toml]
       - name: Run python tests
-        run: tox -e py
+        run: tox
       - name: Generate coverage.xml
         shell: bash
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,35 +202,6 @@ def reporter(request, env):
 
 
 @pytest.fixture(scope="function")
-def os_user(monkeypatch):
-    # pylint: disable=import-outside-toplevel
-    if os.name == "nt":
-        import getpass  # pylint: disable=unused-import # noqa
-
-        monkeypatch.setattr("getpass.getuser", lambda: "Lektor Test")
-        return "lektortest"
-
-    # we disable pylint, because there is no such
-    # modules on windows & it's false positive
-    import pwd  # pylint: disable=import-error
-
-    struct = pwd.struct_passwd(
-        (
-            "lektortest",  # pw_name
-            "lektorpass",  # pw_passwd
-            9999,  # pw_uid
-            9999,  # pw_gid
-            "Lektor Test",  # pw_gecos
-            "/tmp/lektortest",  # pw_dir
-            "/bin/lektortest",  # pw_shell
-        )
-    )
-    monkeypatch.setattr("pwd.getpwuid", lambda id: struct)
-    monkeypatch.setenv("USER", "lektortest")
-    return "lektortest"
-
-
-@pytest.fixture(scope="function")
 def project_cli_runner(isolated_cli_runner, project, save_sys_path):
     """
     Copy the project files into the isolated file system used by the

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,10 +1,14 @@
+import pytest
+
 from lektor.quickstart import get_default_author
 from lektor.quickstart import get_default_author_email
+from lektor.utils import locate_executable
 
 
 def test_default_author(os_user):
     assert get_default_author() == "Lektor Test"
 
 
+@pytest.mark.skipif(locate_executable("git") is None, reason="git not installed")
 def test_default_author_email():
     assert isinstance(get_default_author_email(), str)

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,4 +1,5 @@
 import os
+from typing import NamedTuple
 
 import pytest
 
@@ -7,16 +8,62 @@ from lektor.quickstart import get_default_author_email
 from lektor.utils import locate_executable
 
 
-def test_default_author(os_user):
-    assert get_default_author() == "Lektor Test"
+class struct_passwd(NamedTuple):
+    pw_name: str = "user"
+    pw_passwd: str = "pw"
+    pw_uid: int = 10000
+    pw_gid: int = 10000
+    pw_gecos: str = "gecos"
+    pw_dir: str = "/tmp"
+    pw_shell: str = "/bin/false"
+
+
+@pytest.fixture
+def no_utils(monkeypatch):
+    """Monkeypatch $PATH to hide any installed external utilities (e.g. git)."""
+    monkeypatch.setitem(os.environ, "PATH", "/dev/null")
+    locate_executable.cache_clear()
+
+
+@pytest.fixture
+def git_config_file(tmp_path, monkeypatch):
+    """Create a temporary git config file, and monkeypatch $GIT_CONFIG to point to it."""
+    config_file = tmp_path / "git_config"
+    config_file.touch()
+    monkeypatch.setitem(os.environ, "GIT_CONFIG", str(config_file))
+    return config_file
+
+
+@pytest.mark.skipif(os.name == "nt", reason="windows")
+def test_default_author_from_pwd(mocker):
+    pw_gecos = "Lektor Tester,,555-1212,,"
+    mocker.patch(
+        "pwd.getpwuid", spec=True, return_value=struct_passwd(pw_gecos=pw_gecos)
+    )
+    assert get_default_author() == "Lektor Tester"
+
+
+def test_default_author_from_username(mocker):
+    mocker.patch("getpass.getuser", spec=True, return_value="lektortester")
+    if os.name != "nt":
+        mocker.patch("os.getuid", spec=True, return_value=-1)
+    assert get_default_author() == "lektortester"
 
 
 @pytest.mark.skipif(locate_executable("git") is None, reason="git not installed")
-def test_default_author_email():
-    assert isinstance(get_default_author_email(), str)
+def test_default_author_email(git_config_file):
+    git_config_file.write_text("[user]\n\temail = tester@example.com\n")
+    assert get_default_author_email() == "tester@example.com"
 
 
-def test_default_author_email_git_unavailable(monkeypatch):
-    monkeypatch.setitem(os.environ, "PATH", "/dev/null")
-    locate_executable.cache_clear()
+@pytest.mark.usefixtures("no_utils")
+def test_default_author_email_from_EMAIL(monkeypatch):
+    email = "tester@example.net"
+    monkeypatch.setitem(os.environ, "EMAIL", email)
+    assert get_default_author_email() == email
+
+
+@pytest.mark.usefixtures("no_utils")
+def test_default_author_email_no_default(monkeypatch):
+    monkeypatch.delitem(os.environ, "EMAIL", raising=False)
     assert get_default_author_email() is None

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from lektor.quickstart import get_default_author
@@ -12,3 +14,9 @@ def test_default_author(os_user):
 @pytest.mark.skipif(locate_executable("git") is None, reason="git not installed")
 def test_default_author_email():
     assert isinstance(get_default_author_email(), str)
+
+
+def test_default_author_email_git_unavailable(monkeypatch):
+    monkeypatch.setitem(os.environ, "PATH", "/dev/null")
+    locate_executable.cache_clear()
+    assert get_default_author_email() is None

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ setenv =
     # Use per-testenv coverage files to prevent contention when parallel
     # tests (using `tox -p`)
     COVERAGE_FILE=.coverage.{envname}
+    # To test in environment without external utitilities like imagemagick and git installed,
+    # break PATH in noutils environment(s).
+    noutils: PATH=/dev/null
 deps =
     pytest>=6
     pytest-click

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,15 @@
 [tox]
 minversion = 3.3
-envlist = lint,py36,py37,py38,py39,py310
+envlist = lint,py36,py37,py38,py39,py310{,-noutils}
 isolated_build = true
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 commands = pytest --cov={envsitepackagesdir}/lektor {posargs:tests}


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #998

#### Other clean-ups and fixes

Handle potential `KeyError` from `pwd.getpwuid` in `lektor.quickstart.get_default_author`.

If _git_ is not available, or if git's `user.email` is unset, fall back to checking `$EMAIL` in `get_default_author_email`.

`Lektor.quickstart.project_quickstart` had logic intended to generate the new project in the current directory if run in an empty directory.  This logic was however [broken][2] in such a way that it never could be activated.  I've just deleted it — we've survived this long without that functionality, so hopefully, no one will miss it.

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

Added a `noutils` tox _[factor][]_ to run tests with an empty `$PATH` in order to check that tests pass without external utilities (e.g. `git`, `imagemagick`) installed.

[factor]: https://tox.wiki/en/latest/config.html#generating-environments-conditional-settings

A couple of the tests in `tests/test_devcli.py` were making the brittle assumption that `lektor.quickstart.get_default_author_email` would return a non-`None` value.  Here we monkey-patch `get_default_author_email` so return a known value for these tests.

The test for `get_default_author_email` in `tests/test_quickstart.py` was also incorrectly making that assumption.  Note that `get_default_author_email` should be allowed to return `None` in the case that no default can be reasonably guessed.  The only use for the return value is to feed as the default to `click.prompt` — for that use, `None` is an allowed value, used to indicate that no default exists.

I've deleted a couple of unnecessary conditional conversions from `bytes` to `str` in `lektor.quickstart`.  As of python 3, at least, there is no possibility of the given values being `bytes`.

- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

[2]: https://github.com/lektor/lektor/blob/2f701037cfc5f913094aa533a7a42abfff7c8296/lektor/quickstart.py#L210

<!--- Thanks for your help making Lektor better for everyone! --->
