### PR TITLE
Enable a default set of mistune2 plugins for feature parity with mistune0

### DIFF
--- a/lektor/markdown/controller.py
+++ b/lektor/markdown/controller.py
@@ -127,6 +127,10 @@ class RendererHelper:
         )
 
 
+class UnknownPluginError(LookupError):
+    """Exception raised when a mistune2 plugin name can not be resolved."""
+
+
 class RenderResult(NamedTuple):
     html: str
     meta: Meta

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -13,6 +13,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
 from pathlib import PurePosixPath
+from typing import Hashable
+from typing import Iterable
+from typing import TypeVar
 from urllib.parse import urlsplit
 
 from jinja2 import is_undefined
@@ -695,3 +698,17 @@ def process_extra_flags(flags):
         else:
             rv[flag] = flag
     return rv
+
+
+_H = TypeVar("_H", bound=Hashable)
+
+
+def unique_everseen(seq: Iterable[_H]) -> Iterable[_H]:
+    """Filter out duplicates from iterable."""
+    # This is a less general version of more_itertools.unique_everseen.
+    # Should we need more general functionality, consider using that instead.
+    seen = set()
+    for val in seq:
+        if val not in seen:
+            seen.add(val)
+            yield val

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -170,22 +170,19 @@ def improved_renderer():
     return ImprovedRenderer()
 
 
-if MISTUNE_VERSION.startswith("0."):
+@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+@pytest.mark.usefixtures("renderer_context")
+def test_ImprovedRenderer_record(record, improved_renderer):
+    with pytest.deprecated_call() as warnings:
+        assert improved_renderer.record is record
+    assert re.search(r"Use .*Renderer\.lektor.record instead", str(warnings[0].message))
 
-    @pytest.mark.usefixtures("renderer_context")
-    def test_ImprovedRenderer_record(record, improved_renderer):
-        with pytest.deprecated_call() as warnings:
-            assert improved_renderer.record is record
-        assert re.search(
-            r"Use .*Renderer\.lektor.record instead", str(warnings[0].message)
-        )
 
-    def test_ImprovedRenderer_meta(renderer_context, improved_renderer):
-        with pytest.deprecated_call() as warnings:
-            assert improved_renderer.meta is renderer_context.meta
-        assert re.search(
-            r"Use .*Renderer\.lektor.meta instead", str(warnings[0].message)
-        )
+@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+def test_ImprovedRenderer_meta(renderer_context, improved_renderer):
+    with pytest.deprecated_call() as warnings:
+        assert improved_renderer.meta is renderer_context.meta
+    assert re.search(r"Use .*Renderer\.lektor.meta instead", str(warnings[0].message))
 
 
 @pytest.mark.parametrize(
@@ -249,6 +246,22 @@ def test_markdown_to_html(record, field_options):
     assert result.html.rstrip() == "<p>goober</p>"
 
 
+def plugin_linkcount(md):
+    """A test mistune2 plugin.
+
+    This replaces ``[link-count]`` in text with the current link count
+    wrapped in a <code> element.
+    """
+
+    def parse_linkcount(inline, _m, _state):
+        nlinks = inline.renderer.lektor.meta["nlinks"]
+        return "codespan", str(nlinks)
+
+    md.inline.register_rule("link_count", r"\[link-count\]", parse_linkcount)
+    index = md.inline.rules.index("ref_link2")
+    md.inline.rules.insert(index, "link_count")
+
+
 class LinkCounterPlugin(Plugin):
     """A test plugin to test the renderer meta system."""
 
@@ -262,6 +275,13 @@ class LinkCounterPlugin(Plugin):
 
     def on_markdown_config(self, config, **kwargs):
         config.renderer_mixins.append(self.RendererMixin)
+
+    @staticmethod
+    def on_markdown_lexer_config(config, renderer, **kwargs):
+        if not hasattr(config, "parser_options"):
+            return  # mistune 0
+        # Configure a plugin just to make sure we can
+        config.parser_options.setdefault("plugins", []).append(plugin_linkcount)
 
     def on_markdown_meta_init(self, meta, **kwargs):
         # pylint: disable=no-self-use
@@ -326,6 +346,13 @@ class TestMarkdown:
     def test_getitem(self, markdown):
         assert markdown["nlinks"] == 0
 
+    @pytest.mark.parametrize("source", ["[x](/y) [link-count]"])
+    @pytest.mark.usefixtures("context", "link_counter_plugin")
+    @pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+    def test_linkcount_plugin(self, markdown):
+        assert markdown["nlinks"] == 1
+        assert re.search(r"<code>1</code>", markdown.html)
+
     @pytest.mark.usefixtures("context")
     def test_str(self, markdown):
         assert str(markdown).rstrip() == "<p>text</p>"
@@ -378,6 +405,18 @@ def _normalize_html(output: Union[str, Markup]) -> str:
         ("![](x&amp;y.gif)", r'.*<img\b[^>]* src="x&amp;y.gif"'),
         # FIXME: which of these is right?
         ("![](x<br>y.gif)", r'.*<img\b[^>]* src="x(&lt;br&gt;|%3Cbr%3E)y.gif"'),
+        # Autolink
+        ("autolink: <http://example.org>", r'.*<a href="http://example\.org"'),
+        #################
+        # Extra features enabled by default in mistune 0.8.4, but which require
+        # plugins to be enabled in mistune 2
+        ("strikethrough: ~~stricken~~ foo", r".*<del>stricken</del> foo"),
+        (
+            "footnotes[^note]\n\n[^note]: comment",
+            r'(?s).*<a href="#fn-([^"]+)">.*<li id="fn-\1">',
+        ),
+        ("| Table Header |\n| -------|\n| Cell |\n", r"(?s).*<tr>"),
+        ("raw URL - http://example.net/ foo", r'.*<a href="http://example\.net/"'),
     ],
 )
 @pytest.mark.usefixtures("context")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from lektor.utils import magic_split_ext
 from lektor.utils import make_relative_url
 from lektor.utils import parse_path
 from lektor.utils import slugify
+from lektor.utils import unique_everseen
 
 
 def test_join_path():
@@ -127,3 +128,15 @@ def test_make_relative_url(source, target, expected):
 def test_make_relative_url_relative_source_absolute_target():
     with pytest.raises(ValueError):
         make_relative_url("rel/a/tive/", "/abs/o/lute")
+
+
+@pytest.mark.parametrize(
+    "seq, expected",
+    [
+        (iter(()), ()),
+        ((2, 1, 1, 2, 1), (2, 1)),
+        ((1, 2, 1, 2, 1), (1, 2)),
+    ],
+)
+def test_unique_everseen(seq, expected):
+    assert tuple(unique_everseen(seq)) == expected


### PR DESCRIPTION
The features provided by the [mistune2 plugins] `url`, `strikethrough`, `footnotes`, and `table` provide features which were supported by mistune 0.8.4 out of the box.

For the sake of backwards-compatibility, since these features were all supported by older versions of Lektor (due to use of mistune 0.x) we should enable these plugins by default when running with mistune2. 

This PR does that.

[mistune2 plugins]: https://mistune.readthedocs.io/en/latest/plugins.html

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

When using mistune >= 2, markdown features which were previously supported under mistune 0.x are disabled by default.

### Related Issues / Links

This builds upon the work to support mistune 2 in PR #992.

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)

