### PR TITLE
Remove the deprecated --build-flag option

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -1,5 +1,4 @@
 # pylint: disable=import-outside-toplevel
-import itertools
 import os
 import sys
 import time
@@ -9,7 +8,6 @@ import click
 import pkg_resources
 
 from lektor.cli_utils import AliasedGroup
-from lektor.cli_utils import buildflag
 from lektor.cli_utils import echo_json
 from lektor.cli_utils import extraflag
 from lektor.cli_utils import pass_context
@@ -84,7 +82,6 @@ def cli(ctx, project=None, language=None):
     "`.lektor` inside the output path.",
 )
 @extraflag
-@buildflag
 @click.option("--profile", is_flag=True, help="Enable build profiler.")
 @pass_context
 def build_cmd(
@@ -97,7 +94,6 @@ def build_cmd(
     buildstate_path,
     profile,
     extra_flags,
-    build_flags,
 ):
     """Builds the entire project into the final artifacts.
 
@@ -118,8 +114,6 @@ def build_cmd(
     """
     from lektor.builder import Builder
     from lektor.reporter import CliReporter
-
-    extra_flags = tuple(itertools.chain(extra_flags or (), build_flags or ()))
 
     if output_path is None:
         output_path = ctx.get_default_output_path()
@@ -320,12 +314,9 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
     help="Increases the verbosity of the logging.",
 )
 @extraflag
-@buildflag
 @click.option("--browse", is_flag=True)
 @pass_context
-def server_cmd(
-    ctx, host, port, output_path, prune, verbosity, extra_flags, build_flags, browse
-):
+def server_cmd(ctx, host, port, output_path, prune, verbosity, extra_flags, browse):
     """The server command will launch a local server for development.
 
     Lektor's development server will automatically build all files into
@@ -335,7 +326,6 @@ def server_cmd(
     """
     from lektor.devserver import run_server
 
-    extra_flags = tuple(itertools.chain(extra_flags or (), build_flags or ()))
     if output_path is None:
         output_path = ctx.get_default_output_path()
     ctx.load_plugins(extra_flags=extra_flags)

--- a/lektor/cli_utils.py
+++ b/lektor/cli_utils.py
@@ -1,7 +1,6 @@
 # pylint: disable=import-outside-toplevel
 import json
 import os
-import warnings
 
 import click
 
@@ -31,25 +30,6 @@ def extraflag(cli):
         help="Defines an arbitrary flag.  These can be used by plugins "
         "to customize the build and deploy process.  More information can be "
         "found in the documentation of affected plugins.",
-    )(cli)
-
-
-def _buildflag_deprecated(ctx, param, value):
-    if value:
-        warnings.warn(
-            "use --extra-flag instead of --build-flag",
-            DeprecationWarning,
-        )
-    return value
-
-
-def buildflag(cli):
-    return click.option(
-        "--build-flag",
-        "build_flags",
-        multiple=True,
-        help="Deprecated. Use --extra-flag instead.",
-        callback=_buildflag_deprecated,
     )(cli)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import os
 import re
-import warnings
 
 import pytest
 from markers import imagemagick
@@ -86,18 +85,6 @@ def test_build_extra_flag(project_cli_runner, mocker):
     result = project_cli_runner.invoke(cli, ["build", "-f", "webpack"])
     assert result.exit_code == 0
     assert mock_builder.call_args[1]["extra_flags"] == ("webpack",)
-    assert "use --extra-flag instead of --build-flag" not in result.output
-
-
-def test_deprecated_build_flag(project_cli_runner, mocker):
-    mock_builder = mocker.patch("lektor.builder.Builder")
-    mock_builder.return_value.build_all.return_value = 0
-    with warnings.catch_warnings(record=True) as w:
-        result = project_cli_runner.invoke(cli, ["build", "--build-flag", "webpack"])
-        assert result.exit_code == 0
-        assert mock_builder.call_args[1]["extra_flags"] == ("webpack",)
-        assert w
-        assert "use --extra-flag instead of --build-flag" in str(w[0].message)
 
 
 def test_deploy_extra_flag(project_cli_runner, mocker):


### PR DESCRIPTION
The `--build-flag` command-line option has been deprecated  since PR #326, which was included Lektor version 3.1.0, released in early 2018.  It's probably time to remove it.

Anyone who is still using `--build-flag` can just switch to using `--extra-flag` instead.

Fixes #525.

