### PR TITLE
Fixes for newly released Werkzeug 2.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,7 +51,7 @@ December 2021.
 #### Bit-rot
 
 - Fixes for `click==8.1.3`. ([#1031][], [#1033][])
-- Fixes for `werkzeug>=2.1.0`. ([#1019][], [#1018][])
+- Fixes for `werkzeug>=2.2.0`. ([#1019][], [#1018][], [#1051][])
 - Update npm package minimist. ([#1021][])
 - Remove dependency on the `requests[security]` extra. ([#1036][])
 - Remove `build-system.requires` dependencies on `wheel`, and the
@@ -96,6 +96,7 @@ December 2021.
 [#1042]: https://github.com/lektor/lektor/pull/1042
 [#1043]: https://github.com/lektor/lektor/issues/1043
 [#1044]: https://github.com/lektor/lektor/pull/1044
+[#1051]: https://github.com/lektor/lektor/pull/1051
 
 ## 3.3.2 (2022-03-01)
 

--- a/lektor/admin/modules/dash.py
+++ b/lektor/admin/modules/dash.py
@@ -9,7 +9,8 @@ from flask import request
 bp = Blueprint("dash", __name__, url_prefix="/admin")
 
 
-@bp.route("/<any(edit, delete, preview, add-child, upload, ''):page>", endpoint="app")
+@bp.route("/", defaults={"page": ""})
+@bp.route("/<any(edit, delete, preview, add-child, upload):page>", endpoint="app")
 def app_view(**kwargs: Any) -> str:
     """Render the React admin GUI app."""
     # Note: client side app handles redirect from page='' to page='edit'

--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -2,10 +2,10 @@ from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import Union
+from wsgiref.util import shift_path_info
 
 from flask import Flask
 from flask import request
-from werkzeug.wsgi import pop_path_info
 
 from lektor.admin.context import LektorApp
 from lektor.admin.context import LektorInfo
@@ -66,7 +66,7 @@ def make_app(
         environ["lektor.site_root"] = request.root_path
         while environ.get("PATH_INFO", "") != f"/{page}":
             assert environ["PATH_INFO"]
-            pop_path_info(request.environ)
+            shift_path_info(request.environ)
         return admin_app.wsgi_app
 
     # Add rule to construct URL to /admin/edit

--- a/tests/admin/test_dash.py
+++ b/tests/admin/test_dash.py
@@ -1,7 +1,8 @@
+from wsgiref.util import shift_path_info
+
 import pytest
 from werkzeug.exceptions import NotFound
 from werkzeug.test import Client
-from werkzeug.wsgi import pop_path_info
 
 from lektor.admin.webui import make_app
 
@@ -13,7 +14,7 @@ def app(env, ui_lang, tmp_path, admin_path, app_prefix):
         return app
 
     def prefixed_app(environ, start_response):
-        if pop_path_info(environ) != app_prefix:
+        if shift_path_info(environ) != app_prefix:
             return NotFound()(environ, start_response)
         return app(environ, start_response)
 


### PR DESCRIPTION
The recent release of Werkzeug 2.2.0 has changed the `any` route converter just that if it is given the empty string as one of the choices the resulting route will match anything.

So here we add a separate route to match the empty string alternative. 


Also `werkzeug.wsgi.pop_path_info` has been deprecated in favor of the apparently identical `wsgiref.util.shift_path_info` from the standard library.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->



<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
