### PR TITLE
Fixes for #203: visible children of hidden parents

### DIFF
--- a/frontend/js/widgets/BooleanInputWidget.tsx
+++ b/frontend/js/widgets/BooleanInputWidget.tsx
@@ -37,7 +37,7 @@ export function BooleanInputWidget({
           onChange={(ev) => {
             onChange(ev.target.checked ? "yes" : "no");
           }}
-          onKeyPress={(ev) => {
+          onKeyDown={(ev) => {
             if (isDeleteOrBackspace(ev)) {
               ev.preventDefault();
               ev.stopPropagation();

--- a/frontend/js/widgets/BooleanInputWidget.tsx
+++ b/frontend/js/widgets/BooleanInputWidget.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { WidgetProps } from "./types";
 import { trans_obj } from "../i18n";
 
@@ -12,6 +12,15 @@ export function BooleanInputWidget({
   placeholder,
   onChange,
 }: WidgetProps): JSX.Element {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const input = ref.current;
+    if (input) {
+      input.indeterminate = !value;
+    }
+  }, [value]);
+
   return (
     <div className="form-check">
       <label className="form-check-label">
@@ -19,17 +28,8 @@ export function BooleanInputWidget({
           type="checkbox"
           className="form-check-input"
           disabled={disabled}
-          ref={(checkbox) => {
-            if (checkbox) {
-              if (!value && placeholder) {
-                checkbox.indeterminate = true;
-                checkbox.checked = isTrue(placeholder);
-              } else {
-                checkbox.indeterminate = false;
-              }
-            }
-          }}
-          checked={isTrue(value)}
+          ref={ref}
+          checked={isTrue(value || placeholder)}
           onChange={(ev) => {
             onChange(ev.target.checked ? "yes" : "no");
           }}

--- a/frontend/js/widgets/BooleanInputWidget.tsx
+++ b/frontend/js/widgets/BooleanInputWidget.tsx
@@ -1,9 +1,17 @@
-import React, { useEffect, useRef } from "react";
+import React, { KeyboardEvent } from "react";
 import { WidgetProps } from "./types";
-import { trans_obj } from "../i18n";
+import { trans, trans_obj } from "../i18n";
 
-const isTrue = (value?: string) =>
+const isTrue = (value?: string | null) =>
   value === "true" || value === "yes" || value === "1";
+
+const isDeleteOrBackspace = (event: KeyboardEvent<HTMLInputElement>) => {
+  if (event.altKey || event.metaKey || (event.shiftKey && !event.ctrlKey)) {
+    // If modifiers other than <ctrl>, <ctrl>-<shift>, or none are used, ignore
+    return false;
+  }
+  return event.key === "Delete" || event.key === "Backspace";
+};
 
 export function BooleanInputWidget({
   type,
@@ -11,16 +19,7 @@ export function BooleanInputWidget({
   disabled,
   placeholder,
   onChange,
-}: WidgetProps): JSX.Element {
-  const ref = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const input = ref.current;
-    if (input) {
-      input.indeterminate = !value;
-    }
-  }, [value]);
-
+}: WidgetProps<string | null>): JSX.Element {
   return (
     <div className="form-check">
       <label className="form-check-label">
@@ -28,11 +27,24 @@ export function BooleanInputWidget({
           type="checkbox"
           className="form-check-input"
           disabled={disabled}
-          ref={ref}
+          ref={(checkbox) => {
+            if (checkbox) {
+              // wierdly, `indeterminate` can not be set via HTML attribute
+              checkbox.indeterminate = !value;
+            }
+          }}
           checked={isTrue(value || placeholder)}
           onChange={(ev) => {
             onChange(ev.target.checked ? "yes" : "no");
           }}
+          onKeyPress={(ev) => {
+            if (isDeleteOrBackspace(ev)) {
+              ev.preventDefault();
+              ev.stopPropagation();
+              onChange(null); // set value back to unset
+            }
+          }}
+          title={trans("TRISTATE_CHECKBOX_TOOLTIP")}
         />
         {type.checkbox_label_i18n ? trans_obj(type.checkbox_label_i18n) : null}
       </label>

--- a/frontend/js/widgets/BooleanInputWidget.tsx
+++ b/frontend/js/widgets/BooleanInputWidget.tsx
@@ -25,7 +25,10 @@ export function BooleanInputWidget({
       <label className="form-check-label">
         <input
           type="checkbox"
-          className="form-check-input"
+          className={[
+            "form-check-input",
+            `form-check-input--default-${placeholder ? "true" : "false"}`,
+          ].join(" ")}
           disabled={disabled}
           ref={(checkbox) => {
             if (checkbox) {

--- a/frontend/scss/forms.scss
+++ b/frontend/scss/forms.scss
@@ -123,7 +123,8 @@ div.flow-block {
     // Slash, rather than bootstrap's horizontal bar, seems more intuitive indication
     // of indeterminate state.
     background-image:  escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$form-check-input-indeterminate-color}' stroke-linecap='round' stroke-width='3' d='M6 6 l8 8'/></svg>"));
-    &[checked] {
+
+    &.form-check-input--default-true {
         background-color: scale-color(
             $form-check-input-checked-bg-color,
             $alpha: -25%

--- a/frontend/scss/forms.scss
+++ b/frontend/scss/forms.scss
@@ -107,3 +107,27 @@ div.flow-block {
 .spacing-widget {
   height: 30px;
 }
+
+// Visually distinguish between checked and unchecked indeterminate checkbox
+// (Checkboxes, as far as the browser is concerned only have three states.
+// Indeterminate checkboxes are not :checked, but we still set the default value
+// for the field in the checked attribute and would like to be able to tell
+// the difference between those that default to true vs false.)
+.form-check-input[type="checkbox"]:indeterminate {
+    border-color: rgba(#000, 0.25);
+    background-color: scale-color(
+        $form-check-input-checked-bg-color,
+        $alpha: -70%,
+        $saturation: -30%
+    );
+    // Slash, rather than bootstrap's horizontal bar, seems more intuitive indication
+    // of indeterminate state.
+    background-image:  escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$form-check-input-indeterminate-color}' stroke-linecap='round' stroke-width='3' d='M6 6 l8 8'/></svg>"));
+    &[checked] {
+        background-color: scale-color(
+            $form-check-input-checked-bg-color,
+            $alpha: -25%
+        );
+        border-color: $form-check-input-checked-border-color;
+    }
+}

--- a/lektor/build_programs.py
+++ b/lektor/build_programs.py
@@ -108,7 +108,7 @@ class BuildProgram:
             _build(artifact, build_func)
 
         # If we failed anywhere we want to mark *all* artifacts as dirty.
-        # This means that if a sub-artifact failes we also rebuild the
+        # This means that if a sub-artifact fails we also rebuild the
         # parent next time around.
         if failures:
             for artifact in self.artifacts:

--- a/lektor/build_programs.py
+++ b/lektor/build_programs.py
@@ -217,6 +217,7 @@ class PageBuildProgram(BuildProgram):
         # If pagination is disabled, all children and attachments are linked
         # to this page.
         all_children = self.source.children.include_undiscoverable(True)
+        all_children = all_children.include_hidden(True)
         if pagination_enabled:
             if self.source.page_num is None:
                 child_sources.append(self._iter_paginated_children())

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -620,7 +620,11 @@ class Page(Record):
         # When we resolve URLs we also want to be able to explicitly
         # target undiscoverable pages.  Those who know the URL are
         # rewarded.
-        q = self.children.include_undiscoverable(True)
+
+        # We also want to resolve hidden children
+        # here. Pad.resolve_url_path() is where the check for hidden
+        # records is done.
+        q = self.children.include_undiscoverable(True).include_hidden(True)
 
         for idx in range(len(url_path)):
             piece = "/".join(url_path[: idx + 1])

--- a/lektor/translations/en.json
+++ b/lektor/translations/en.json
@@ -124,5 +124,6 @@
   "OPEN_OTHER_PROJECT": "Open other Project",
   "OPEN_OTHER_PROJECT_QUESTION": "Opening this file requires opening another project (%s). The current project will be closed. Do you want to continue?",
   "COLLAPSE": "Collapse",
-  "EXPAND": "Expand"
+  "EXPAND": "Expand",
+   "TRISTATE_CHECKBOX_TOOLTIP": "Tri-state checkbox: use <del> or <backspace> to revert to unset"
 }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -78,6 +78,28 @@ def test_url_matching_with_customized_slug_in_alt(pad):
     assert get_alts(en) == ["en", "de"]
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/extra/container/a",  # child if hidden page explicit marked as non-hidden
+        "/extra/container/hello.txt",  # attachment of hidden page
+    ],
+)
+def test_resolve_url(pad, path):
+    assert pad.resolve_url_path(path) is not None
+
+
+def test_resolve_url_hidden_page(pad):
+    assert pad.resolve_url_path("/extra/container") is None
+    assert pad.resolve_url_path("/extra/container", include_invisible=True) is not None
+
+
+def test_resolve_url_asset(pad):
+    assert pad.resolve_url_path("/static/demo.css") is not None
+    assert pad.resolve_url_path("/static/demo.css", include_assets=False) is None
+
+
 def test_basic_alts(pad):
     with Context(pad=pad):
         assert get_alts() == ["en", "de"]


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

This PR allows one to have visible children under a hidden parent page.  No artifact (e.g. `index.html`) will be built for the hidden parent, but artifact(s) will now be built for any explicitly non-hidden children.

Contrary to what the documentation says, up until now, Lektor made no attempt to build children of a hidden parent.

Other changes here:
- Fixes some related bugs having to do with URL resolution to pages that have hidden parents.
- Fix the builders pruning logic to prune artifacts that belong to hidden pages.  (These were presumably built at a time when the page was not marked as hidden.)
- Fix the BooleanInputWidget’s logic for setting checkboxes to the _indeterminate_ state.  Previously, checkboxes were only set to indeterminate if their default value was true.  I think the proper (more useful) behavior is to set the checkbox to indeterminate if the `contents.lr` file does not explicitly set a value for the field, regardless of what the default value is.
- Updates the BooleanInputWidget (checkbox) so that typing \<Delete> or \<Backspace> (while it has the focus) will revert it to _unset_ (or _indeterminate_) state, rather than `true` or `false`.  This is important for the `_hidden` field, since when the `_hidden` field is unset it means something different (e.g. "inherit from parent") than when `_hidden = false` (or `_hidden = true`).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #203

### Related Issues / Links

Clarified documentation on the `_missing` field in lektor/lektor-website@7a6ccd0e38d1c645da18bfbe167ad96756bb63b8
<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
- [x] Should implement a real tri-state checkbox widget in the admin UI.  (`_hidden` unset ≠ `_hidden = no`)
<!--- Remember that an image/animation is worth a thousand words! --->

- [x] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website) (See lektor/lektor-website@7a6ccd0e38d1c645da18bfbe167ad96756bb63b8.)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
