### PR TITLE
Fixes for werkzeug 2.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: "21.9b0"
+    rev: "22.3.0"
     hooks:
       - id: black
   - repo: https://github.com/asottile/reorder_python_imports

--- a/lektor/buildfailures.py
+++ b/lektor/buildfailures.py
@@ -2,8 +2,7 @@ import errno
 import hashlib
 import json
 import os
-
-from werkzeug.debug.tbtools import Traceback
+from traceback import TracebackException
 
 
 class BuildFailure:
@@ -12,13 +11,14 @@ class BuildFailure:
 
     @classmethod
     def from_exc_info(cls, artifact_name, exc_info):
-        tb = Traceback(*exc_info)
-        tb.filter_hidden_frames()
+        te = TracebackException(*exc_info)
+        # NB: we have dropped werkzeug's support for Paste's __traceback_hide__
+        # frame local.
         return cls(
             {
                 "artifact": artifact_name,
-                "exception": tb.exception,
-                "traceback": tb.plaintext,
+                "exception": "".join(te.format_exception_only()).strip(),
+                "traceback": "".join(te.format()).strip(),
             }
         )
 

--- a/lektor/environment/expressions.py
+++ b/lektor/environment/expressions.py
@@ -8,7 +8,7 @@ class Expression:
 
         def result_func(value):
             result.append(value)
-            return u""
+            return ""
 
         values = self.env.make_default_tmpl_values(pad, this, values, alt)
         values["__result__"] = result_func

--- a/lektor/imagetools.py
+++ b/lektor/imagetools.py
@@ -182,7 +182,7 @@ class EXIFInfo:
         val = self._get_float("EXIF ShutterSpeedValue")
         if val is not None:
             return "1/%d" % round(
-                1 / (2 ** -val)  # pylint: disable=invalid-unary-operand-type
+                1 / (2**-val)  # pylint: disable=invalid-unary-operand-type
             )
         return None
 

--- a/lektor/metaformat.py
+++ b/lektor/metaformat.py
@@ -1,6 +1,6 @@
 def _line_is_dashes(line):
     line = line.strip()
-    return line == u"-" * len(line) and len(line) >= 3
+    return line == "-" * len(line) and len(line) >= 3
 
 
 def _process_buf(buf):
@@ -43,9 +43,9 @@ def tokenize(iterable, interesting_keys=None, encoding=None):
         iterable = (x.decode(encoding, "replace") for x in iterable)
 
     for line in iterable:
-        line = line.rstrip(u"\r\n") + u"\n"
+        line = line.rstrip("\r\n") + "\n"
 
-        if line.rstrip() == u"---":
+        if line.rstrip() == "---":
             want_newline = False
             if key:
                 yield _flush_item()
@@ -57,7 +57,7 @@ def tokenize(iterable, interesting_keys=None, encoding=None):
             if is_interesting:
                 buf.append(line)
         else:
-            bits = line.split(u":", 1)
+            bits = line.split(":", 1)
             if len(bits) == 2:
                 key = [bits[0].strip()]
                 if interesting_keys is None:
@@ -65,7 +65,7 @@ def tokenize(iterable, interesting_keys=None, encoding=None):
                 else:
                     is_interesting = key[0] in interesting_keys
                 if is_interesting:
-                    first_bit = bits[1].strip(u"\t ")
+                    first_bit = bits[1].strip("\t ")
                     if first_bit.strip():
                         buf = [first_bit]
                     else:
@@ -86,7 +86,7 @@ def serialize(iterable, encoding=None):
     def _produce(item, escape=False):
         if escape:
             if _line_is_dashes(item):
-                item = u"-" + item
+                item = "-" + item
         if encoding is not None:
             item = item.encode(encoding)
         return item

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -526,7 +526,7 @@ class GithubPagesPublisher(Publisher):
 
     def update_git_config(self, repo, url, branch, credentials=None):
         ssh_command = None
