### PR TITLE
Fix semantics of Record equality

### DIFF
--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -12,7 +12,7 @@ def get_asset(pad, filename, parent=None):
         return None
 
     try:
-        stat_obj = os.stat(os.path.join(parent.source_filename, filename))
+        stat_obj = os.stat(os.path.join(parent._source_filename, filename))
     except OSError:
         return None
     if stat.S_ISDIR(stat_obj.st_mode):
@@ -24,11 +24,7 @@ def get_asset(pad, filename, parent=None):
 
 
 class Asset(SourceObject):
-    # Source specific overrides.  The source_filename to none removes
-    # the inherited descriptor.
     source_classification = "asset"
-    source_filename = None
-
     artifact_extension = ""
 
     def __init__(self, pad, name, path=None, parent=None):
@@ -36,11 +32,14 @@ class Asset(SourceObject):
         if parent is not None:
             if path is None:
                 path = name
-            path = os.path.join(parent.source_filename, path)
-        self.source_filename = path
+            path = os.path.join(parent._source_filename, path)
+        self._source_filename = path
 
         self.name = name
         self.parent = parent
+
+    def iter_source_filenames(self):
+        yield self._source_filename
 
     @property
     def url_name(self):
@@ -99,7 +98,7 @@ class Directory(Asset):
     @property
     def children(self):
         try:
-            files = os.listdir(self.source_filename)
+            files = os.listdir(self._source_filename)
         except OSError:
             return
 

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -976,7 +976,7 @@ class Artifact:
         if exc_info is None:
             self._memorize_dependencies(
                 ctx.referenced_dependencies,
-                ctx.referenced_virtual_dependencies.values(),
+                ctx.referenced_virtual_dependencies,
             )
             self._commit()
             return
@@ -992,7 +992,7 @@ class Artifact:
         # use a new database connection that immediately commits.
         self._memorize_dependencies(
             ctx.referenced_dependencies,
-            ctx.referenced_virtual_dependencies.values(),
+            ctx.referenced_virtual_dependencies,
             for_failure=True,
         )
 

--- a/lektor/context.py
+++ b/lektor/context.py
@@ -241,8 +241,8 @@ class Context:
 
     def record_virtual_dependency(self, virtual_source):
         """Records a dependency from processing."""
-        path = virtual_source.path
-        self.referenced_virtual_dependencies[path] = virtual_source
+        key = virtual_source.path, virtual_source.alt
+        self.referenced_virtual_dependencies[key] = virtual_source
         for coll in self._dependency_collectors:
             coll(virtual_source)
 

--- a/lektor/context.py
+++ b/lektor/context.py
@@ -93,7 +93,7 @@ class Context:
 
         # Processing information
         self.referenced_dependencies = set()
-        self.referenced_virtual_dependencies = {}
+        self.referenced_virtual_dependencies = set()
         self.sub_artifacts = []
 
         self.flow_block_render_stack = []
@@ -241,8 +241,7 @@ class Context:
 
     def record_virtual_dependency(self, virtual_source):
         """Records a dependency from processing."""
-        key = virtual_source.path, virtual_source.alt
-        self.referenced_virtual_dependencies[key] = virtual_source
+        self.referenced_virtual_dependencies.add(virtual_source)
         for coll in self._dependency_collectors:
             coll(virtual_source)
 

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -33,7 +33,7 @@ from lektor.imagetools import get_image_info
 from lektor.imagetools import make_image_thumbnail
 from lektor.imagetools import read_exif
 from lektor.imagetools import ThumbnailMode
-from lektor.sourceobj import SourceObject
+from lektor.sourceobj import DBSourceObject
 from lektor.sourceobj import VirtualSourceObject
 from lektor.utils import cleanup_path
 from lektor.utils import cleanup_url_path
@@ -302,12 +302,12 @@ class _RecordQueryProxy:
 F = _RecordQueryProxy()
 
 
