### PR TITLE
Refactor(watcher): replace Queue with Semaphore

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -1,8 +1,8 @@
 # pylint: disable=import-outside-toplevel
 import os
 import sys
-import time
 import warnings
+from contextlib import suppress
 
 import click
 
@@ -154,14 +154,13 @@ def build_cmd(
         if not watch:
             return sys.exit(0 if success else 1)
 
-        from lektor.watcher import watch
+        from lektor.watcher import Watcher
 
         click.secho("Watching for file system changes", fg="cyan")
-        last_build = time.time()
-        for ts, _, _ in watch(env):
-            if ts > last_build:
+        with Watcher(env) as watcher, suppress(KeyboardInterrupt):
+            while True:
+                watcher.wait()
                 _build()
-                last_build = time.time()
 
 
 @cli.command("clean")

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -23,8 +23,9 @@ class EventHandler(FileSystemEventHandler):
         self.event = threading.Event()
 
     def _check(self, path):
-        if self.is_interesting(None, None, path):
-            self.event.set()
+        if not self.event.is_set():
+            if self.is_interesting(None, None, path):
+                self.event.set()
 
     # Generally we only care about changes (modification, creation, deletion) to files
     # within the monitored tree. Changes in directories do not directly affect Lektor

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -123,7 +123,7 @@ class BasicWatcher:
         observer.start()
         self.observer = observer
 
-    def is_interesting(self, time, event_type, path):
+    def is_interesting(self, path: str) -> bool:
         # pylint: disable=no-self-use
         return True
 
@@ -133,7 +133,7 @@ class BasicWatcher:
         if self.semaphore.acquire(blocking=False):
             # was set (unread change pending): just put it back
             self.semaphore.release()
-        elif self.is_interesting(None, None, path):
+        elif self.is_interesting(path):
             # was not set, but got an change event, set it
             self.semaphore.release()
 
@@ -157,7 +157,7 @@ class Watcher(BasicWatcher):
         self.output_path = output_path
         self.cache_dir = os.path.abspath(get_cache_dir())
 
-    def is_interesting(self, time, event_type, path):
+    def is_interesting(self, path: str) -> bool:
         path = os.path.abspath(path)
 
         if self.env.is_uninteresting_source_name(os.path.basename(path)):

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import os
 import threading
-import time
 from collections import OrderedDict
-from contextlib import suppress
 from dataclasses import dataclass
 from itertools import zip_longest
 from typing import Callable
@@ -169,11 +167,3 @@ class Watcher(BasicWatcher):
         ):
             return False
         return True
-
-
-def watch(env):
-    """Returns a generator of file system events in the environment."""
-    with Watcher(env) as watcher, suppress(KeyboardInterrupt):
-        while True:
-            watcher.wait()
-            yield time.time(), None, None

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -18,7 +18,6 @@ from watchdog.observers.polling import PollingObserver
 
 from lektor import utils
 from lektor.watcher import BasicWatcher
-from lektor.watcher import watch
 from lektor.watcher import Watcher
 
 
@@ -236,16 +235,3 @@ def test_is_interesting(env):
 
     w.output_path = None
     assert is_interesting(str(build_dir / "output.file"))
-
-
-def test_watch(env, mocker):
-    # just here for coverage
-    Watcher = mocker.patch("lektor.watcher.Watcher")
-    watcher = Watcher.return_value.__enter__.return_value
-    watcher.wait.side_effect = [True, KeyboardInterrupt()]
-
-    now = time.time()
-    events = list(watch(env))
-    assert len(events) == 1
-    time_, _event_type, _path = events[0]
-    assert time_ == pytest.approx(now, abs=0.1)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import os
 import shutil
 import sys
@@ -228,9 +227,7 @@ def test_is_interesting(env):
     build_dir = py.path.local("build")
 
     w = Watcher(env, str(build_dir))
-
-    # This partial makes the testing code shorter
-    is_interesting = functools.partial(w.is_interesting, 0, "generic")
+    is_interesting = w.is_interesting
 
     assert is_interesting("a.file")
     assert not is_interesting(".file")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -92,14 +92,14 @@ class WatcherTest:
                 # happened before is was started.  Here, we wait a little bit for things to
                 # start, then discard any pre-existing events.
                 time.sleep(0.1)
-                watcher.event.clear()
+                watcher.wait(blocking=False)
 
             yield self.watched_path
 
             if should_set_event:
-                assert watcher.event.wait(timeout=timeout)
+                assert watcher.wait(timeout=timeout)
             else:
-                assert not watcher.event.wait(timeout=timeout)
+                assert not watcher.wait(timeout=timeout)
 
 
 @pytest.fixture(


### PR DESCRIPTION
The current implementation stores all unprocessed filesystem change events in an unbounded Queue.  There can possibly be quite a number of events, so this can be (in some situations) a memory consumption issue.

(In addition, we were storing, event-type and path in the queue, though we never referenced it.)

All we really care about is whether there has been *any* interesting event since the last time we checked. All we need for that is a flag, not a queue.  So here we replace the `queue.Queue` with a <del>`threading.Event`</del> `threading.BoundedSemaphore`.

### API Changes

This does change the API to our `Watcher` class.  I think Lektor itself is the only user of that, however, so I don't think that's a big deal.

We might as well remove the `lektor.watcher.watch` function, too.  It's just as easy to use the `Watcher` class directly.

### Other Changes

There's logic in the current code that, for successful builds, only check for file changes that occur after the end of the last successful build.  (For failed builds, this logic is bypassed, so any unprocessed changes will trigger a new build-all.)
I think both of these are not quite correct.  Really we want to check for any changes since the beginning of the previous build — whether or not it was successful.


<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Related Issues / Links

Depends on #1117 

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
