### PR TITLE
Bug: `title_i18n` is None if not provided

### DIFF
--- a/lektor/build_programs.py
+++ b/lektor/build_programs.py
@@ -31,7 +31,7 @@ class SourceInfo:
     """
 
     def __init__(
-        self, path, filename, alt=PRIMARY_ALT, type="unknown", title_i18n=None
+        self, path, filename, alt=PRIMARY_ALT, type="unknown", title_i18n={}
     ):
         self.path = path
         self.alt = alt


### PR DESCRIPTION
https://github.com/lektor/lektor/blob/a7c532a436f3c29dcf365ac9d004414e669dea14/lektor/build_programs.py#L33-L44

Optional method argument `title_i18n=None` can not be checked with `in` operator.

Suggesting a default value of `title_i18n={}` instead.