### PR TITLE
Fix dependency tracking on VirtualSourceObjects

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import os
 import shutil
@@ -8,6 +10,7 @@ import tempfile
 from collections import deque
 from collections import namedtuple
 from contextlib import contextmanager
+from dataclasses import dataclass
 from itertools import chain
 
 import click
@@ -635,12 +638,12 @@ def _unpack_virtual_source_path(packed):
     return path, alt
 
 
+@dataclass
 class VirtualSourceInfo:
-    def __init__(self, path, alt, mtime=None, checksum=None):
-        self.path = path
-        self.alt = alt
-        self.mtime = mtime
-        self.checksum = checksum
+    path: str
+    alt: str | None
+    mtime: int | None = None
+    checksum: str | None = None
 
     def unchanged(self, other):
         if not isinstance(other, VirtualSourceInfo):
@@ -653,12 +656,6 @@ class VirtualSourceInfo:
             )
 
         return (self.mtime, self.checksum) == (other.mtime, other.checksum)
-
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}"
-            f"({self.path!r}, {self.alt!r}, {self.mtime!r}, {self.checksum!r})"
-        )
 
 
 artifacts_row = namedtuple(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ paths = [
 exclude_lines = [
     "pragma: no cover",
     '^\s*\.\.\.\s*$',
+    '^\s*raise\s+NotImplementedError\(\)\s*$',
 ]
 
 ################################################################


### PR DESCRIPTION
This pulls out the key bits from draft PR #1007.
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

#### The `alt` of virtual source dependencies is not being recorded in the buildstate database

The `artifacts` table in the buildstate database tracks artifacts dependencies on two types of sources:
- source files
- VirtualSourceObjects

It identifies those sources with the string-valued column `path`.

Source files are tracked by setting `path` to the file-system path of the source file.
Currently, virtual sources are tracked by setting `path` to `VirtualSourceObject.path` — i.e. the Lektor db-path of the virtual source.

The issue is that the path is not the full identity key for a VirtualSourceObject — virtual sources vary with `alt` as well as `path`.

As a concrete example, what happens in the issues described in #959 is (e.g.), when building the German page for the first blog post (artifact = `/de/blog/first-post/index.html`), [`post.get_siblings()`][2] is called which registers a dependency on the `Siblings` virtual source object attached to the post.  Since the post has `alt="de"`, this is the virtual source that may be obtained by calling `pad.get("/blog/first-post@siblings", alt="de")`.  Currently, however, the dependency gets recorded only by its path (`/blog/first-post@siblings`).   When the builder, checking for changes that would necessitate a rebuild, goes to check the current state of the virtual source, it fetches [`pad.get("/blog/first-post@siblings")`][1] with no alt specified.  This is a different object — instead of `alt="de"` it has the default alt (`en`, or `_primary` before #958) — so it always compares as changed, forcing an unconditional rebuild.

[1]: https://github.com/lektor/lektor/blob/1999510ea5ba389ba97d8c99417bb336fc381320/lektor/builder.py#L160
[2]: https://github.com/lektor/lektor/blob/1999510ea5ba389ba97d8c99417bb336fc381320/example/templates/macros/blog.html#L30

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Related Issues / Links

Supercedes #1007
Supercedes #959
<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