-class Record(SourceObject):
+class Record(DBSourceObject):
     source_classification = "record"
     supports_pagination = False
 
     def __init__(self, pad, data, page_num=None):
-        SourceObject.__init__(self, pad)
+        super().__init__(pad)
         self._data = data
         self._bound_data = {}
         if page_num is not None and not self.supports_pagination:
@@ -469,17 +469,6 @@ class Record(SourceObject):
             rv = rv.__get__(self)
         self._bound_data[name] = rv
         return rv
-
-    def __eq__(self, other):
-        if self is other:
-            return True
-        if self.__class__ != other.__class__:
-            return False
-        # NB: self.path potentially includes page_num for Pages
-        return self.path == other.path and self.alt == other.alt
-
-    def __hash__(self):
-        return hash((self.path, self.alt))
 
     def __repr__(self):
         return "<%s model=%r path=%r%s%s>" % (

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -764,10 +764,11 @@ class Attachment(Record):
         return self["_id"]
 
     def iter_source_filenames(self):
-        yield self.source_filename
+        attachment_filename = self.attachment_filename
         if self.alt != PRIMARY_ALT:
-            yield self.pad.db.to_fs_path(self["_path"]) + ".lr"
-        yield self.attachment_filename
+            yield f"{attachment_filename}+{self.alt}.lr"
+        yield f"{attachment_filename}.lr"
+        yield attachment_filename
 
     @property
     def url_path(self):

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -559,18 +559,11 @@ class Page(Record):
             alt=self.alt,
         )
 
-    @property
-    def source_filename(self):
-        if self.alt != PRIMARY_ALT:
-            return os.path.join(
-                self.pad.db.to_fs_path(self["_path"]), "contents+%s.lr" % self.alt
-            )
-        return os.path.join(self.pad.db.to_fs_path(self["_path"]), "contents.lr")
-
     def iter_source_filenames(self):
-        yield self.source_filename
+        fs_path = self.pad.db.to_fs_path(self._data["_path"])
         if self.alt != PRIMARY_ALT:
-            yield os.path.join(self.pad.db.to_fs_path(self["_path"]), "contents.lr")
+            yield os.path.join(fs_path, f"contents+{self.alt}.lr")
+        yield os.path.join(fs_path, "contents.lr")
 
     @property
     def url_path(self):
@@ -723,14 +716,6 @@ class Attachment(Record):
     """This represents a loaded attachment."""
 
     is_attachment = True
-
-    @property
-    def source_filename(self):
-        if self.alt != PRIMARY_ALT:
-            suffix = "+%s.lr" % self.alt
-        else:
-            suffix = ".lr"
-        return self.pad.db.to_fs_path(self["_path"]) + suffix
 
     def _is_considered_hidden(self):
         # Attachments are only considered hidden if they have been

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -27,7 +27,13 @@ class SourceObject:
 
     @property
     def source_filename(self):
-        """The primary source filename of this source object."""
+        """The primary source filename of this source object.
+
+        In general, subclasses should implement/override ``iter_source_filenames``
+        rather than this property.
+        """
+        source_filenames = self.iter_source_filenames()
+        return next(iter(source_filenames), None)
 
     is_hidden = False
     is_discoverable = True
@@ -43,13 +49,16 @@ class SourceObject:
         return not self.is_discoverable
 
     def iter_source_filenames(self):
-        fn = self.source_filename
-        if fn is not None:
-            yield self.source_filename
+        """An iterable of the source filenames for this source object.
+
+        The first returned filename should be the "primary" one.
+        """
+        # pylint: disable=no-self-use
+        return ()
 
     def iter_virtual_sources(self):
         # pylint: disable=no-self-use
-        return []
+        return ()
 
     @property
     def url_path(self):
@@ -234,9 +243,8 @@ class VirtualSourceObject(SourceObject):
     def alt(self):
         return self.record.alt
 
