### PR TITLE
refactor(db)!: remove SourceObject.iter_virtual_sources from our API

### DIFF
--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1494,8 +1494,8 @@ class Database:
                 else:
                     affects_url = True
                 ctx.record_dependency(filename, affects_url=affects_url)
-            for virtual_source in record.iter_virtual_sources():
-                ctx.record_virtual_dependency(virtual_source)
+            if isinstance(record, VirtualSourceObject):
+                ctx.record_virtual_dependency(record)
             if getattr(record, "datamodel", None) and record.datamodel.filename:
                 ctx.record_dependency(record.datamodel.filename)
                 for dep_model in self.iter_dependent_models(record.datamodel):

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -56,10 +56,6 @@ class SourceObject:
         # pylint: disable=no-self-use
         return ()
 
-    def iter_virtual_sources(self):
-        # pylint: disable=no-self-use
-        return ()
-
     @property
     def url_path(self):
         """The URL path of this source object if available."""
@@ -279,6 +275,3 @@ class VirtualSourceObject(DBSourceObject):
         # the parent record, it may make sense to override this to
         # return an empty (or some other) list of file names.
         return self.record.iter_source_filenames()
-
-    def iter_virtual_sources(self):
-        yield self


### PR DESCRIPTION
The [SourceObject.iter_virtual_sources](https://github.com/lektor/lektor/blob/91e205cdbf8f4694ad6fe2ce0e350e6f87314bca/lektor/sourceobj.py#L50) method was introduced in PR #118.  It is called (only) in [Database.track_record_dependency](https://github.com/lektor/lektor/blob/91e205cdbf8f4694ad6fe2ce0e350e6f87314bca/lektor/db.py#L1516-L1517) to identify *virtual sources* to declare dependencies upon.

I have searched the Lektor source, as well as all of the Lektor plugins I can find on PyPI and GitHub, and have only found one instance where `iter_virtual_sources` returns anything other than an empty set.  That is [VirtualSourceObject.iter_virtual_sources](https://github.com/lektor/lektor/blob/91e205cdbf8f4694ad6fe2ce0e350e6f87314bca/lektor/sourceobj.py#LL241C7-L242C4), which returns only a single virtual source: `self`.

(Here is a search, purportedly of all the public repositories on GitHub, for [iter_virtual_sources](https://github.com/search?q=iter_virtual_sources&type=code&p=1).)

It doesn't seem to make any sense for a record to declare a virtual source object as a dependency.  Generally, records depend on the data and datamodel files (the `.lr` and `.ini` files) that define their content and behavior.  What would it mean for a record to depend on another record?  (And even if that were allowed, why only allow records to depend on other virtual sources but not regular non-virtual sources?)

PR #118 introduced this API, but didn't use it.  The PR introduced the `Siblings` virtual source object.  But it doesn't get introduced to an artifact's dependencies by way of `SourceObject.iter_virtual_sources`.  The Siblings virtual source object gets declared as a dependency of the current artifact when it is accessed in [Page.get_siblings()](https://github.com/lektor/lektor/blob/91e205cdbf8f4694ad6fe2ce0e350e6f87314bca/lektor/db.py#L687).  (This makes perfect sense: when a source object is accessed during the building of an artifact it gets added to the dependency list.)

### Breaking Change

This is potentially a breaking change, despite the fact that I can find no code that uses this feature.

We could first deprecate the API — issuing a warning whenever `iter_virtual_sources` returns anything unexpected — before removing it altogether.  But I highly suspect nobody is using this bit of API.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Cleans out unused code.   Removes confusing and not particularly useful API.



<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
