### PR TITLE
Fix template global markdown filter

### DIFF
--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Dict
 from typing import Hashable
+from typing import Optional
 from typing import Type
 from typing import TYPE_CHECKING
 from weakref import ref as weakref
@@ -48,10 +49,10 @@ def markdown_to_html(
 
 class Markdown:
     def __init__(
-        self, source: str, record: SourceObject, field_options: FieldOptions
+        self, source: str, record: Optional[SourceObject], field_options: FieldOptions
     ) -> None:
         self.source = source
-        self.__record = weakref(record)
+        self.__record = weakref(record) if record is not None else None
         self.__field_options = field_options
         self.__cache: Dict[Hashable, RenderResult] = {}
 
@@ -62,7 +63,10 @@ class Markdown:
 
     @property
     def record(self) -> SourceObject:
-        record = self.__record()
+        ref = self.__record
+        if ref is None:
+            return None
+        record = ref()
         if record is None:
             raise RuntimeError("Record has gone away")
         return record

--- a/lektor/markdown/controller.py
+++ b/lektor/markdown/controller.py
@@ -45,7 +45,7 @@ def require_ctx() -> Context:
 class RendererContext(NamedTuple):
     """Extra data used during Markdown rendering."""
 
-    record: SourceObject
+    record: Optional[SourceObject]
     meta: Meta
     field_options: FieldOptions
 
@@ -68,7 +68,7 @@ class RendererHelper:
     """Various helpers used by our markdown renderer subclasses."""
 
     @property
-    def record(self) -> SourceObject:
+    def record(self) -> Optional[SourceObject]:
         """The record that owns the markdown field being rendered.
 
         This is used as the base for resolving relative URLs in the Markdown text.
@@ -116,6 +116,12 @@ class RendererHelper:
         # Default is to resolve links to Lektor source objects when possible
         # This is a change from previous versions where we never resolved
         # links in Markdown.
+        record = self.record
+        if record is None:
+            if resolve_links == "always":
+                raise RuntimeError("A source object is required to resolve URLs")
+            return url
+
         resolve = strict_resolve = None
         if resolve_links == "always":
             strict_resolve = True
@@ -163,7 +169,7 @@ class MarkdownController(ABC):
         return ctx.base_url
 
     def render(
-        self, source: str, record: SourceObject, field_options: FieldOptions
+        self, source: str, record: Optional[SourceObject], field_options: FieldOptions
     ) -> RenderResult:
         """Render markdown string"""
         meta: Meta = {}

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,8 +1,21 @@
+import re
 import sys
 from html import unescape
 from pathlib import Path
 
 import pytest
+
+import lektor.context
+
+
+@pytest.fixture
+def scratch_project_data(scratch_project_data):
+    # Add a sub-page to the scratch project
+    data = {"_model": "page", "title": "Subpage", "body": "Subpage body"}
+    subpage_lr = scratch_project_data / "content/sub-page/contents.lr"
+    subpage_lr.parent.mkdir()
+    subpage_lr.write_text("".join(lektor.metaformat.serialize(data.items())))
+    return scratch_project_data
 
 
 @pytest.fixture
@@ -14,6 +27,21 @@ def compile_template(scratch_env):
         return scratch_env.jinja_env.get_template(name)
 
     return compile_template
+
+
+@pytest.fixture
+def source_path():
+    return "/"
+
+
+@pytest.fixture
+def bogus_context(scratch_pad, source_path):
+    # Construct a Context that has a source, without going through all
+    # all the steps necessary to construct an Artifact.
+    with lektor.context.Context(pad=scratch_pad) as ctx:
+        if source_path is not None:
+            ctx.source = scratch_pad.get(source_path)
+        yield
 
 
 def test_jinja2_feature_autoescape(compile_template):
@@ -33,6 +61,48 @@ def test_jinja2_feature_do(compile_template):
         "{% set x = ['a'] %}{% do x.append('b') %}{{ x|join('-') }}"
     )
     assert tmpl.render() == "a-b"
+
+
+@pytest.mark.parametrize("source_path", [None, "/"])
+@pytest.mark.usefixtures("bogus_context")
+def test_jinja2_markdown_filter(compile_template):
+    tmpl = compile_template("{{ '**word**' | markdown }}")
+    assert "<strong>word</strong>" in tmpl.render()
+
+
+@pytest.mark.usefixtures("bogus_context")
+def test_jinja2_markdown_filter_resolve_links(compile_template):
+    tmpl = compile_template(
+        "{{ '[subpage](sub-page)' | markdown(resolve_links='always') }}"
+    )
+    assert re.search(r"<a.*\bhref=(['\"])sub-page/\1.*>subpage</a>", tmpl.render())
+
+
+@pytest.mark.parametrize(
+    "source_path, resolve_links",
+    [
+        (None, "if-possible"),
+        (None, "never"),
+        ("/", "never"),
+    ],
+)
+@pytest.mark.usefixtures("bogus_context")
+def test_jinja2_markdown_filter_noresolve_links(compile_template, resolve_links):
+    tmpl = compile_template(
+        f"{{{{ '[subpage](sub-page)' | markdown(resolve_links={resolve_links!r}) }}}}"
+    )
+    assert re.search(r"<a.*\bhref=(['\"])sub-page\1.*>subpage</a>", tmpl.render())
+
+
+@pytest.mark.parametrize("source_path", [None])
+@pytest.mark.usefixtures("bogus_context")
+def test_jinja2_markdown_filter_resolve_raises_if_no_source_obj(compile_template):
+    tmpl = compile_template(
+        "{{ '[subpage](sub-page)' | markdown(resolve_links='always') }}"
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        tmpl.render()
+    assert re.search(r"\bsource object\b.*\brequired\b", str(exc_info.value))
 
 
 def test_no_reference_cycle_in_environment(project):


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1100

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->
Doc update at lektor/lektor-website#362

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
- [x] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

This PR makes these changes:

1. It allows `lektor.markdown.Markdown` instances to be created with `record` set to `None`.
 
    The `record` is used to resolve relative URLs within the rendered markdown text to Lektor db objects, so as to (among other things) correctly generate URLs to attachments when `alt`s are involved.  Obviously, in cases where `record` is `None`, URL resolution via the Lektor db will not be attempted.

2. The `markdown` jinja filter is fixed so that it works.  It was broken by PR #992.
    - When the filter is invoked in a context of an artifact build, relative URLs in the markdown text will be resolved relative to the source object being built, otherwise, resolution of URLs via the Lektor db will not be enabled.
   - An optional `resolve_links` keyword argument is added to the `markdown` jinja filter.  This argument behaves like the [`resolve_links` field option](https://www.getlektor.com/docs/api/db/types/markdown/#resolution-of-links) for markdown fields.

<!--- Thanks for your help making Lektor better for everyone! --->