-        path = url.host + u"/" + url.path.strip(u"/")
+        path = url.host + "/" + url.path.strip("/")
         cred = None
         if url.scheme in ("ghpages", "ghpages+ssh"):
             push_url = "git@github.com:%s.git" % path

--- a/lektor/types/flow.py
+++ b/lektor/types/flow.py
@@ -127,7 +127,7 @@ class Flow:
         self.record = record
 
     def __html__(self):
-        return Markup(u"\n\n".join(x.__html__() for x in self.blocks))
+        return Markup("\n\n".join(x.__html__() for x in self.blocks))
 
     def __bool__(self):
         return bool(self.blocks)
@@ -215,7 +215,7 @@ class FlowType(Type):
 
                 d = {}
                 for key, lines in tokenize(block_lines):
-                    d[key] = u"".join(lines)
+                    d[key] = "".join(lines)
                 rv.append(flowblock.process_raw_data(d, pad=raw.pad))
         except BadFlowBlock as e:
             return raw.bad_value(str(e))

--- a/lektor/types/formats.py
+++ b/lektor/types/formats.py
@@ -16,4 +16,4 @@ class MarkdownType(Type):
     widget = "multiline-text"
 
     def value_from_raw(self, raw):
-        return MarkdownDescriptor(raw.value or u"")
+        return MarkdownDescriptor(raw.value or "")

--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -27,7 +27,7 @@ class StringType(SingleInputType):
         try:
             return raw.value.splitlines()[0].strip()
         except IndexError:
-            return u""
+            return ""
 
 
 class StringsType(Type):

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -329,10 +329,10 @@ def htmlsafe_json_dump(obj, **kwargs):
     kwargs.setdefault("cls", JSONEncoder)
     rv = (
         json.dumps(obj, **kwargs)
-        .replace(u"<", u"\\u003c")
-        .replace(u">", u"\\u003e")
-        .replace(u"&", u"\\u0026")
-        .replace(u"'", u"\\u0027")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("'", "\\u0027")
     )
     if not _slash_escape:
         rv = rv.replace("\\/", "/")
@@ -405,7 +405,7 @@ def get_dependent_url(url_path, suffix, ext=None):
     url_base, url_ext = posixpath.splitext(url_filename)
     if ext is None:
         ext = url_ext
-    return posixpath.join(url_directory, url_base + u"@" + suffix + ext)
+    return posixpath.join(url_directory, url_base + "@" + suffix + ext)
 
 
 @contextmanager
@@ -590,10 +590,10 @@ def deg_to_dms(deg):
 def format_lat_long(lat=None, long=None, secs=True):
     def _format(value, sign):
         d, m, sd = deg_to_dms(value)
