### PR TITLE
Add go/no-go tests to check that various sites are buildable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,16 +113,16 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
+      - name: Install ffmpeg (Linux)
+        if: runner.os == 'Linux' && matrix.install-imagemagick
         run: sudo apt-get install -y ffmpeg
 
-      - name: Install macOS system dependencies
-        if: startsWith(runner.os, 'macos') && matrix.install-imagemagick
+      - name: Install imagemagick and ffmpeg (macOS)
+        if: runner.os == 'macOS' && matrix.install-imagemagick
         run: brew install imagemagick ffmpeg
 
-      - name: Install Windows system dependencies
-        if: startsWith(runner.os, 'windows') && matrix.install-imagemagick
+      - name: Install imagemagick and ffmpeg (Windows)
+        if: runner.os == 'Windows' && matrix.install-imagemagick
         run: |
           choco install --no-progress --timeout 600 imagemagick.app ffmpeg
           # The imagemagick.app package, for whatever reason, installs
@@ -143,7 +143,7 @@ jobs:
         # Refs:
         #   https://github.com/lektor/lektor/pull/933#issuecomment-923107580
         #   https://github.com/tox-dev/tox/issues/1550
-        if: startsWith(runner.os, 'windows')
+        if: runner.os == 'Windows'
         run: Out-File $env:GITHUB_ENV utf8 -Append -InputObject 'PYTHONIOENCODING=utf-8'
 
       - name: Install python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
 
       - name: Install ffmpeg (Linux)
         if: runner.os == 'Linux' && matrix.install-imagemagick
-        run: sudo apt-get install -y ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
 
       - name: Install imagemagick and ffmpeg (macOS)
         if: runner.os == 'macOS' && matrix.install-imagemagick

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
             pip-cache-dir: ~\AppData\Local\pip\Cache
           - python: "3.10"
             install-imagemagick: true
+    env:
+      # Run the slow tests.
+      PYTEST_ADDOPTS: --runslow
     steps:
       - uses: actions/checkout@v2
       - name: Cache pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ffmpeg
+
       - name: Install macOS system dependencies
         if: startsWith(runner.os, 'macos') && matrix.install-imagemagick
         run: brew install imagemagick ffmpeg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,27 @@ from lektor.project import Project
 from lektor.reporter import BufferReporter
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slowtest: marks very slow tests that are normally skipped; use --runslow enable",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--runslow"):
+        skip = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slowtest" in item.keywords:
+                item.add_marker(skip)
+
+
 @pytest.fixture(scope="session")
 def data_path():
     """Path to directory which contains test data.

--- a/tests/test_build_sites.py
+++ b/tests/test_build_sites.py
@@ -23,7 +23,7 @@ def build_project(tmp_path):
 
     def build_project(project_dir):
         run(
-            (sys.executable, "-m", "lektor", "build", "-O", output_dir),
+            (sys.executable, "-m", "lektor", "build", "-O", output_dir.__fspath__()),
             cwd=project_dir,
             check=True,
         )
@@ -59,5 +59,5 @@ def test_build_lektor_website(tmp_path, build_project):
     repo = "https://github.com/lektor/lektor-website.git"
     project_dir = tmp_path / "project"
 
-    run(("git", "clone", "--depth=1", repo, project_dir), check=True)
+    run(("git", "clone", "--depth=1", repo, project_dir.__fspath__()), check=True)
     build_project(project_dir)

--- a/tests/test_build_sites.py
+++ b/tests/test_build_sites.py
@@ -1,0 +1,61 @@
+"""Go/no-go tests that attempt to build various known Lektor sites."""
+import os
+import sys
+from pathlib import Path
+from shutil import which
+from subprocess import run
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def with_temporary_lektor_cache(tmp_path_factory, monkeypatch):
+    # Don't pollute user's lektor cache
+    cache_dir = tmp_path_factory.mktemp("cache")
+    for key in "XDG_CACHE_HOME", "LOCALAPPDATA":
+        monkeypatch.setitem(os.environ, key, str(cache_dir))
+
+
+@pytest.fixture
+def build_project(tmp_path):
+    output_dir = tmp_path / "output"
+
+    def build_project(project_dir):
+        run(
+            (sys.executable, "-m", "lektor", "build", "-O", output_dir),
+            cwd=project_dir,
+            check=True,
+        )
+
+    return build_project
+
+
+def _not_unbuildable(path):
+    # This one is not actually buildable (due to bad page id 'bäd')
+    return path.name != "ünicöde-project"
+
+
+def iter_projects(path=Path.cwd(), maxdepth=2, filter=_not_unbuildable):
+    if filter(path) and any(path.glob("*.lektorproject")):
+        yield str(path.relative_to(Path.cwd()))
+
+    if maxdepth > 0:
+        for subdir in path.iterdir():
+            if subdir.is_dir():
+                yield from iter_projects(subdir, maxdepth=maxdepth - 1)
+
+
+@pytest.mark.parametrize("project", iter_projects())
+def test_build_project(project, build_project):
+    build_project(project)
+
+
+@pytest.mark.skipif(not which("git"), reason="git not installed")
+@pytest.mark.requiresinternet
+@pytest.mark.slowtest
+def test_build_lektor_website(tmp_path, build_project):
+    repo = "https://github.com/lektor/lektor-website.git"
+    project_dir = tmp_path / "project"
+
+    run(("git", "clone", "--depth=1", repo, project_dir), check=True)
+    build_project(project_dir)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,11 @@ commands = pytest --cov={envsitepackagesdir}/lektor {posargs:tests}
 passenv =
     USERNAME
     PYTEST_ADDOPTS
+    # These are apparently necessary for Lektor to be able to install
+    # distributions requiring the compilation of extension modules on
+    # Windows.  (At least on the GitHub-hosted runner.)
+    ProgramData
+    ProgramFiles*
 setenv =
     # Use per-testenv coverage files to prevent contention when parallel
     # tests (using `tox -p`)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ python =
 
 [testenv]
 commands = pytest --cov={envsitepackagesdir}/lektor {posargs:tests}
-passenv = USERNAME
+passenv =
+    USERNAME
+    PYTEST_ADDOPTS
 setenv =
     # Use per-testenv coverage files to prevent contention when parallel
     # tests (using `tox -p`)


### PR DESCRIPTION
This adds a set of tests that check that all the sample sites included the Lektor source code build without error.

The sites built include the `example` site as well as the various test projects in the `tests` subdirectory.

A test is included which builds the master branch of [lektor-website]. However, since it is very slow and requires internet connectivity, this test is skipped by default.  A new `--runslow` custom pytest command-line parameter has been implemented which will enable this test.

[lektor-website]: https://github.com/lektor/lektor-website/