### PR TITLE
Install extra for "dev" dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,24 +28,29 @@ For installation instructions head to the official documentation:
 
 ## Want to develop on Lektor?
 
-This gets you started (assuming you have Python, pip, Make and pre-commit
-installed):
+This gets you started (assuming you have Python, pip, and Make installed):
 
-```
-$ git clone https://github.com/lektor/lektor
-$ cd lektor
-$ virtualenv venv
-$ . venv/bin/activate
-$ pip install --editable .
-$ make build-js
-$ pre-commit install
-$ export LEKTOR_DEV=1
-$ cp -r example example-project
-$ lektor --project example-project server
+```shell
+git clone https://github.com/lektor/lektor
+cd lektor
+virtualenv venv
+. venv/bin/activate
+pip install --editable ".[dev]"
+make build-js
+pre-commit install
+export LEKTOR_DEV=1
+cp -r example example-project
+lektor --project example-project server
 ```
 
-If you want to run the test suite (you'll need tox installed):
+If you want to run the whole test suite:
 
+```shell
+tox
 ```
-$ tox
+
+or more granular test commands directly with
+
+```shell
+pytest
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,16 @@ install_requires =
 [options.extras_require]
 ipython =
     ipython
+dev =
+    ipdb
+    pre-commit
+    pylint
+    pytest>=6
+    pytest-click
+    pytest-cov
+    pytest-mock
+    tox
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
     lektor = lektor.cli:main


### PR DESCRIPTION
This PR adds an extra install dependency to make development a little easier. Since the move to tox, the old `test` extra went away. We now also have pre-commit in the mix. This adds all of the testing and linting tools, and ipdb, to the `dev` dependencies, except for what pre-commit runs, so people like myself can get up and running more quickly.

I specifically included all of the pytest deps like before tox, because I often prefer to run pytest directly while developing something. Tox can add headache, especially if I'm trying to put a `breakpoint` in a test script. Now pytest and tox are both ready to go, so I can use either.