### PR TITLE
ci: use generic lts/* and current specifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-3.9-pip-${{ hashFiles('**/setup.cfg') }}
       - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
@@ -37,6 +32,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: "**/setup.cfg"
       - name: Install python dependencies
         run: python -m pip install tox
       - name: Run pylint
@@ -93,25 +90,15 @@ jobs:
           - os: "windows-latest"
             python: "3.9"
         include:
-          - os: "ubuntu-latest"
-            pip-cache-dir: ~/.cache/pip
-          - os: "macos-latest"
-            pip-cache-dir: ~/Library/Caches/pip
-          - os: "windows-latest"
-            pip-cache-dir: ~\AppData\Local\pip\Cache
           - python: "3.10"
             install-imagemagick: true
     steps:
       - uses: actions/checkout@v3
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.pip-cache-dir }}
-          key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('**/setup.cfg') }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-
+          cache: "pip"
+          cache-dependency-path: "**/setup.cfg"
       - name: Install macOS system dependencies
         if: startsWith(runner.os, 'macos') && matrix.install-imagemagick
         run: brew install imagemagick ffmpeg
@@ -148,4 +135,4 @@ jobs:
       - name: Run python tests
         run: tox
       - name: Publish coverage data to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py-3.9-pip-${{ hashFiles('**/setup.cfg') }}
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
       - name: Install node dependencies
         run: make frontend/node_modules
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install python dependencies
@@ -61,7 +61,7 @@ jobs:
           - node: "current"
             os: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
@@ -102,13 +102,13 @@ jobs:
           - python: "3.10"
             install-imagemagick: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ matrix.pip-cache-dir }}
           key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('**/setup.cfg') }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
         node: ["lts/*"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         include:
-          - node: "14"
-            os: "ubuntu-latest"
           - node: "current"
             os: "ubuntu-latest"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py-3.9-pip-${{ hashFiles('**/setup.cfg') }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "lts/*"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Install node dependencies
@@ -48,19 +48,21 @@ jobs:
   # Node tests
   ############################################################################
   node:
-    name: ${{ matrix.os}} node${{ matrix.node }}
+    name: ${{ matrix.os}} node-${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        node: ["14"]
+        node: ["lts/*"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         include:
-          - node: "16"
+          - node: "14"
+            os: "ubuntu-latest"
+          - node: "current"
             os: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-python@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
       - name: Build frontend


### PR DESCRIPTION

### Description of Changes

That way, we always test the "current" and LTS release of Node on all
platforms. For completeness we also test the old 14 LTS release.
