### PR TITLE
docs: Fix a few typos

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -2179,7 +2179,7 @@ class Tree:
 
 
 class RecordCache:
-    """The record cache holds records eitehr in an persistent or ephemeral
+    """The record cache holds records either in an persistent or ephemeral
     section which helps the pad not load records it already saw.
     """
 

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -427,7 +427,7 @@ del _deprecated_data_proxy
 class EditorData(Mapping):
     """A read-only view of edited data.
 
-    This is a chained dict with (possibly) mutated data overlayed on
+    This is a chained dict with (possibly) mutated data overlaid on
     the original data for the record.
     """
 
@@ -493,7 +493,7 @@ class EditorData(Mapping):
 class MutableEditorData(EditorData, MutableMapping):
     """A mutable view of edited data.
 
-    This is a chained dict with (possibly) mutated data overlayed on
+    This is a chained dict with (possibly) mutated data overlaid on
     the original data for the record.
     """
 

--- a/lektor/environment/config.py
+++ b/lektor/environment/config.py
@@ -201,7 +201,7 @@ class Config:
         return sorted(self.values["ALTERNATIVES"])
 
     def iter_alternatives(self):
-        """Iterates over all alterantives.  If the system is disabled this
+        """Iterates over all alternatives.  If the system is disabled this
         yields '_primary'.
         """
         found = False

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -74,7 +74,7 @@ def test_client(webadmin):
 
 
 def test_recordinfo_children_sort_limited_alts(test_client):
-    # This excercises the bug described in #962, namely that
+    # This exercises the bug described in #962, namely that
     # if a page has a child that only has content in a subset of the
     # configured alts, get_record_info throws an exception.
     data = test_client.get("/admin/api/recordinfo?path=/projects").get_json()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -12,7 +12,7 @@ from lektor.publisher import publish
 
 
 def test_Command_triggers_no_warnings():
-    # This excercises the issue where publishing via rsync resulted
+    # This exercises the issue where publishing via rsync resulted
     # in ResourceWarnings about unclosed streams.
 
     with warnings.catch_warnings():


### PR DESCRIPTION
There are small typos in:
- lektor/db.py
- lektor/editor.py
- lektor/environment/config.py
- tests/admin/test_api.py
- tests/test_publisher.py

Fixes:
- Should read `overlaid` rather than `overlayed`.
- Should read `exercises` rather than `excercises`.
- Should read `either` rather than `eitehr`.
- Should read `alternatives` rather than `alterantives`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md