### PR TITLE
Add `server --browse-subpage $URL` cli arg

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -314,7 +314,13 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
     help="Increases the verbosity of the logging.",
 )
 @extraflag
-@click.option("--browse", is_flag=True)
+@click.option("--browse", is_flag=True, help="open homepage in browser on startup")
+@click.option(
+    "--browse-subpage",
+    default=None,
+    help="open a specific subpage in browser on startup. "
+    "example: --browse-subpage /admin/edit",
+)
 @click.option(
     "--no-reload",
     "reload",
@@ -325,7 +331,16 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 )
 @pass_context
 def server_cmd(
-    ctx, host, port, output_path, prune, verbosity, extra_flags, browse, reload
+    ctx,
+    host,
+    port,
+    output_path,
+    prune,
+    verbosity,
+    extra_flags,
+    browse,
+    browse_subpage,
+    reload,
 ):
     """The server command will launch a local server for development.
 
@@ -351,6 +366,7 @@ def server_cmd(
         extra_flags=extra_flags,
         lektor_dev=os.environ.get("LEKTOR_DEV") == "1",
         browse=browse,
+        browse_subpage=browse_subpage,
         reload=reload,
     )
 

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -60,7 +60,7 @@ def browse_to_address(addr, subpage=None):
 
     def browse():
         time.sleep(1)
-        if subpage:
+        if subpage is not None:
             addr_with_subpage = addr + (subpage,)
             webbrowser.open("http://%s:%s/%s" % addr_with_subpage)
         else:

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -54,13 +54,17 @@ class BackgroundBuilder(threading.Thread):
                         self.build()
 
 
-def browse_to_address(addr):
+def browse_to_address(addr, subpage=None):
     # pylint: disable=import-outside-toplevel
     import webbrowser
 
     def browse():
         time.sleep(1)
-        webbrowser.open("http://%s:%s" % addr)
+        if subpage:
+            addr_with_subpage = addr + (subpage,)
+            webbrowser.open("http://%s:%s/%s" % addr_with_subpage)
+        else:
+            webbrowser.open("http://%s:%s" % addr)
 
     t = threading.Thread(target=browse)
     t.daemon = True
@@ -76,6 +80,7 @@ def run_server(
     lektor_dev=False,
     ui_lang="en",
     browse=False,
+    browse_subpage=None,
     extra_flags=None,
     reload=True,
 ):
@@ -114,6 +119,9 @@ def run_server(
 
     if browse:
         browse_to_address(bindaddr)
+
+    if browse_subpage:
+        browse_to_address(bindaddr, browse_subpage.lstrip("/"))
 
     try:
         return run_simple(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,13 @@ def test_build_abort_in_existing_nonempty_dir(project_cli_runner):
     assert result.exit_code == 1
 
 
+def test_server_browse_subpage_requires_subpage(project_cli_runner):
+    """ensure server fails when no argument supplied to --browse-subpage"""
+    result = project_cli_runner.invoke(cli, ["server", "--browse-subpage"])
+    assert "requires an argument" in result.output
+    assert result.exit_code == 2
+
+
 @imagemagick
 def test_build_continue_in_existing_nonempty_dir(project_cli_runner):
     os.mkdir("build_dir")


### PR DESCRIPTION
### Issue(s) Resolved

Fixes #1097

### Related Issues / Links

None Currently

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

This lets you open up a specified page, like an admin page upon starting
the development server.

I find this useful for rapidly editing my blog via:
lektor --project example-project server --browse-subpage '/admin/edit?path=%2Fblog'