### PR TITLE
Delete unused cruft

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -91,14 +91,6 @@ def _require_ctx(record):
     return ctx
 
 
-def _is_content_file(filename, alt=PRIMARY_ALT):
-    if filename == "contents.lr":
-        return True
-    if alt != PRIMARY_ALT and filename == "contents+%s.lr" % alt:
-        return True
-    return False
-
-
 class _CmpHelper:
     def __init__(self, value, reverse):
         self.value = value

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1000,17 +1000,6 @@ class Query:
         self._page_num = None
         self._filter_func = None
 
-    def __get_lektor_param_hash__(self, h):
-        h.update(str(self.alt))
-        h.update(str(self._include_pages))
-        h.update(str(self._include_attachments))
-        h.update("(%s)" % "|".join(self._order_by or ()).encode("utf-8"))
-        h.update(str(self._limit))
-        h.update(str(self._offset))
-        h.update(str(self._include_hidden))
-        h.update(str(self._include_undiscoverable))
-        h.update(str(self._page_num))
-
     @property
     def self(self):
         """Returns the object this query starts out from."""

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import codecs
-import hashlib
 import json
 import os
 import posixpath
@@ -560,46 +559,6 @@ def get_relative_path(source, target):
     # We should never get here.  (The last ancestor in source.parents will
     # be '.' — target.relative_to('.') will always succeed.)
     raise AssertionError("This should not happen")
-
-
-def get_structure_hash(params):
-    """Given a Python structure this generates a hash.  This is useful for
-    storing artifact config hashes.  Not all Python types are supported, but
-    quite a few are.
-    """
-    h = hashlib.md5()
-
-    def _hash(obj):
-        if obj is None:
-            h.update("N;")
-        elif obj is True:
-            h.update("T;")
-        elif obj is False:
-            h.update("F;")
-        elif isinstance(obj, dict):
-            h.update("D%d;" % len(obj))
-            for key, value in sorted(obj.items()):
-                _hash(key)
-                _hash(value)
-        elif isinstance(obj, tuple):
-            h.update("T%d;" % len(obj))
-            for item in obj:
-                _hash(item)
-        elif isinstance(obj, list):
-            h.update("L%d;" % len(obj))
-            for item in obj:
-                _hash(item)
-        elif isinstance(obj, int):
-            h.update("T%d;" % obj)
-        elif isinstance(obj, bytes):
-            h.update("B%d;%s;" % (len(obj), obj))
-        elif isinstance(obj, str):
-            h.update("S%d;%s;" % (len(obj), obj.encode("utf-8")))
-        elif hasattr(obj, "__get_lektor_param_hash__"):
-            obj.__get_lektor_param_hash__(h)
-
-    _hash(params)
-    return h.hexdigest()
 
 
 def profile_func(func):

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -645,6 +645,9 @@ class URLBuilder:
 
 
 def build_url(iterable, trailing_slash=None):
+    # NB: While this function is not used by Lektor itself, it is used
+    # by a number of plugins including: lektor-atom,
+    # lektor-gemini-capsule, lektor-index-pages, and lektor-tags.
     builder = URLBuilder()
     for item in iterable:
         builder.append(item)

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from functools import lru_cache
 from pathlib import PurePosixPath
 
-import click
 from jinja2 import is_undefined
 from markupsafe import Markup
 from slugify import slugify as _slugify
@@ -645,10 +644,6 @@ def format_lat_long(lat=None, long=None, secs=True):
     if long is not None:
         rv.append(_format(long, "EW"))
     return u", ".join(rv)
-
-
-def get_app_dir():
-    return click.get_app_dir("Lektor")
 
 
 def get_cache_dir():


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

I'm starting a PR to delete unused cruft from the Lektor source.

First on the chopping block is [`lektor.db._is_content_file`][1] which appears not to have been used in the life of this repo.  I.e. the following finds nothing of interest:
```sh
git grep _is_content_file
git log -G_is_content_file
```

Also, [I have written a script](https://github.com/dairiki/all-lektor-packages) to download source code of all the Lektor-plugins I can find. I've grepped said source code and found no references to `_is_content_file`.

[1]: https://github.com/lektor/lektor/blob/1999510ea5ba389ba97d8c99417bb336fc381320/lektor/db.py#L94

## Cruft Deleted

Here's a list of all cruft deleted.  None of this appears to have ever been used by Lektor itself, nor — as far as I can tell — by any plugins.

- `lektor.db._is_content_file`
- `lektor.utils.WorkerPool`, `lektor.utils.Worker`, `lektor.utils.safe_call`
- `lektor.utils.get_app_dir`
- `lektor.utils.get_structure_hash`, `lektor.db.Query.__get_lektor_param_hash__`
