### PR TITLE
Update/fix resolution of relative output path

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -48,7 +48,11 @@ def cli(ctx, project=None, language=None):
 
 @cli.command("build")
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=click.Path(resolve_path=True),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "--watch",
@@ -159,7 +163,11 @@ def build_cmd(
 
 @cli.command("clean")
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=click.Path(resolve_path=True),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "-v",
@@ -195,7 +203,11 @@ def clean_cmd(ctx, output_path, verbosity, extra_flags):
 @cli.command("deploy", short_help="Deploy the website.")
 @click.argument("server", required=False)
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=click.Path(resolve_path=True),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "--username",
@@ -300,7 +312,7 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(),
+    type=click.Path(resolve_path=True),
     default=None,
     help="The dev server will build into the same folder as "
     "the build command by default.",

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -11,6 +11,7 @@ from lektor.cli_utils import echo_json
 from lektor.cli_utils import extraflag
 from lektor.cli_utils import pass_context
 from lektor.cli_utils import pruneflag
+from lektor.cli_utils import ResolvedPath
 from lektor.cli_utils import validate_language
 from lektor.compat import importlib_metadata as metadata
 from lektor.project import Project
@@ -50,7 +51,7 @@ def cli(ctx, project=None, language=None):
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(resolve_path=True),
+    type=ResolvedPath(),
     default=None,
     help="The output path.",
 )
@@ -165,7 +166,7 @@ def build_cmd(
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(resolve_path=True),
+    type=ResolvedPath(),
     default=None,
     help="The output path.",
 )
@@ -205,7 +206,7 @@ def clean_cmd(ctx, output_path, verbosity, extra_flags):
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(resolve_path=True),
+    type=ResolvedPath(),
     default=None,
     help="The output path.",
 )
@@ -312,7 +313,7 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(resolve_path=True),
+    type=ResolvedPath(),
     default=None,
     help="The dev server will build into the same folder as "
     "the build command by default.",

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -108,12 +108,13 @@ class Project:
 
     def get_output_path(self):
         """The path where output files are stored."""
-        config = self.open_config()
+        config = self.open_config()  # raises if no project_file
         output_path = config.get("project.output_path")
         if output_path:
-            return os.path.join(self.tree, os.path.normpath(output_path))
-
-        return os.path.join(get_cache_dir(), "builds", self.id)
+            path = Path(config.filename).parent / output_path
+        else:
+            path = Path(get_cache_dir(), "builds", self.id)
+        return str(path)
 
     class PackageCacheType(Enum):
         VENV = "venv"  # The new virtual environment-based package cache

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from lektor.cli_utils import ResolvedPath
+
+
+@pytest.mark.parametrize("file_exists", [True, False])
+def test_ResolvedPath_resolves_relative_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_exists: bool
+) -> None:
+    resolved_path = ResolvedPath()
+    monkeypatch.chdir(tmp_path)
+    if file_exists:
+        Path(tmp_path, "filename").touch()
+
+    resolved = resolved_path.convert("filename", None, None)
+    assert isinstance(resolved, str)
+    # NB: os.path.realpath does not resolve symlinks on Windows with Python==3.7
+    assert resolved == os.path.join(Path().resolve(), "filename")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,28 @@
+import inspect
+from pathlib import Path
+
+from lektor.project import Project
+
+
+def test_Project_get_output_path(tmp_path: Path) -> None:
+    project_file = tmp_path / "test.lektorproject"
+    project_file.touch()
+    project = Project.from_file(project_file)
+    assert Path(project.get_output_path()).parts[-2:] == ("builds", project.id)
+
+
+def test_Project_get_output_path_is_relative_to_project_file(tmp_path: Path) -> None:
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    project_file = tmp_path / "test.lektorproject"
+    project_file.write_text(
+        inspect.cleandoc(
+            """[project]
+            path = tree
+            output_path = htdocs
+            """
+        )
+    )
+
+    project = Project.from_file(project_file)
+    assert project.get_output_path() == str(tmp_path / "htdocs")


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

- Update cli.py so that `--output-path` is interpreted relative to the current working directory.
- Fix `Project.get_output_path` to resolve a relative `output_path` configured in the project file relative to the location of the project file (as the [docs](https://www.getlektor.com/docs/project/file/#project) claim should happen).

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1103

### Related Issues / Links

Doc updates in lektor/lektor-website#367
<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [x] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
