### PR TITLE
allow absolute urls in `asseturl`

### DIFF
--- a/lektor/context.py
+++ b/lektor/context.py
@@ -18,7 +18,7 @@ def url_to(*args, **kwargs):
     return ctx.url_to(*args, **kwargs)
 
 
-def get_asset_url(asset):
+def get_asset_url(asset, absolute=None):
     """Calculates the asset URL relative to the current record."""
     ctx = get_ctx()
     if ctx is None:
@@ -26,7 +26,7 @@ def get_asset_url(asset):
     asset = ctx.pad.get_asset(asset)
     if asset is None:
         return Undefined("Asset not found")
-    return ctx.get_asset_url(asset)
+    return ctx.get_asset_url(asset, absolute=absolute)
 
 
 @LocalProxy
@@ -180,14 +180,14 @@ class Context:
             strict_resolve=strict_resolve,
         )
 
-    def get_asset_url(self, asset):
+    def get_asset_url(self, asset, absolute=None):
         """Calculates the asset URL relative to the current record."""
         if self.source is None:
             raise RuntimeError(
                 "Can only generate paths to assets if "
                 "the context has a source document set."
             )
-        asset_url = self.source.url_to("!" + asset.url_path)
+        asset_url = self.source.url_to("!" + asset.url_path, absolute=absolute)
         info = self.build_state.get_file_info(asset.source_filename)
         self.record_dependency(asset.source_filename)
         return f"{asset_url}?h={info.checksum[:8]}"

--- a/lektor/context.py
+++ b/lektor/context.py
@@ -18,7 +18,7 @@ def url_to(*args, **kwargs):
     return ctx.url_to(*args, **kwargs)
 
 
-def get_asset_url(asset, absolute=None):
+def get_asset_url(asset, **kwargs):
     """Calculates the asset URL relative to the current record."""
     ctx = get_ctx()
     if ctx is None:
@@ -26,7 +26,7 @@ def get_asset_url(asset, absolute=None):
     asset = ctx.pad.get_asset(asset)
     if asset is None:
         return Undefined("Asset not found")
-    return ctx.get_asset_url(asset, absolute=absolute)
+    return ctx.get_asset_url(asset, **kwargs)
 
 
 @LocalProxy
@@ -180,14 +180,14 @@ class Context:
             strict_resolve=strict_resolve,
         )
 
-    def get_asset_url(self, asset, absolute=None):
+    def get_asset_url(self, asset, **kwargs):
         """Calculates the asset URL relative to the current record."""
         if self.source is None:
             raise RuntimeError(
                 "Can only generate paths to assets if "
                 "the context has a source document set."
             )
-        asset_url = self.source.url_to("!" + asset.url_path, absolute=absolute)
+        asset_url = self.source.url_to("!" + asset.url_path, **kwargs)
         info = self.build_state.get_file_info(asset.source_filename)
         self.record_dependency(asset.source_filename)
         return f"{asset_url}?h={info.checksum[:8]}"


### PR DESCRIPTION
### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [x] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

This PR adds a new `absolute` parameter option to `asseturl`.
This way you can have absolute asset URLs while the remaining website stays relative. Especially useful for error pages ([doc](https://www.getlektor.com/docs/guides/error-pages/)) with stylesheets etc. As long as you think of manually adding absolute URLs in your error pages when necessary.

We could also allow all `**kwargs` to pass to `url_to`, but `alt` does not make sense for assets ~and `external` does not seem to work with `!`-urls.~
EDIT: my bad, `absolute` overrides `external`, thats why it didn't work.

Disclaimer: I have not run any tests, though it should not break anything (fingers crossed).