### PR TITLE
Fix for #1031: "multiple not valid with is_flag" from click 8.1.3

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -357,39 +357,28 @@ def server_cmd(
 @cli.command("project-info", short_help="Shows the info about a project.")
 @click.option("as_json", "--json", is_flag=True, help="Prints out the data as json.")
 @click.option(
-    "ops",
     "--name",
     is_flag=True,
-    multiple=True,
-    flag_value="name",
     help="Print the project name",
 )
 @click.option(
-    "ops",
     "--project-file",
     is_flag=True,
-    multiple=True,
-    flag_value="project_file",
     help="Print the path to the project file.",
 )
 @click.option(
-    "ops",
     "--tree",
     is_flag=True,
-    multiple=True,
-    flag_value="tree",
     help="Print the path to the tree.",
 )
 @click.option(
-    "ops",
+    "default_output_path",
     "--output-path",
     is_flag=True,
-    multiple=True,
-    flag_value="default_output_path",
     help="Print the path to the default output path.",
 )
 @pass_context
-def project_info_cmd(ctx, as_json, ops):
+def project_info_cmd(ctx, as_json, **opts):
     """Prints out information about the project.  This is particular
     useful for script usage or for discovering information about a
     Lektor project that is not immediately obvious (like the paths
@@ -400,6 +389,7 @@ def project_info_cmd(ctx, as_json, ops):
         echo_json(project.to_json())
         return
 
+    ops = [k for k, v in opts.items() if v]
     if ops:
         data = project.to_json()
         for op in ops:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,11 @@ import os
 import re
 import warnings
 
+import pytest
 from markers import imagemagick
 
 from lektor.cli import cli
+from lektor.project import Project
 
 
 def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
@@ -103,3 +105,23 @@ def test_deploy_extra_flag(project_cli_runner, mocker):
     result = project_cli_runner.invoke(cli, ["deploy", "-f", "draft"])
     assert result.exit_code == 0
     assert mock_publish.call_args[1]["extra_flags"] == ("draft",)
+
+
+@pytest.mark.parametrize(
+    "flag, expect",
+    [
+        ("--name", "Demo Project"),
+        ("--project-file", "{tree_dir}{os.sep}Website.lektorproject"),
+        ("--tree", "{tree_dir}"),
+        ("--output-path", "{output_path}"),
+    ],
+)
+def test_project_info_path_flags(project_cli_runner, flag, expect):
+    tree_dir = os.getcwd()
+    result = project_cli_runner.invoke(cli, ["project-info", flag])
+    assert result.exit_code == 0
+    assert result.stdout.rstrip() == expect.format(
+        tree_dir=tree_dir,
+        output_path=Project.from_path(tree_dir).get_output_path(),
+        os=os,
+    )


### PR DESCRIPTION

The latest release of click raises `TypeError` for Options that are
declared with both `multiple` and `is_flag` set. The exception message
suggests using `count` instead, but that does not do what we want.

This commit rejiggers things to avoid the use of `multiple` on
`is_flag` options.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1031

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
