### PR TITLE
Save and preview

### DIFF
--- a/frontend/js/components/AdminLinkWithHotkey.tsx
+++ b/frontend/js/components/AdminLinkWithHotkey.tsx
@@ -1,7 +1,7 @@
 import React, { MutableRefObject, useCallback, useEffect, useRef } from "react";
 import { NavLink } from "react-router-dom";
 import { useRecord } from "../context/record-context";
-import { KeyboardShortcut, keyboardShortcutHandler } from "../utils";
+import { getKey, KeyboardShortcut, keyboardShortcutHandler } from "../utils";
 import { AdminLinkProps } from "./AdminLink";
 import { adminPath } from "./use-go-to-admin-page";
 
@@ -61,6 +61,7 @@ export default function AdminLinkWithHotkey({
         isActive && recordMatches ? "active" : undefined
       }
       ref={el}
+      title={getKey(shortcut)}
       {...otherProps}
     >
       {children}

--- a/frontend/js/components/DialogSlot.tsx
+++ b/frontend/js/components/DialogSlot.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import FindFiles from "../dialogs/find-files/FindFiles";
 import Publish from "../dialogs/Publish";
 import Refresh from "../dialogs/Refresh";
-import { LektorEvents, subscribe, unsubscribe } from "../events";
+import { LektorEvents, useLektorEvent } from "../events";
 
 type DialogDetails = LektorEvents["lektor-dialog"];
 
@@ -20,14 +20,14 @@ export default function DialogSlot(): JSX.Element | null {
       setDialog((d) => (d ? { ...d, preventNavigation } : null)),
     []
   );
-  useEffect(() => {
-    const handler = ({ detail }: CustomEvent<DialogDetails>) => {
+
+  useLektorEvent(
+    "lektor-dialog",
+    useCallback(({ detail }) => {
       // Only change dialog if there is no dialog yet.
       setDialog((current) => current ?? detail);
-    };
-    subscribe("lektor-dialog", handler);
-    return () => unsubscribe("lektor-dialog", handler);
-  }, []);
+    }, [])
+  );
 
   if (!dialog) {
     return null;

--- a/frontend/js/components/ErrorDialog.tsx
+++ b/frontend/js/components/ErrorDialog.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import SlideDialog from "./SlideDialog";
 import { trans, TranslationEntry } from "../i18n";
-import { LektorEvents, subscribe, unsubscribe } from "../events";
+import { useLektorEvent } from "../events";
 
 /**
  * Listen to events and show an error dialog (potentially on top of an open
@@ -12,12 +12,12 @@ export default function ErrorDialog(): JSX.Element | null {
 
   const dismiss = useCallback(() => setError(null), []);
 
-  useEffect(() => {
-    const handler = ({ detail }: CustomEvent<LektorEvents["lektor-error"]>) =>
+  useLektorEvent(
+    "lektor-error",
+    useCallback(({ detail }) => {
       setError(detail);
-    subscribe("lektor-error", handler);
-    return () => unsubscribe("lektor-error", handler);
-  }, []);
+    }, [])
+  );
 
   if (!error) {
     return null;

--- a/frontend/js/events.ts
+++ b/frontend/js/events.ts
@@ -16,7 +16,7 @@ export function dispatch<T extends keyof LektorEvents>(
 }
 
 /** Subscribe to one of Lektor's custom events. */
-export function subscribe<T extends keyof LektorEvents>(
+function subscribe<T extends keyof LektorEvents>(
   type: T,
   handler: (ev: CustomEvent<LektorEvents[T]>) => void
 ): void {
@@ -24,7 +24,7 @@ export function subscribe<T extends keyof LektorEvents>(
 }
 
 /** Subscribe from one of Lektor's custom events. */
-export function unsubscribe<T extends keyof LektorEvents>(
+function unsubscribe<T extends keyof LektorEvents>(
   type: T,
   handler: (ev: CustomEvent<LektorEvents[T]>) => void
 ): void {

--- a/frontend/js/events.ts
+++ b/frontend/js/events.ts
@@ -1,7 +1,10 @@
+import { useEffect } from "react";
+
 export type LektorEvents = {
   "lektor-attachments-changed": string;
   "lektor-dialog": { type: "find-files" | "refresh" | "publish" };
   "lektor-error": { code: string };
+  "lektor-notification": { message: string };
 };
 
 /** Dispatch one of the custom events. */
@@ -26,4 +29,20 @@ export function unsubscribe<T extends keyof LektorEvents>(
   handler: (ev: CustomEvent<LektorEvents[T]>) => void
 ): void {
   document.removeEventListener(type, handler as EventListener);
+}
+
+/**
+ * Use a subscription to one of the Lektor's events.
+ *
+ * The handler should be wrapped in a use callback to avoid frequent
+ * re-attaching of the event handler.
+ */
+export function useLektorEvent<T extends keyof LektorEvents>(
+  type: T,
+  handler: (ev: CustomEvent<LektorEvents[T]>) => void
+) {
+  useEffect(() => {
+    subscribe(type, handler);
+    return () => unsubscribe(type, handler);
+  }, [type, handler]);
 }

--- a/frontend/js/sidebar/PageActions.tsx
+++ b/frontend/js/sidebar/PageActions.tsx
@@ -40,6 +40,7 @@ function BrowseFSLink() {
 }
 
 const editKey = { key: "Control+e", mac: "Meta+e", preventDefault: true };
+const previewKey = { key: "Control+p", mac: "Meta+p", preventDefault: true };
 
 function PageActions({ recordInfo }: { recordInfo: RecordInfo }) {
   const { path, alt } = useRecord();
@@ -70,9 +71,14 @@ function PageActions({ recordInfo }: { recordInfo: RecordInfo }) {
           </li>
         )}
         <li key="preview">
-          <AdminLink page="preview" path={path} alt={alt}>
+          <AdminLinkWithHotkey
+            page="preview"
+            path={path}
+            alt={alt}
+            shortcut={previewKey}
+          >
             {trans("PREVIEW")}
-          </AdminLink>
+          </AdminLinkWithHotkey>
         </li>
         {recordInfo.exists && (
           <li key="fs-open">

--- a/frontend/js/sidebar/Sidebar.tsx
+++ b/frontend/js/sidebar/Sidebar.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useReducer, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useReducer,
+  useState,
+} from "react";
 import { get } from "../fetch";
 import { trans_obj } from "../i18n";
 import { showErrorDialog } from "../error-dialog";
@@ -8,7 +14,7 @@ import Alternatives from "./Alternatives";
 import AttachmentActions from "./AttachmentActions";
 import { CHILDREN_PER_PAGE } from "./constants";
 import ChildActions from "./ChildActions";
-import { subscribe, unsubscribe } from "../events";
+import { useLektorEvent } from "../events";
 import { PageContext } from "../context/page-context";
 import { useRecordPath } from "../context/record-context";
 
@@ -54,15 +60,17 @@ function Sidebar(): JSX.Element | null {
   const [childPosCache] = useState(() => new ChildPosCache());
   const [updateForced, forceUpdate] = useReducer((x) => x + 1, 0);
 
-  useEffect(() => {
-    const handler = ({ detail }: CustomEvent<string>) => {
-      if (detail === path) {
-        forceUpdate();
-      }
-    };
-    subscribe("lektor-attachments-changed", handler);
-    return () => unsubscribe("lektor-attachments-changed", handler);
-  }, [path]);
+  useLektorEvent(
+    "lektor-attachments-changed",
+    useCallback(
+      ({ detail }) => {
+        if (detail === path) {
+          forceUpdate();
+        }
+      },
+      [path]
+    )
+  );
 
   useEffect(() => {
     let ignore = false;

--- a/frontend/js/views/App.tsx
+++ b/frontend/js/views/App.tsx
@@ -5,6 +5,7 @@ import Sidebar from "../sidebar/Sidebar";
 import DialogSlot from "../components/DialogSlot";
 import ServerStatus from "../components/ServerStatus";
 import ErrorDialog from "../components/ErrorDialog";
+import Notifications from "./Notifications";
 
 import EditPage from "./edit/EditPage";
 import DeletePage from "./delete/DeletePage";
@@ -28,6 +29,7 @@ export default function App() {
   const MainComponent = mainComponentForPage[page];
   return (
     <>
+      <Notifications />
       <Header sidebarIsActive={sidebarIsActive} toggleSidebar={toggleSidebar} />
       <ErrorDialog />
       <DialogSlot />

--- a/frontend/js/views/Notifications.css
+++ b/frontend/js/views/Notifications.css
@@ -1,0 +1,7 @@
+.notifications {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 240px;
+  z-index: 10000;
+}

--- a/frontend/js/views/Notifications.tsx
+++ b/frontend/js/views/Notifications.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback, useState } from "react";
+import { useLektorEvent } from "../events";
+
+import "./Notifications.css";
+
+export default function Notifications(): JSX.Element {
+  const [notifications, setNotifications] = useState<{ message: string }[]>([]);
+
+  const addNotification = useCallback((s: string) => {
+    const notification = { message: s };
+    setNotifications((ns) => [...ns, notification]);
+    setTimeout(() => {
+      setNotifications((ns) => ns.filter((n) => n !== notification));
+    }, 3000);
+  }, []);
+
+  useLektorEvent(
+    "lektor-notification",
+    useCallback(
+      (ev) => {
+        addNotification(ev.detail.message);
+      },
+      [addNotification]
+    )
+  );
+
+  return (
+    <div className="notifications">
+      {notifications.map(({ message }, i) => (
+        <div
+          key={`${message};${i}`}
+          className="alert alert-success"
+          role="alert"
+        >
+          {message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/js/views/edit/EditPageActions.tsx
+++ b/frontend/js/views/edit/EditPageActions.tsx
@@ -7,9 +7,11 @@ import { RawRecordInfo } from "./EditPage";
 export function EditPageActions({
   recordInfo,
   hasPendingChanges,
+  saveChangesAndPreview,
 }: {
   recordInfo: RawRecordInfo;
   hasPendingChanges: boolean;
+  saveChangesAndPreview: () => void;
 }): JSX.Element {
   const { path, alt } = useRecord();
   const goToAdminPage = useGoToAdminPage();
@@ -26,6 +28,14 @@ export function EditPageActions({
         className="btn btn-primary"
       >
         {trans("SAVE_CHANGES")}
+      </button>
+      <button
+        type="button"
+        disabled={!hasPendingChanges}
+        onClick={saveChangesAndPreview}
+        className="btn btn-secondary"
+      >
+        {trans("SAVE_CHANGES_AND_PREVIEW")}
       </button>
       {recordInfo.can_be_deleted ? (
         <button

--- a/frontend/scss/bootstrap-overrides.scss
+++ b/frontend/scss/bootstrap-overrides.scss
@@ -51,8 +51,11 @@ $theme-colors: map-merge($theme-colors, $custom-theme-colors);
 @import "../node_modules/bootstrap/scss/navbar";
 
 // Components
-@import "../node_modules/bootstrap/scss/breadcrumb";
+@import "../node_modules/bootstrap/scss/alert";
+@import "../node_modules/bootstrap/scss/forms/input-group";
 @import "../node_modules/bootstrap/scss/list-group";
+@import "../node_modules/bootstrap/scss/breadcrumb";
 
 // Utility classes
+@import "../node_modules/bootstrap/scss/utilities";
 @import "../node_modules/bootstrap/scss/utilities/api";

--- a/lektor/translations/en.json
+++ b/lektor/translations/en.json
@@ -56,6 +56,8 @@
   "EDIT_ATTACHMENT_METADATA_OF": "Edit Metadata of Attachment “%s”",
   "EDIT_PAGE_NAME": "Edit “%s”",
   "SAVE_CHANGES": "Save Changes",
+  "SAVE_CHANGES_AND_PREVIEW": "Save Changes and Preview",
+  "SAVE_SUCCESS": "Page saved successfully",
   "BROWSE_FS": "Browse in Filesystem",
   "BROWSE_FS_MAC": "Reveal in Finder",
   "BROWSE_FS_WINDOWS": "Open in Explorer",


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Supercedes #701


<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

The current behaviour is to jump to the preview page after saving. This PR adds a new button ("Save Changes and Preview") which behaves like the current one and changes the main "Save Changes" button to only save the changes (and show a notification in the top right corner that saving succeeded). That behaviour seems to be more in line with how most "editors" behave on save.

For keyboard users, this adds a shortcut (Ctrl/Meta+p) which allows one to quickly jump between the edit (or any other) and the preview page. This was currently only possible with the Ctrl/Meta+s shortcut, which only worked on the edit page if one had actually changed something. Saving and previewing now takes one additional click (but I think having distinct shortcuts is more explicit and avoids saving unwanted changes if one just wants to jump to the preview page).