### PR TITLE
Fix extra_flag crash 

### DIFF
--- a/lektor/admin/context.py
+++ b/lektor/admin/context.py
@@ -59,7 +59,7 @@ class LektorContext(LektorInfo):
 
     @cached_property
     def builder(self) -> Builder:
-        return Builder(self.pad, self.output_path, self.extra_flags)
+        return Builder(self.pad, self.output_path, extra_flags=self.extra_flags)
 
     @cached_property
     def failure_controller(self) -> FailureController:

--- a/tests/admin/test_serve.py
+++ b/tests/admin/test_serve.py
@@ -163,6 +163,7 @@ def output_path(tmp_path):
 def flag(request):
     return request.param
 
+
 @pytest.fixture
 def app(output_path, project_path, flag):
     project = Project.from_path(project_path)
@@ -172,6 +173,7 @@ def app(output_path, project_path, flag):
     app.register_blueprint(serve.bp, url_prefix="/")
     app.add_url_rule("/ADMIN/EDIT", "url.edit", build_only=True)
     return app
+
 
 ################################################################
 

--- a/tests/admin/test_serve.py
+++ b/tests/admin/test_serve.py
@@ -159,16 +159,19 @@ def output_path(tmp_path):
     return output_path
 
 
+@pytest.fixture(params=[None, ["FLAG"]])
+def flag(request):
+    return request.param
+
 @pytest.fixture
-def app(output_path, project_path):
+def app(output_path, project_path, flag):
     project = Project.from_path(project_path)
     env = Environment(project, load_plugins=False)
-    lektor_info = LektorInfo(env, output_path)
+    lektor_info = LektorInfo(env, output_path, extra_flags=flag)
     app = LektorApp(lektor_info)
     app.register_blueprint(serve.bp, url_prefix="/")
     app.add_url_rule("/ADMIN/EDIT", "url.edit", build_only=True)
     return app
-
 
 ################################################################
 


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #1041

### Description of Changes

`LektorContext.builder(...)` is now using a keyword argument for extra_flags to match the signature of `Builder.__init__(...)` and prevent passing them as the `buildstate_path`.
I've added a fixture to generate apps with and without flags. This adds more testcases than necessary but is the easiest solution regarding my knowledge of the codebase.

