### PR TITLE
Add missing implicit requires, remove dropped extras & unneeded wheel build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6"]
+requires = ["setuptools>=45", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,14 @@ install_requires =
     importlib_metadata;python_version<"3.8"
     inifile>=0.4.1
     Jinja2>=3.0
+    MarkupSafe
     marshmallow
     marshmallow_dataclass
     mistune>=0.7.0,<3
     pip
     python-slugify
-    requests[security]
+    pytz
+    requests
     setuptools
     watchdog
     Werkzeug>=2.1.0,<3


### PR DESCRIPTION
This issue template looks _awfully_ familiar to the one I originally created for the Spyder org many years ago...I'm flattered :)

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Seemed small and task-based enough that it didn't need an issue, but I can create one if you really want.

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] ~Wrote at least one-line docstrings (for any new functions)~ No code changes
- [x] ~Added unit test(s) covering the changes (if testable)~ No code changes
<!--- Remember that an image/animation is worth a thousand words! --->
- [x] ~Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))~ No UI changes
- [x] ~Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)~ No user-facing changes

<!--- Explain what you've done and why --->

Updates several build and run-time dependency specs to reflect recent changes and modern guidance. This doesn't actually change the solve result for existing installs, but avoids things breaking in the future.

Changes originally discovered, tested and fixed downstream in conda-forge/lektor-feedstock#19 .

* Add MarkupSafe and pytz as explicit runtime deps, since they are imported and used directly by Lektor but not explicitly declared, and only happen to be satisfied transitively which cannot be relied upon.
* Remove the [security] extra to requests, as it was dropped in psf/requests#5267 due to being unnecessary in any modern, supported Python (>=3.6-3.7, which is the minimum Lektor supports), and actually makes things substantially _less_ secure.
* Remove the [toml] extra to Setuptools_SCM, which was dropped in Setuptools_SCM 6.2.0, and bump the version slightly accordingly (see pypa/setuptools_scm#610 )
* Remove wheel as a direct build-system.requires following updated normative recommendations (see, for example, pypa/packaging.python.org#1050 ), as it never was supposed to be there in the first place and was only initially added in earlier guidance as an oversight.

<!--- Thanks for your help making Lektor better for everyone! --->
