### PR TITLE
admin server: pass requests for /admin on to frontend app

### DIFF
--- a/lektor/admin/modules/dash.py
+++ b/lektor/admin/modules/dash.py
@@ -9,9 +9,10 @@ from flask import request
 bp = Blueprint("dash", __name__, url_prefix="/admin")
 
 
-@bp.route("/<any(edit, delete, preview, add-child, upload):view>", endpoint="app")
+@bp.route("/<any(edit, delete, preview, add-child, upload, ''):page>", endpoint="app")
 def app_view(**kwargs: Any) -> str:
     """Render the React admin GUI app."""
+    # Note: client side app handles redirect from page='' to page='edit'
     return render_template(
         "dash.html",
         lektor_config={

--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -58,12 +58,13 @@ def make_app(
     app.register_blueprint(serve.bp)
 
     # Pass requests for /admin/... to the admin app
-    @app.route(f"{admin_path}/<path:path>", methods=["GET", "POST", "PUT"])
-    def admin_view(path: str) -> "WSGIApplication":
+    @app.route(f"{admin_path}/", defaults={"page": ""})
+    @app.route(f"{admin_path}/<path:page>", methods=["GET", "POST", "PUT"])
+    def admin_view(page: str) -> "WSGIApplication":
         environ = request.environ
         # Save top-level SCRIPT_NAME (used by dash)
         environ["lektor.site_root"] = request.root_path
-        while environ.get("PATH_INFO", "") != f"/{path}":
+        while environ.get("PATH_INFO", "") != f"/{page}":
             assert environ["PATH_INFO"]
             pop_path_info(request.environ)
         return admin_app.wsgi_app

--- a/tests/admin/test_webui.py
+++ b/tests/admin/test_webui.py
@@ -60,3 +60,18 @@ def test_get(test_client, url, mimetype, is_editable):
     assert resp.mimetype == mimetype
     data = b"".join(resp.get_app_iter(flask.request.environ)).decode("utf-8")
     assert ("/admin/edit?" in data) == is_editable
+
+
+def test_get_admin_does_something_useful(test_client, mocker):
+    # Test that GET /admin eventually gets to the admin JS app
+    # See https://github.com/lektor/lektor/issues/1043
+    render_template = mocker.patch(
+        "lektor.admin.modules.dash.render_template",
+        return_value="RENDERED",
+    )
+    resp = test_client.get("/admin", follow_redirects=True)
+    assert resp.status_code == 200
+    assert resp.get_data(as_text=True) == render_template.return_value
+    assert render_template.mock_calls == [
+        mocker.call("dash.html", lektor_config=mocker.ANY),
+    ]


### PR DESCRIPTION

Fix the admin server so that `http://localhost:5000/admin` gets one to the admin interface (instead of returning 404).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1043

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
