### PR TITLE
drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
         exclude:
-          - os: "macos-latest"
-            python: "3.7"
           - os: "macos-latest"
             python: "3.8"
           - os: "macos-latest"
             python: "3.9"
-          - os: "windows-latest"
-            python: "3.6"
           - os: "windows-latest"
             python: "3.8"
           - os: "windows-latest"

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -5,7 +5,6 @@ import os
 import posixpath
 import shutil
 import subprocess
-import sys
 import tempfile
 from contextlib import contextmanager
 from ftplib import Error as FTPError
@@ -114,13 +113,10 @@ class Command:
         if capture:
             kwargs["stdout"] = subprocess.PIPE
             kwargs["stderr"] = subprocess.STDOUT
-            if sys.version_info >= (3, 7):
-                # Python >= 3.7 has sane encoding defaults in the case that the system is
-                # (likely mis-)configured to use ASCII as the default encoding (PEP538).
-                # It also provides a way for the user to force the use of UTF-8 (PEP540).
-                kwargs["text"] = True
-            else:
-                kwargs["encoding"] = "utf-8"
+            # Since 3.7, Python has sane encoding defaults in the case that the system is
+            # (likely mis-)configured to use ASCII as the default encoding (PEP538).
+            # It also provides a way for the user to force the use of UTF-8 (PEP540).
+            kwargs["text"] = True
             kwargs["errors"] = "replace"
         self.capture = capture
         self._cmd = portable_popen(argline, **kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -28,7 +27,7 @@ classifiers =
 packages = find:
 include_package_data = True
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     Babel
     click>=6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 minversion = 3.3
-envlist = lint,py36,py37,py38,py39,py310{,-noutils}
+envlist = lint,py37,py38,py39,py310{,-noutils}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Python 3.6 has reached EOL two months ago and Python 3.7 provides a
couple of niceties. In particular, the following are or could be of use
in Lektor:

- dataclasses
- importlib.resources
- postponed evalution of type annotations
- better encoding defaults
- big performance improvements related to typing
- all dicts are now ordered (not just as an implementation detail of
  CPython, but also as specified by the language)