-        return u"%d° %d′ %s%s" % (
+        return "%d° %d′ %s%s" % (
             abs(d),
             abs(m),
-            secs and (u"%d″ " % abs(sd)) or "",
+            secs and ("%d″ " % abs(sd)) or "",
             sign[d < 0],
         )
 
@@ -602,7 +602,7 @@ def format_lat_long(lat=None, long=None, secs=True):
         rv.append(_format(lat, "NS"))
     if long is not None:
         rv.append(_format(long, "EW"))
-    return u", ".join(rv)
+    return ", ".join(rv)
 
 
 def get_cache_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def project():
 def scratch_project_data(tmpdir):
     base = tmpdir.mkdir("scratch-proj")
     lektorfile_text = textwrap.dedent(
-        u"""
+        """
         [project]
         name = Scratch
 
@@ -98,7 +98,7 @@ def scratch_project_data(tmpdir):
     )
     base.join("Scratch.lektorproject").write_text(lektorfile_text, "utf8", ensure=True)
     content_text = textwrap.dedent(
-        u"""
+        """
         _model: page
         ---
         title: Index
@@ -108,14 +108,14 @@ def scratch_project_data(tmpdir):
     )
     base.join("content", "contents.lr").write_text(content_text, "utf8", ensure=True)
     template_text = textwrap.dedent(
-        u"""
+        """
         <h1>{{ this.title }}</h1>
         {{ this.body }}
     """
     )
     base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
     model_text = textwrap.dedent(
-        u"""
+        """
         [model]
         label = {{ this.title }}
 

--- a/tests/test_buildfailures.py
+++ b/tests/test_buildfailures.py
@@ -1,0 +1,87 @@
+import os
+import re
+import sys
+
+import pytest
+
+from lektor.buildfailures import BuildFailure
+from lektor.buildfailures import FailureController
+
+
+@pytest.fixture
+def output_path(tmp_path):
+    return tmp_path.__fspath__()
+
+
+@pytest.fixture
+def failure_controller(pad, output_path):
+    return FailureController(pad, output_path)
+
+
+def test_BuildFailure_from_exc_info():
+    def throw_exception():
+        x = {}
+        try:
+            x["somekey"]
+        except KeyError:
+            raise RuntimeError("test error")  # pylint: disable=raise-missing-from
+
+    artifact_name = "test_artifact"
+    try:
+        throw_exception()
+    except Exception:
+        failure = BuildFailure.from_exc_info(artifact_name, sys.exc_info())
+
+    assert failure.data["artifact"] == artifact_name
+    assert failure.data["exception"] == "RuntimeError: test error"
+    traceback = failure.data["traceback"]
+    print(traceback)
+    patterns = [
+        r'x\["somekey"\]',
+        r"KeyError: .somekey.",
+        r"During handling of the above exception, another exception occurred",
+        r"throw_exception\(\)",
+        r'raise RuntimeError\("test error"\)',
+        r"RuntimeError: test error",
+    ]
+    for pattern in patterns:
+        assert re.search(pattern, traceback)
+
+
+def test_failure_controller(failure_controller):
+    try:
+        raise RuntimeError("test exception")
+    except Exception:
+        failure_controller.store_failure("artifact_name", sys.exc_info())
+
+    failure = failure_controller.lookup_failure("artifact_name")
+    assert failure.data["exception"] == "RuntimeError: test exception"
+
+    failure_controller.clear_failure("artifact_name")
+    assert failure_controller.lookup_failure("artifact_name") is None
+
+
+def test_failure_controller_clear_lookup_missing(failure_controller):
+    assert failure_controller.lookup_failure("missing_artifact") is None
+
+
+def test_failure_controller_clear_missing(failure_controller):
+    failure_controller.clear_failure("missing_artifact")
+    assert failure_controller.lookup_failure("missing_artifact") is None
+
+
+def test_failure_controller_fs_exceptions(failure_controller):
+    # Create a directory in the location that FailureController wants
+    # a file stored to trigger unexpected OSErrors.
+    filename = failure_controller.get_filename("broken")
+    os.makedirs(filename)
+
+    with pytest.raises(OSError):
+        failure_controller.lookup_failure("broken")
+    with pytest.raises(OSError):
+        failure_controller.clear_failure("broken")
+    with pytest.raises(OSError):
+        try:
+            assert False
+        except Exception:
+            failure_controller.store_failure("broken", sys.exc_info())

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -59,7 +59,7 @@ def test_exif(pad):
     assert image.exif.copyright is None
     assert image.exif.created_at == datetime(2015, 12, 6, 11, 37, 38)
     assert image.exif.exposure_time == "1/33"
-    assert image.exif.f == u"\u0192/2.2"
+    assert image.exif.f == "\u0192/2.2"
     assert almost_equal(image.exif.f_num, 2.2)
     assert image.exif.flash_info == "Flash did not fire, compulsory flash mode"
     assert image.exif.focal_length == "4.2mm"

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -17,10 +17,10 @@ def test_paginated_children(pad):
     children = page1.pagination.items.all()
     assert len(children) == 4
     assert [x["name"] for x in children] == [
-        u"Coffee",
-        u"Bagpipe",
-        u"Master",
-        u"Oven",
+        "Coffee",
+        "Bagpipe",
+        "Master",
+        "Oven",
     ]
 
     assert ("projects", "en", "1") in pad.cache.persistent
@@ -35,9 +35,9 @@ def test_paginated_children(pad):
     children = page2.pagination.items.all()
     assert len(children) == 3
     assert [x["name"] for x in children] == [
-        u"Postage",
-        u"Slave",
-        u"Wolf",
+        "Postage",
+        "Slave",
+        "Wolf",
     ]
 
     assert ("projects", "en", "2") in pad.cache.persistent
@@ -54,13 +54,13 @@ def test_unpaginated_children(pad):
     children = page_all.pagination.items.all()
     assert len(children) == 7
     assert [x["name"] for x in children] == [
-        u"Coffee",
-        u"Bagpipe",
-        u"Master",
-        u"Oven",
-        u"Postage",
-        u"Slave",
-        u"Wolf",
+        "Coffee",
+        "Bagpipe",
+        "Master",
+        "Oven",
+        "Postage",
+        "Slave",
+        "Wolf",
     ]
 
 
@@ -147,14 +147,14 @@ def test_unpaginated_children_other_alt(pad):
     children = page_all.pagination.items.all()
     assert len(children) == 8
     assert [x["name"] for x in children] == [
-        u"Kaffee",
-        u"Dudelsack",
-        u"Meister",
-        u"Ofen",
-        u"Porto",
-        u"Sklave",
-        u"Wolf",
-        u"Zaun",
+        "Kaffee",
+        "Dudelsack",
+        "Meister",
+        "Ofen",
+        "Porto",
+        "Sklave",
+        "Wolf",
+        "Zaun",
     ]
 
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -39,7 +39,7 @@ def theme_project(theme_project_tmpdir, request):
 
     # Create the .lektorproject file
     lektorfile_text = textwrap.dedent(
-        u"""
+        """
         [project]
         name = Themes Project
         {}

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -10,9 +10,7 @@ from lektor.reporter import BufferReporter
 
 
 def get_unicode_builder(tmpdir):
-    proj = Project.from_path(
-        os.path.join(os.path.dirname(__file__), u"ünicöde-project")
-    )
+    proj = Project.from_path(os.path.join(os.path.dirname(__file__), "ünicöde-project"))
     env = Environment(proj)
     pad = Database(env).new_pad()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,7 +65,7 @@ def test_magic_split_ext():
 def test_slugify():
 
     assert slugify("w o w") == "w-o-w"
-    assert slugify(u"Șö prĕtty") == "so-pretty"
+    assert slugify("Șö prĕtty") == "so-pretty"
     assert slugify("im age.jpg") == "im-age.jpg"
     assert slugify("slashed/slug") == "slashed/slug"
 

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -90,5 +90,6 @@ def test_resolve_artifact(resolve_artifact, url_path, expected, output_path):
 def test_resolve_artifact_redirects(resolve_artifact, url_path, location):
     with pytest.raises(HTTPException) as exc:
         resolve_artifact(url_path)
-    assert exc.value.response.status_code == 301
+    # add_slash_redirect in werkzeug>=2.1.0 returns 308 - previously it returned 301
+    assert exc.value.response.status_code in (301, 308)
     assert exc.value.response.headers["Location"] == location


### PR DESCRIPTION
Lektor has been using an undocumented internal API from `werkzeug.debug.tbtools` to format exceptions and stack tracebacks.  Werkzeug 2.1.0, released yesterday, significantly refactors that module.

In this PR, we disuse `werkzeug.debug.tbtools` instead using exception formatting machinery available in the standard `traceback` module (since python 3.5) to format exceptions.


This PR also makes minor changes to `test/test_webui.py` to accommodate changes in werkzeug==2.1.0's  `append_slash_redirect`.

And we update the pre-commit config to use black 22.3.0.  Prior versions of black fail to run with the latest click==8.1.0.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1018

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
