### PR TITLE
Another possible fix for annoying admin page scrolling

### DIFF
--- a/frontend/js/widgets/MultiLineTextInputWidget.tsx
+++ b/frontend/js/widgets/MultiLineTextInputWidget.tsx
@@ -1,3 +1,4 @@
+import fitTextarea from "fit-textarea";
 import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
 import { getInputClass, WidgetProps } from "./types";
 
@@ -10,11 +11,9 @@ export function MultiLineTextInputWidget({
 }: WidgetProps) {
   const textarea = useRef<HTMLTextAreaElement | null>(null);
 
-  const recalculateSize = useCallback(() => {
-    const node = textarea.current;
-    if (node) {
-      node.style.height = "auto";
-      node.style.height = node.scrollHeight + "px";
+  useEffect(() => {
+    if (textarea?.current) {
+      fitTextarea.watch(textarea?.current);
     }
   }, []);
 
@@ -24,17 +23,6 @@ export function MultiLineTextInputWidget({
     },
     [onChangeProp]
   );
-
-  useEffect(() => {
-    recalculateSize();
-  }, [recalculateSize, value]);
-
-  useEffect(() => {
-    window.addEventListener("resize", recalculateSize);
-    return () => {
-      window.removeEventListener("resize", recalculateSize);
-    };
-  }, [recalculateSize]);
 
   return (
     <div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^8.4.1",
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "fit-textarea": "^3.0.0",
         "font-awesome": "^4.3.0",
         "jsdom": "^19.0.0",
         "mocha": "^9.0.3",
@@ -2552,6 +2553,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/fit-textarea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fit-textarea/-/fit-textarea-3.0.0.tgz",
+      "integrity": "sha512-27CNxgJ0bL+ATJbLZuOjtUGfAiwa99kT6omFscYTQ9P/u6Lawekkws6lylTu32VgzkQTnTEXbu+bRaHtwoN02Q==",
+      "dev": true
     },
     "node_modules/flat": {
       "version": "5.0.2",
@@ -7267,6 +7274,12 @@
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "fit-textarea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fit-textarea/-/fit-textarea-3.0.0.tgz",
+      "integrity": "sha512-27CNxgJ0bL+ATJbLZuOjtUGfAiwa99kT6omFscYTQ9P/u6Lawekkws6lylTu32VgzkQTnTEXbu+bRaHtwoN02Q==",
+      "dev": true
     },
     "flat": {
       "version": "5.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "eslint": "^8.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "fit-textarea": "^3.0.0",
     "font-awesome": "^4.3.0",
     "jsdom": "^19.0.0",
     "mocha": "^9.0.3",


### PR DESCRIPTION
This is an alternative to PR #1045.

I've now found the [fit-textarea](https://github.com/fregante/fit-textarea) which seems both cleaner and light-weight than the `react-textarea-autosize` library used in #1045.

A limitation of `fit-textarea` is that it always wants the textarea to be sized to exactly fit its content. (A minimum height can be set, but no maximum.)  Without some ugly hacks, there is no way to support user-resizing via drag handles.

That's both good and bad.
- Con: If you have some fields with many, many lines of data, you may have to scroll the page a lot to get to the fields below it.
- Pro: Since textareas never have scroll-bars, there's never any confusion about what your scroll-wheel is scrolling. 

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1038
Fixes #1

### Related Issues / Links

Supercedes #1045

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
