### PR TITLE
Better input validation for the date/time formatting jinja filters

### DIFF
--- a/tests/demo-project/Website.lektorproject
+++ b/tests/demo-project/Website.lektorproject
@@ -7,11 +7,13 @@ included_assets = _*
 name = English
 name[de] = Englisch
 primary = yes
+locale = en_US
 
 [alternatives.de]
 name = German
 name[de] = Deutsch
 url_prefix = /de/
+locale = de_DE
 
 [servers.production]
 enabled = yes

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import sys
 from html import unescape
@@ -6,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import lektor.context
+from lektor.environment import Environment
 
 
 @pytest.fixture
@@ -110,3 +112,76 @@ def test_no_reference_cycle_in_environment(project):
     # reference count should be two: one from our `env` variable, and
     # another from the argument to sys.getrefcount
     assert sys.getrefcount(env) == 2
+
+
+@pytest.fixture
+def render_string(env):
+    def render_string(s, **kwargs):
+        template = env.jinja_env.from_string(s)
+        return template.render(**kwargs)
+
+    return render_string
+
+
+def test_dateformat_filter(render_string):
+    tmpl = "{{ dt | dateformat('yyyy-MM-dd') }}"
+    dt = datetime.date(2001, 2, 3)
+    assert render_string(tmpl, dt=dt) == "2001-02-03"
+
+
+def test_datetimeformat_filter_not_inlined(pad):
+    template = pad.env.jinja_env.from_string("{{ 1678749806 | datetimeformat }}")
+    en_date = template.render()
+    with lektor.context.Context(pad=pad) as ctx:
+        ctx.source = pad.get("/", alt="de")
+        de_date = template.render()
+    assert en_date != de_date
+
+
+def test_datetimeformat_filter(render_string):
+    tmpl = "{{ dt | datetimeformat('yyyy-MM-ddTHH:mm') }}"
+    dt = datetime.datetime(2001, 2, 3, 4, 5, 6)
+    assert render_string(tmpl, dt=dt) == "2001-02-03T04:05"
+
+
+def test_timeformat_filter(render_string):
+    tmpl = "{{ dt | datetimeformat('HH:mm') }}"
+    dt = datetime.time(1, 2, 3)
+    assert render_string(tmpl, dt=dt) == "01:02"
+
+
+@pytest.fixture(params=["dateformat", "datetimeformat", "timeformat"])
+def dates_filter(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+def test_dates_format_filter_handles_undefined(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ undefined | %s }}" % dates_filter)
+    assert template.render() == ""
+
+
+def test_dates_format_filter_raises_type_error_on_bad_arg(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ obj | %s }}" % dates_filter)
+    with pytest.raises(TypeError, match="unexpected exception"):
+        template.render(obj=object())
+
+
+def test_dates_format_filter_raises_type_error_on_bad_format(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ now | %s(42) }}" % dates_filter)
+    with pytest.raises(TypeError, match="should be a str"):
+        template.render(now=datetime.datetime.now())
+
+
+@pytest.mark.parametrize("arg", ["locale", "tzinfo"])
+def test_dates_format_filter_raises_type_error_on_bad_kwarg(
+    env: Environment, dates_filter: str, arg: str
+) -> None:
+    template = env.jinja_env.from_string("{{ now | %s(%s=42) }}" % (dates_filter, arg))
+    with pytest.raises(TypeError):
+        template.render(now=datetime.datetime.now())


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

Our `dateformat`, `timeformat` and `datetimeformat` jinja filters use `babel.dates.format_date`, etc. behind the scenes.  Babel’s format_* functions do not handle unexpected/invalid types well.  In particular, passing a `jinja2.Undefined` instance to them produces non-obvious exceptions. E.g. see #1121.

Here we check the inputs a bit better before passing them to Babel's formatting function.  If the filter is passed an *undefined* value (such as might result from referencing a `datetime` field with no value set), we return that undefined value coerced to a `str`.  In general, this results in an empty string being returned.  (Depending on the exact type of the undefined value, there are other possibilities: coercing a `StrictUndefined` to a string results in an `UndefinedError` being raised; coercing a `DebugUndefined` to a string results in a descriptive message being returned.)

We also catch unexpected errors from the Babel formatting function, and instead raise a `TypeError` with a quasi-informative message hinting that a bad type was passed to the filter.




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1121

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
