### PR TITLE
Fix static file service from admin server with relative output directory

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -77,8 +77,10 @@ def _deduce_mimetype(filename: Filename) -> str:
 
 def _checked_send_file(filename: Filename, mimetype: Optional[str] = None) -> Response:
     """Same as flask.send_file, except raises NotFound on file errors."""
+    # NB: flask.send_file interprets relative paths relative to
+    # current_app.root_path. We don't want that.
     try:
-        resp = send_file(filename, mimetype=mimetype)
+        resp = send_file(os.path.abspath(filename), mimetype=mimetype)
     except (FileNotFoundError, IsADirectoryError, PermissionError):
         abort(404)
     return resp
@@ -211,7 +213,7 @@ def serve_file(path: str) -> Response:
     if safe_path is None:
         abort(404)
 
-    filename = Path(output_path, safe_path)  # coverts safe_path to native path seps
+    filename = Path(output_path, safe_path)  # converts safe_path to native path seps
     if filename.is_dir():
         if not path.endswith("/"):
             return append_slash_redirect(request.environ)

--- a/tests/admin/test_serve.py
+++ b/tests/admin/test_serve.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -408,6 +409,22 @@ def test_serve_file(output_path, app):
         content = b"".join(resp.get_app_iter(flask.request.environ))
     assert resp.mimetype == "text/plain"
     assert content == b"content"
+
+
+@pytest.mark.parametrize("output_path", [Path("relative")])
+def test_serve_file_with_relative_output_path(output_path, app, tmp_path):
+    # This excercises a bug having to do with serving files when
+    # Lektor is given a relative output directory.
+    #
+    # E.g. via `lektor server -O outdir`
+    #
+    save_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        output_path.mkdir()
+        test_serve_file(output_path, app)
+    finally:
+        os.chdir(save_cwd)
 
 
 @pytest.mark.parametrize("index_html", ["index.html", "index.htm"])


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved


The admin server currently fails to serve static files (secondary artifacts) when the configured output directory is a relative path.  

E.g.
```
(cd example && lektor server -O output) &
curl -I http://localhost:5000/logo@250.png
> HTTP/1.1 404 NOT FOUND
[...]
```
(without the `-O output` option, this works fine.)

This fixes that.

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)