-    @property
-    def source_filename(self):
-        return self.record.source_filename
+    def iter_source_filenames(self):
+        return self.record.iter_source_filenames()
 
     def iter_virtual_sources(self):
         yield self

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -77,7 +77,7 @@ def test_asset_children(asset, child_names):
 
 @pytest.mark.parametrize("asset_path", ["/static"])
 def test_asset_children_no_children_if_dir_unreadable(asset):
-    asset.source_filename += "-missing"
+    asset._source_filename += "-missing"
     assert len(set(asset.children)) == 0
 
 

--- a/tests/test_sourceobj.py
+++ b/tests/test_sourceobj.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "key1, key2, is_eq",
+    [
+        ({"path": "/"}, {"path": "/"}, True),
+        ({"path": "/"}, {"path": "/", "alt": "en"}, True),
+        ({"path": "/"}, {"path": "/blog"}, False),
+        ({"path": "/blog/post1"}, {"path": "/blog/post1@siblings"}, False),
+        ({"path": "/"}, {"path": "/", "page_num": 1}, False),
+        ({"path": "/"}, {"path": "/", "alt": "de"}, False),
+        ({"path": "/", "alt": "en"}, {"path": "/", "alt": "de"}, False),
+    ],
+)
+def test_records_eq(pad, key1, key2, is_eq):
+    r1 = pad.get(**key1)
+    pad.cache.flush()
+    r2 = pad.get(**key2)
+    if is_eq:
+        assert r1 == r2
+        assert hash(r1) == hash(r2)
+    else:
+        assert r1 != r2
+
+
+def test_records_from_different_pads_ne(env):
+    pad1 = env.new_pad()
+    pad2 = env.new_pad()
+    assert pad1.get("/") == pad1.get("/")
+    assert pad1.get("/") != pad2.get("/")
+
+
+def test_asset_ne_record(pad):
+    record = pad.get("/")
+    asset = pad.get_asset("/")
+    assert record != asset
+    assert asset != record


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

These are bits extracted from the stale draft PR #1007.

It changes/fixes the equality semantics for `Records` and `VirtualSourceObjects` so that they compare equal only if all of the following match:
- `__class__`
- `path` (which includes `page_num` in the case of `Pages`)
- `alt`
- `pad`

Previously only `__class__` and `_path` were compared, thus records with differing `page_num`, `alt`, or `pad` were comparing as equal.

In general, a record is obtained by calling `pad.get(path, alt, page_num)` and a "different" record obtains if any of `pad`, `path`, `alt`, or `page_num` is changed.

### Other Changes

#### All SourceObjects should now implement iter_source_filenames

In general, the data comprising a `SourceObject` can come from multiple source files.
This happens for *Pages* when *alts* are in use.  It happens for *attachments* even when *alts* are not being used: an `Attachment` depends on both the attachment file and its corresponding metadata `.lr` file.

I suspect that we should deprecate the `SourceObject.source_filename` property altogether.  The primary use of `source_filename` or `iter_source_filenames` is for dependency tracking — in that case, we always want to track all (potential) source files.  In cases where a source object has multiple source files, 'm not sure the concept of a "primary" source file makes sense.

#### New class: DBSourceObject

This PR introduces a `DBSourceObject` class.  It is a subclass of `SourceObject` and serves as a superclass of all the object types that can be returned from `Pad.get`.
(The fixed equality comparison is implemented for `DBSourceObject`.)

The new class hierarchy (for classes in the Lektor source which derive from `SourceObject`) is

```mermaid
classDiagram
    SourceObject <|-- DBSourceObject
   DBSourceObject <|-- Record
   Record <|-- Page
   Record <|-- Attachment
   Attachment <|-- Image
   Attachment <|-- Video
   DBSourceObject <|-- VirtualSourceObject
   VirtualSourceObject <|-- Siblings
    SourceObject <|-- Asset
    Asset <|-- Directory
    Asset <|-- File
```


### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1101

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
