### PR TITLE
Be more careful about handling TypeError from plugin hook method calls

### DIFF
--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import os
 import sys
 import warnings
@@ -188,24 +189,31 @@ class PluginController:
         return self.env.plugins.values()
 
     def emit(self, event, **kwargs):
+        """Invoke event hook for all plugins that support it.
 
+        Any ``kwargs`` are passed to the hook methods.
+
+        Returns a dict mapping plugin ids to hook method return values.
+        """
         rv = {}
-        kwargs["extra_flags"] = process_extra_flags(self.extra_flags)
+        extra_flags = process_extra_flags(self.extra_flags)
         funcname = "on_" + event.replace("-", "_")
         for plugin in self.iter_plugins():
             handler = getattr(plugin, funcname, None)
             if handler is not None:
+                kw = {**kwargs, "extra_flags": extra_flags}
                 try:
-                    rv[plugin.id] = handler(**kwargs)
+                    inspect.signature(handler).bind(**kw)
                 except TypeError:
-                    old_style_kwargs = kwargs.copy()
-                    old_style_kwargs.pop("extra_flags")
-                    rv[plugin.id] = handler(**old_style_kwargs)
+                    del kw["extra_flags"]
+                rv[plugin.id] = handler(**kw)
+                if "extra_flags" not in kw:
                     warnings.warn(
-                        'The plugin "{}" function "{}" does not accept extra_flags. '
+                        f"The plugin {plugin.id!r} function {funcname!r} does not "
+                        "accept extra_flags. "
                         "It should be updated to accept `**extra` so that it will "
                         "not break if new parameters are passed to it by newer "
-                        "versions of Lektor.".format(plugin.id, funcname),
+                        "versions of Lektor.",
                         DeprecationWarning,
                     )
         return rv

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -48,6 +48,13 @@ class DummyPlugin(Plugin):
         self.calls.append({"event": "legacy-event"})
         return "legacy-event return value"
 
+    def on_one_type_error(self, **kwargs):
+        """Raises TypeError only on the first call."""
+        self.calls.append({"event": "one-type-error"})
+        if len(self.calls) == 1:
+            raise TypeError("test")
+        return "one-type-error return value"
+
 
 @pytest.fixture(autouse=True)
 def dummy_plugin_calls(monkeypatch):
@@ -330,6 +337,13 @@ class TestPluginController:
         with pytest.deprecated_call():
             rv = plugin_controller.emit("legacy-event")
         assert rv == {dummy_plugin.id: "legacy-event return value"}
+
+    def test_emit_is_not_confused_by_type_error(self, plugin_controller, dummy_plugin):
+        # Excercises https://github.com/lektor/lektor/issues/1085
+        with pytest.raises(TypeError):
+            plugin_controller.emit("one-type-error")
+        rv = plugin_controller.emit("one-type-error")
+        assert rv == {dummy_plugin.id: "one-type-error return value"}
 
 
 @pytest.mark.usefixtures("dummy_plugin_distribution")


### PR DESCRIPTION
`PluginController.emit`, under certain circumstances, will silently ignore `TypeError`s raised by plugin hook methods.

This fixes that.

In addition, each call to `emit` will now call each hook method at most once.  Previously, under some circumstances, a hook method could be called twice during a single call to `emit` — that could possibly have unintended and confusing consequences for hooks that mutate plugin state.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1085



<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
