### PR TITLE
Remove dependency on pytz

### DIFF
--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -118,9 +118,9 @@ class DateTimeType(SingleInputType):
         if raw.value is None:
             return raw.missing_value("Missing datetime")
 
-        # The previous version of this code allowed a time zonename, followed by a zone
+        # The previous version of this code allowed a timezone name, followed by a zone
         # offset. In that case the zone name would be ignored (unless the combined zone
-        # name, including the offset matched an IANA zone key). For the sake of
+        # name, including the offset, matched an IANA zone key). For the sake of
         # backwards compatibility we do the same here.
         m = re.match(
             r"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,10 @@ install_requires =
     marshmallow_dataclass>=8.5.9
     mistune>=0.7.0,<3
     pip
+    pytz; python_version<"3.9"  # favor zoneinfo for python>=3.9
     python-slugify
     requests
+    tzdata; python_version>="3.9" and sys_platform == 'win32'
     watchdog
     Werkzeug>=2.1.0,<3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     mistune>=0.7.0,<3
     pip
     python-slugify
-    pytz
     requests
     watchdog
     Werkzeug>=2.1.0,<3

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ minversion = 4.1
 envlist =
     lint
     {py37,py38,py39,py310,py311}{,-mistune0}
-    py311-noutils,py311-pytz
+    py311-noutils
+    py311-pytz
+    py311-tzdata
     cover-{clean,report}
 isolated_build = true
 
@@ -26,6 +28,7 @@ deps =
     coverage[toml]
     mistune0: mistune<2
     pytz: pytz
+    tzdata: tzdata
 depends =
     py{37,38,39,310,311}{,-mistune0,-noutils}: cover-clean
     cover-report: py{37,38,39,310,311}{,-mistune0,-noutils}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 minversion = 4.1
 envlist =
     lint
-    {py37,py38,py39,py310,py311}{,-mistune0},py311-noutils
+    {py37,py38,py39,py310,py311}{,-mistune0}
+    py311-noutils,py311-pytz
     cover-{clean,report}
 isolated_build = true
 
@@ -24,6 +25,7 @@ deps =
     pytest-mock
     coverage[toml]
     mistune0: mistune<2
+    pytz: pytz
 depends =
     py{37,38,39,310,311}{,-mistune0,-noutils}: cover-clean
     cover-report: py{37,38,39,310,311}{,-mistune0,-noutils}


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->
Since the introduction of <del>PEP 614</del> PEP 615 (the `zoneinfo` module in the standard library, available since python 3.9), the future, apparently, is to transition away from `pytz` to `zoneinfo` for timezone support.

Babel, since 2.12, will now work with either `pytz` or `zoneinfo`, and no longer requires `pytz` on pythons >= 3.9.

This change also fixes some hokey-ness in the previous implementation of DateTimeType.

### Related Issues / Links

See #1109.

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
