### PR TITLE
cleanup manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,16 @@
 # NB: Everything in git gets automatically included by setuptools_scm
+#     We only need to include the built frontend JS, CSS and fonts
+#     and exclude development-related files.
 
 prune frontend
 graft lektor/admin/static
 
-global-exclude *.py[cdo] __pycache__ *.so .DS_Store .gitkeep *~
 prune .github
-exclude .gitignore .git-blame-ignore-revs
-exclude .codecov.yml .editorconfig .pre-commit-config.yaml
-
-exclude Makefile pylintrc
+exclude .codecov.yml
+exclude .editorconfig
+exclude .git-blame-ignore-revs
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude Makefile
 
 prune example

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: build-js
 
 .PHONY: build-js
 build-js: frontend/node_modules
+	@echo "---> cleaning static files"
+	@rm -rf lektor/admin/static
 	@echo "---> building static files"
 	@cd frontend; npm run build
 
@@ -38,7 +40,7 @@ test-all: test-js
 
 # This creates source distribution and a wheel.
 dist: build-js setup.cfg MANIFEST.in
-	rm -r build dist
+	rm -rf build dist
 	python -m build
 
 # Before making a release, CHANGES.md needs to be updated and


### PR DESCRIPTION
### Description of Changes

setuptools_scm only includes files that are tracked in git, so there is no need
to have excludes for files like `*.pyc`. With this we can avoid warnings on
package build.

- manifest: remove unnecessary excludes
- makefile: clean built frontend before re-building

