### PR TITLE
Back-port #1065 to the 3.3.x branch

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -6,7 +6,6 @@ import time
 import warnings
 
 import click
-import pkg_resources
 
 from lektor.cli_utils import AliasedGroup
 from lektor.cli_utils import buildflag
@@ -15,12 +14,13 @@ from lektor.cli_utils import extraflag
 from lektor.cli_utils import pass_context
 from lektor.cli_utils import pruneflag
 from lektor.cli_utils import validate_language
+from lektor.compat import importlib_metadata as metadata
 from lektor.project import Project
 from lektor.utils import profile_func
 from lektor.utils import secure_url
 
 
-version = pkg_resources.get_distribution("Lektor").version  # pylint: disable=no-member
+version = metadata.version("Lektor")
 
 
 @click.group(cls=AliasedGroup)

--- a/lektor/compat.py
+++ b/lektor/compat.py
@@ -1,0 +1,9 @@
+import sys
+
+__all__ = ["importlib_metadata"]
+
+if sys.version_info >= (3, 10):
+    from importlib import metadata as importlib_metadata
+else:
+    # we use importlib.metadata.packages_distributions() which is new in python 3.10
+    import importlib_metadata

--- a/lektor/compat.py
+++ b/lektor/compat.py
@@ -2,8 +2,7 @@ import sys
 
 __all__ = ["importlib_metadata"]
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 8):
     from importlib import metadata as importlib_metadata
 else:
-    # we use importlib.metadata.packages_distributions() which is new in python 3.10
     import importlib_metadata

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -7,7 +7,6 @@ import tempfile
 from subprocess import PIPE
 
 import click
-import pkg_resources
 import requests
 
 from lektor.utils import portable_popen
@@ -296,19 +295,6 @@ def update_cache(package_root, remote_packages, local_package_path, refresh=Fals
         write_manifest(manifest_file, all_packages)
 
 
-def add_site(path):
-    """This adds a path to as proper site packages to all associated import
-    systems.  Primarily it invokes `site.addsitedir` and also configures
-    pkg_resources' metadata accordingly.
-    """
-    site.addsitedir(path)
-    ws = pkg_resources.working_set
-    ws.entry_keys.setdefault(path, [])
-    ws.entries.append(path)
-    for dist in pkg_resources.find_distributions(path, False):
-        ws.add(dist, path, insert=True)
-
-
 def load_packages(env, reinstall=False):
     """This loads all the packages of a project.  What this does is updating
     the current cache in ``root/package-cache`` and then add the Python
@@ -326,7 +312,7 @@ def load_packages(env, reinstall=False):
         os.path.join(env.root_path, "packages"),
         refresh=reinstall,
     )
-    add_site(package_root)
+    site.addsitedir(package_root)
 
 
 def wipe_package_cache(env):

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -1,19 +1,33 @@
-import errno
+import hashlib
 import os
 import shutil
 import site
+import subprocess
 import sys
-import tempfile
-from subprocess import PIPE
+import sysconfig
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Iterator
+from typing import Optional
+from typing import Set
+from typing import Sized
+from typing import TYPE_CHECKING
+from venv import EnvBuilder
 
 import click
 import requests
+from build.util import project_wheel_metadata
 
 from lektor.utils import portable_popen
 
 
-class PackageException(Exception):
-    pass
+if TYPE_CHECKING:
+    from _typeshed import StrPath
+    from lektor.environment import Environment  # circ dependency
+else:
+    StrPath = object
 
 
 def _get_package_version_from_project(cfg, name):
@@ -25,7 +39,7 @@ def _get_package_version_from_project(cfg, name):
 
 
 def add_package_to_project(project, req):
-    """Given a pacakge requirement this returns the information about this
+    """Given a package requirement this returns the information about this
     plugin.
     """
     if "@" in req:
@@ -74,251 +88,242 @@ def remove_package_from_project(project, name):
     return None
 
 
-def download_and_install_package(
-    package_root, package=None, version=None, requirements_file=None
-):
-    """This downloads and installs a specific version of a package."""
-    # XXX: windows
-    env = dict(os.environ)
-
-    args = [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--target",
-        package_root,
-    ]
-
-    if package is not None:
-        args.append("%s%s%s" % (package, version and "==" or "", version or ""))
-    if requirements_file is not None:
-        args.extend(("-r", requirements_file))
-
-    rv = portable_popen(args, env=env).wait()
-    if rv != 0:
-        raise RuntimeError("Failed to install dependency package.")
-
-
-def install_local_package(package_root, path):
-    """This installs a local dependency of a package."""
-    # XXX: windows
-    env = dict(os.environ)
-    env["PYTHONPATH"] = package_root
-
-    # Step 1: generate egg info and link us into the target folder.
-    rv = portable_popen(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--editable",
-            path,
-            "--install-option=--install-dir=%s" % package_root,
-            "--no-deps",
-        ],
-        env=env,
-    ).wait()
-    if rv != 0:
-        raise RuntimeError("Failed to install local package")
-
-    # Step 2: generate the egg info into a temp folder to find the
-    # requirements.
-    tmp = tempfile.mkdtemp()
-    try:
-        rv = portable_popen(
-            [
-                sys.executable,
-                "setup.py",
-                "--quiet",
-                "egg_info",
-                "--quiet",
-                "--egg-base",
-                tmp,
-            ],
-            cwd=path,
-        ).wait()
-        dirs = os.listdir(tmp)
-        if rv != 0 or len(dirs) != 1:
-            raise RuntimeError("Failed to create egg info for local package.")
-        requires = os.path.join(tmp, dirs[0], "requires.txt")
-
-        # We have dependencies, install them!
-        if os.path.isfile(requires):
-            download_and_install_package(package_root, requirements_file=requires)
-    finally:
-        shutil.rmtree(tmp)
-
-
 def get_package_info(path):
-    """Returns the name of a package at a path."""
-    rv = (
-        portable_popen(
-            [
-                sys.executable,
-                "setup.py",
-                "--quiet",
-                "--name",
-                "--author",
-                "--author-email",
-                "--license",
-                "--url",
-            ],
-            cwd=path,
-            stdout=PIPE,
-        )
-        .communicate()[0]
-        .splitlines()
+    """Returns various package metadata of a local package at a path."""
+    # FIXME: Do we need this at all?  It's only used to by `lektor plugins publish`
+    # sub-command to check that the package name matches `lektor-*` before publishing.
+    #
+    keymap = (
+        ("name", "Name"),
+        ("author", "Author"),
+        ("author_email", "Author-Email"),
+        ("license", "License"),
+        ("url", "Home-Page"),
     )
-
-    def _process(value):
-        value = value.strip()
-        if value == "UNKNOWN":
-            return None
-        return value.decode("utf-8", "replace")
-
-    return {
-        "name": _process(rv[0]),
-        "author": _process(rv[1]),
-        "author_email": _process(rv[2]),
-        "license": _process(rv[3]),
-        "url": _process(rv[4]),
-        "path": path,
-    }
+    # XXX: isolated=False is considerably faster but seems fragile
+    meta = project_wheel_metadata(path, isolated=True)
+    return {"path": path, **{key: meta.get(metakey) for key, metakey in keymap}}
 
 
 def register_package(path):
     """Registers the plugin at the given path."""
+    # FIXME: Deprecate/delete?
+    # FIXME: Update to use build/twine?
+    # Note that pre-registration is no longer supported by PyPI. See note here:
+    #
+    # https://twine.readthedocs.io/en/stable/#twine-register
+    #
     portable_popen([sys.executable, "setup.py", "register"], cwd=path).wait()
 
 
 def publish_package(path):
     """Registers the plugin at the given path."""
+    # FIXME: Deprecate/delete?
+    # FIXME: Update to use build/twine
     portable_popen(
         [sys.executable, "setup.py", "sdist", "bdist_wheel", "upload"], cwd=path
     ).wait()
 
 
-def load_manifest(filename):
-    rv = {}
-    try:
-        with open(filename, encoding="utf-8") as f:
-            for line in f:
-                if line[:1] == "@":
-                    rv[line.strip()] = None
-                    continue
-                line = line.strip().split("=", 1)
-                if len(line) == 2:
-                    key = line[0].strip()
-                    value = line[1].strip()
-                    rv[key] = value
-    except IOError as e:
-        if e.errno != errno.ENOENT:
-            raise
-    return rv
+class VirtualEnv:
+    """A helper for manipulating our private package cache virtual environment.
 
+    Parameters:
 
-def write_manifest(filename, packages):
-    with open(filename, "w", encoding="utf-8") as f:
-        for package, version in sorted(packages.items()):
-            if package[:1] == "@":
-                f.write("%s\n" % package)
-            else:
-                f.write("%s=%s\n" % (package, version))
+    path — The path to the virtual environment to manage.  This can be an existing
+    environment or not.
 
-
-def list_local_packages(path):
-    """Lists all local packages below a path that could be installed."""
-    rv = []
-    try:
-        for filename in os.listdir(path):
-            if os.path.isfile(os.path.join(path, filename, "setup.py")):
-                rv.append("@" + filename)
-    except OSError:
-        pass
-    return rv
-
-
-def update_cache(package_root, remote_packages, local_package_path, refresh=False):
-    """Updates the package cache at package_root for the given dictionary
-    of packages as well as packages in the given local package path.
     """
-    requires_wipe = False
-    if refresh:
-        click.echo("Force package cache refresh.")
-        requires_wipe = True
 
-    manifest_file = os.path.join(package_root, "lektor-packages.manifest")
-    local_packages = list_local_packages(local_package_path)
+    def __init__(self, path: StrPath):
+        self.path = Path(path)
 
-    old_manifest = load_manifest(manifest_file)
-    to_install = []
+    def create(self, with_pip: bool = True, upgrade_deps: bool = True) -> None:
+        """(Re-)Create a new virtual environment.
 
-    all_packages = dict(remote_packages)
-    all_packages.update((x, None) for x in local_packages)
+        This will remove any existing virtual environment and create a new one.
 
-    # step 1: figure out which remote packages to install.
+        The parameters ``with_pip`` and ``upgrade_deps`` should probably be left at
+        their default values in normal usage.  They are provided here mostly for use in
+        tests. They work as described for ``venv.EnvBuilder`` from the standard library.
+        (Though ``upgrade_deps`` is only supported by EnvBuilder`` in py39+, here we
+        emulate it's behavior if running under older pythons.)
+
+        """
+        # Right now, by default, we always install and upgrade pip to
+        # the latest available version.
+        #
+        # We could optimize by not installing (and not upgrading) pip if
+        # the system pip is sufficient to our needs.
+        #
+        # Note that, e.g., pip>=21.3 is required to support PEP660 editable
+        # installs.
+        options: Dict[str, Any] = {"clear": True, "with_pip": with_pip}
+        if sys.version_info >= (3, 9):
+            EnvBuilder(upgrade_deps=upgrade_deps, **options).create(self.path)
+        else:
+            EnvBuilder(**options).create(self.path)
+            if upgrade_deps:
+                self.run_pip_install("--upgrade", "pip", "setuptools")
+
+    def addsitedir(self, sitedir: str) -> None:
+        """Add an additional sitedir to sys.path for virtual environment.
+
+        Packages installed in ``sitedir`` will be made available to any invocations
+        of python running within the virtual environment.
+        """
+        with Path(self.site_packages, "_lektor.pth").open("a", encoding="utf-8") as fp:
+            fp.write(f"import site; site.addsitedir({sitedir!r})\n")
+
+    def run_pip_install(self, *args: str) -> None:
+        """Run `pip install` in the virtual environment.
+
+        ``Args`` are appended to the command line (following ``pip install``). They
+        should specify how and which packages to install.
+
+        """
+        try:
+            subprocess.run((self.executable, "-m", "pip", "install", *args), check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError("Failed to install dependency package.") from exc
+
+    @property
+    def site_packages(self) -> str:
+        """The path to the virtual environments ``site-packages`` directory."""
+        return self._get_path("purelib")
+
+    @property
+    def executable(self) -> str:
+        """The path to the python interpreter for the virtual environment."""
+        script_path = Path(self._get_path("scripts"))
+        executable_name = Path(sys.executable).name
+        return os.fspath(script_path / executable_name)
+
+    def _get_path(self, name: str) -> str:
+        vars = {"base": os.fspath(self.path)}
+        return sysconfig.get_path(name, vars=vars)
+
+
+class Requirements(Iterable[str], Sized):
+    """Manage package requirements."""
+
+    requirements: Set[str]
+
+    def __init__(self) -> None:
+        self.requirements = set()
+
+    def __len__(self) -> int:
+        return len(self.requirements)
+
+    def __iter__(self) -> Iterator[str]:
+        """The requirements.
+
+        These requirements are in the form of arguments that can be passed to ``pip
+        install``.
+        """
+        return iter(self.requirements)
+
+    def add_requirement(self, package: str, version: Optional[str] = None) -> None:
+        """Add a (remote) distribution to the requirements."""
+        self.requirements.add(f"{package}=={version}" if version else f"{package}")
+
+    def add_local_requirement(self, path: StrPath) -> None:
+        """Add a local distribution source directory to the requirements.
+
+        The distribution source at ``path`` (which should be a legacy `setup.py` or
+        modern PEP660-compatible project) will be installed in editable mode.
+
+        """
+        srcdir = os.fspath(Path(path).resolve())
+        self.requirements.add(f"--editable={srcdir}")
+
+    _DIST_FILES = ("setup.py", "pyproject.toml")
+
+    def add_local_requirements_from(self, packages_path: StrPath) -> None:
+        """Add sub-directories of path that look like local distribution sources.
+
+        Any direct sub-directories of ``packages_path`` which appear to be distribution
+        source code will be added to the requirements in local (editable) mode.
+
+        """
+        try:
+            for path in Path(packages_path).iterdir():
+                if any(path.joinpath(fn).is_file() for fn in self._DIST_FILES):
+                    self.add_local_requirement(path)
+        except OSError:
+            pass
+
+    def hash(self) -> str:
+        """Compute a hash of the requirement set."""
+        hash = hashlib.sha1()
+        for requirement in sorted(self.requirements):
+            hash.update(requirement.encode("utf-8"))
+            hash.update(b"\0")
+        return hash.hexdigest()
+
+
+def update_cache(
+    venv_path: Path,
+    remote_packages: Dict[str, str],
+    local_package_path: Path,
+) -> None:
+    """Ensure the package cache at venv_path is up-to-date.
+
+    ``Remote_packages`` is a dictionary (mapping package names to required versions)
+    that specifies remote packages (to be installed from PyPI).
+
+    ``Local_package_page`` is a path to a directory whose sub-directories may contain
+    local plugin source.  Any such source directories will be installed in "editable"
+    mode.
+
+    """
+    requirements = Requirements()
     for package, version in remote_packages.items():
-        old_version = old_manifest.pop(package, None)
-        if old_version is None:
-            to_install.append((package, version))
-        elif old_version != version:
-            requires_wipe = True
+        requirements.add_requirement(package, version)
+    requirements.add_local_requirements_from(local_package_path)
 
-    # step 2: figure out which local packages to install
-    for package in local_packages:
-        if old_manifest.pop(package, False) is False:
-            to_install.append((package, None))
-
-    # Bad news, we need to wipe everything
-    if requires_wipe or old_manifest:
+    if len(requirements) == 0:
+        shutil.rmtree(venv_path, ignore_errors=True)
+    else:
+        hash_file = venv_path / "lektor-requirements-hash.txt"
         try:
-            shutil.rmtree(package_root)
-        except OSError:
-            pass
-        to_install = all_packages.items()
+            is_stale = hash_file.read_text().strip() != requirements.hash()
+        except FileNotFoundError:
+            is_stale = True
 
-    if to_install:
-        click.echo("Updating packages in %s for project" % package_root)
-        try:
-            os.makedirs(package_root)
-        except OSError:
-            pass
-        for package, version in to_install:
-            if package[:1] == "@":
-                install_local_package(
-                    package_root, os.path.join(local_package_path, package[1:])
-                )
-            else:
-                download_and_install_package(package_root, package, version)
-        write_manifest(manifest_file, all_packages)
+        if is_stale:
+            venv = VirtualEnv(venv_path)
+            venv.create()
+            # Add our site-packages to venv's sys.path
+            our_site_packages = sysconfig.get_path("purelib")
+            venv.addsitedir(our_site_packages)
+
+            venv.run_pip_install(*requirements)
+            hash_file.write_text(f"{requirements.hash()}\n", encoding="ascii")
 
 
-def load_packages(env, reinstall=False):
-    """This loads all the packages of a project.  What this does is updating
-    the current cache in ``root/package-cache`` and then add the Python
-    modules there to the load path as a site directory and register it
-    appropriately with pkg_resource's workingset.
+def load_packages(env: "Environment", reinstall: bool = False) -> None:
+    """Import all of our managed plugins into our ``sys.path``
 
-    Afterwards all entry points should function as expected and imports
-    should be possible.
+    This first ensures that our private package cache is up-to-date, then
+    adds it to ``sys.path``.
+
+    After ``load_packages`` is called, the entry points defined in by
+    plugins that we manage will be available.
     """
+    if reinstall:
+        click.echo("Force package cache refresh.")
+        wipe_package_cache(env)
+
     config = env.load_config()
-    package_root = env.project.get_package_cache_path()
-    update_cache(
-        package_root,
-        config["PACKAGES"],
-        os.path.join(env.root_path, "packages"),
-        refresh=reinstall,
-    )
-    site.addsitedir(package_root)
+    venv_path = env.project.get_package_cache_path()
+    update_cache(venv_path, config["PACKAGES"], Path(env.root_path, "packages"))
+    site.addsitedir(VirtualEnv(venv_path).site_packages)
 
 
-def wipe_package_cache(env):
-    """Wipes the entire package cache."""
-    package_root = env.project.get_package_cache_path()
-    try:
-        shutil.rmtree(package_root)
-    except (OSError, IOError):
-        pass
+def wipe_package_cache(env: "Environment") -> None:
+    """Remove the entire package cache."""
+    project = env.project
+    # Remove the legacy flat package cache, too
+    for cache_type in project.PackageCacheType:
+        shutil.rmtree(project.get_package_cache_path(cache_type), ignore_errors=True)

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -2,6 +2,8 @@ import inspect
 import os
 import sys
 import warnings
+from typing import Optional
+from typing import Type
 from weakref import ref as weakref
 
 from inifile import IniFile
@@ -34,6 +36,8 @@ class Plugin:
     name = "Your Plugin Name"
     description = "Description goes here"
 
+    __dist: metadata.Distribution = None
+
     def __init__(self, env, id):
         self._env = weakref(env)
         self.id = id
@@ -47,10 +51,9 @@ class Plugin:
 
     @property
     def version(self):
-        try:
-            return metadata.version(_dist_name_for_module(self.__module__))
-        except LookupError:
-            return None
+        if self.__dist is not None:
+            return self.__dist.version
+        return None
 
     @property
     def path(self):
@@ -110,32 +113,39 @@ class Plugin:
         }
 
 
-def load_plugins():
-    """Loads all available plugins and returns them."""
-    rv = {}
-    for ep in metadata.entry_points(  # pylint: disable=unexpected-keyword-arg
-        group="lektor.plugins"
-    ):
-        # XXX: do we really need to be so strict about distribution names?
-        match_name = "lektor-" + ep.name.lower()
-        try:
-            dist_name = _dist_name_for_module(ep.module)
-        except LookupError:
-            dist_name = ""
-        if match_name != dist_name.lower():
-            raise RuntimeError(
-                "Disallowed distribution name: distribution name for "
-                f"plugin {ep.name!r} must be {match_name!r} (not {dist_name!r})."
-            )
-        rv[ep.name] = ep.load()
-    return rv
+def _find_plugins():
+    """Find all available plugins.
+
+    Returns an interator of (distribution, entry_point) pairs.
+    """
+    for dist in metadata.distributions():
+        for ep in dist.entry_points:
+            if ep.group == "lektor.plugins":
+                _check_dist_name(dist.name, ep.name)
+                yield dist, ep
+
+
+def _check_dist_name(dist_name, plugin_id):
+    """Check that plugin comes from a validly named distribution.
+
+    Raises RuntimeError if distribution name is not of the form
+    ``lektor-``*<plugin_id>*.
+    """
+    # XXX: do we really need to be so strict about distribution names?
+    match_name = "lektor-" + plugin_id.lower()
+    if match_name != dist_name.lower():
+        raise RuntimeError(
+            "Disallowed distribution name: distribution name for "
+            f"plugin {plugin_id!r} must be {match_name!r} (not {dist_name!r})."
+        )
 
 
 def initialize_plugins(env):
     """Initializes the plugins for the environment."""
-    plugins = load_plugins()
-    for plugin_id, plugin_cls in plugins.items():
-        env.plugin_controller.instanciate_plugin(plugin_id, plugin_cls)
+    for dist, ep in _find_plugins():
+        plugin_id = ep.name
+        plugin_cls = ep.load()
+        env.plugin_controller.instanciate_plugin(plugin_id, plugin_cls, dist)
     env.plugin_controller.emit("setup-env")
 
 
@@ -155,11 +165,22 @@ class PluginController:
             raise RuntimeError("Environment went away")
         return rv
 
-    def instanciate_plugin(self, plugin_id, plugin_cls):
+    def instanciate_plugin(
+        self,
+        plugin_id: str,
+        plugin_cls: Type[Plugin],
+        dist: Optional[metadata.Distribution] = None,
+    ) -> None:
         env = self.env
         if plugin_id in env.plugins:
             raise RuntimeError('Plugin "%s" is already registered' % plugin_id)
-        env.plugins[plugin_id] = plugin_cls(env, plugin_id)
+        plugin = plugin_cls(env, plugin_id)
+        # Plugin.version needs the source distribution to be able to cleanly determine
+        # the plugin version.  For reasons of backward compatibility, we don't want to
+        # change the signature of the constructor, so we stick it in a private attribute
+        # here.
+        plugin._Plugin__dist = dist
+        env.plugins[plugin_id] = plugin
         env.plugin_ids_by_class[plugin_cls] = plugin_id
 
     def iter_plugins(self):
@@ -195,12 +216,3 @@ class PluginController:
                         DeprecationWarning,
                     )
         return rv
-
-
-def _dist_name_for_module(module: str) -> "str | None":
-    """Return the name of the distribution which provides the named module."""
-    top_level = module.partition(".")[0]
-    distributions = metadata.packages_distributions().get(top_level, [])
-    if len(distributions) != 1:
-        raise LookupError(f"Can not find distribution for {module}")
-    return distributions[0]

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -121,7 +121,7 @@ def _find_plugins():
     for dist in metadata.distributions():
         for ep in dist.entry_points:
             if ep.group == "lektor.plugins":
-                _check_dist_name(dist.name, ep.name)
+                _check_dist_name(dist.metadata["Name"], ep.name)
                 yield dist, ep
 
 

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
 import sys
+from enum import Enum
+from pathlib import Path
 
 from inifile import IniFile
 from werkzeug.utils import cached_property
@@ -111,13 +113,25 @@ class Project:
 
         return os.path.join(get_cache_dir(), "builds", self.id)
 
-    def get_package_cache_path(self):
+    class PackageCacheType(Enum):
+        VENV = "venv"  # The new virtual environment-based package cache
+        FLAT = "flat"  # No longer used flat-directory package cache
+
+    def get_package_cache_path(
+        self, cache_type: PackageCacheType = PackageCacheType.VENV
+    ) -> Path:
         """The path where plugin packages are stored."""
+        if cache_type is self.PackageCacheType.FLAT:
+            cache_name = "packages"
+        else:
+            cache_name = "venvs"
+
         h = hashlib.md5()
         h.update(self.id.encode("utf-8"))
         h.update(sys.version.encode("utf-8"))
         h.update(sys.prefix.encode("utf-8"))
-        return os.path.join(get_cache_dir(), "packages", h.hexdigest())
+
+        return Path(get_cache_dir(), cache_name, h.hexdigest())
 
     def content_path_from_filename(self, filename):
         """Given a filename returns the content path or None if

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ zip_safe = False
 python_requires = >=3.6
 install_requires =
     Babel
+    build
     click>=6.0
     EXIFRead
     filetype>=1.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     EXIFRead
     filetype>=1.0.7
     Flask
+    importlib_metadata; python_version<"3.10"
     inifile>=0.4.1
     Jinja2>=3.0
     markupsafe

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     EXIFRead
     filetype>=1.0.7
     Flask
-    importlib_metadata; python_version<"3.10"
+    importlib_metadata; python_version<"3.8"
     inifile>=0.4.1
     Jinja2>=3.0
     markupsafe

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ install_requires =
     Jinja2>=3.0
     markupsafe
     mistune>=0.7.0,<2
-    pip
     python-slugify
     pytz
     requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
+import importlib
 import os
 import shutil
 import sys
 import textwrap
 
-import pkg_resources
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -43,12 +43,12 @@ def temporary_lektor_cache(tmp_path_factory):
 
 @pytest.fixture
 def save_sys_path(monkeypatch):
-    """Save `sys.path`, `sys.modules`, and `pkg_resources` state on test
-    entry, restore after test completion.
+    """Save `sys.path`, and `sys.modules` state on test entry, restore after test
+    completion.
 
     Any test which constructs a `lektor.environment.Environment` instance
     or which runs any of the Lektor CLI commands should use this fixture
-    to ensure that alternations made to `sys.path` do not interfere with
+    to ensure that alterations made to `sys.path` do not interfere with
     other tests.
 
     Lektor's private package cache is added to `sys.path` by
@@ -72,18 +72,15 @@ def save_sys_path(monkeypatch):
     # using monkeypatch to swap it out.
     saved_modules = sys.modules.copy()
 
-    # While pkg_resources.__getstate__ and pkg_resources.__setstate__
-    # do not appear to be a documented part of the pkg_resources API,
-    # they are used in setuptools' own tests, and appear to have been
-    # a stable feature since 2011.
-    saved_state = pkg_resources.__getstate__()
+    # It's not clear that this is necessary, but it probably won't hurt.
+    importlib.invalidate_caches()
+
     try:
         yield
     finally:
         for name in set(sys.modules).difference(saved_modules):
             del sys.modules[name]
         sys.modules.update(saved_modules)
-        pkg_resources.__setstate__(saved_state)
 
 
 @pytest.fixture(scope="function")

--- a/tests/setup_py-dummy-plugin/lektor_dummy_plugin.py
+++ b/tests/setup_py-dummy-plugin/lektor_dummy_plugin.py
@@ -1,0 +1,9 @@
+"""Dummy test plugin"""
+from lektor.pluginsystem import Plugin
+
+
+class DummyPlugin(Plugin):
+    """Dummy test plugin."""
+
+    # pylint: disable=too-few-public-methods
+    name = "dummy"

--- a/tests/setup_py-dummy-plugin/setup.py
+++ b/tests/setup_py-dummy-plugin/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name="lektor-dummy-plugin",
+    description="setup.py test plugin",
+    version="0.1a42",
+    py_modules=["lektor_dummy_plugin"],
+    entry_points={
+        "lektor.plugins": [
+            "dummy = lektor_dummy_plugin:DummyPlugin",
+        ]
+    },
+)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,201 @@
+import inspect
+import os
+import re
+import sys
+import sysconfig
+from pathlib import Path
+from subprocess import PIPE
+from subprocess import run
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lektor.environment import Environment
+from lektor.packages import load_packages
+from lektor.packages import Requirements
+from lektor.packages import update_cache
+from lektor.packages import VirtualEnv
+from lektor.project import Project
+
+
+@pytest.fixture(scope="module")
+def nested_venv(tmp_path_factory: pytest.TempPathFactory) -> VirtualEnv:
+    """Create a lighweight nested virtual environment.
+
+    The created venv does not have anything installed in it — not even pip. It does,
+    however, have our ``site-packages`` directory added to its ``sys.path``, so it
+    should have access to a working ``pip`` that way.
+
+    This lightweight venv is relative quick to create.  Creating a full independent
+    venv involves running ``python -m ensurepip`` and potential network requests
+    to PyPI.
+    """
+    tmp_path = tmp_path_factory.mktemp("nested_venv")
+    venv = VirtualEnv(tmp_path)
+    # venv creation is very quick without installing/upgrading pip
+    venv.create(with_pip=False, upgrade_deps=False)
+
+    # add our site-packages to the venv's sys.path
+    venv.addsitedir(sysconfig.get_path("purelib"))
+    return venv
+
+
+def test_VirtualEnv_creates_site_packages(tmp_path: Path) -> None:
+    venv = VirtualEnv(tmp_path)
+    # venv creation is very quick without installing/upgrading pip
+    venv.create(with_pip=False, upgrade_deps=False)
+    assert Path(venv.site_packages).is_dir()
+
+
+def test_VirtualEnv_addsitedir(nested_venv: VirtualEnv) -> None:
+    # check that we can run pytest (presumably from our site-packages)
+    proc = run((nested_venv.executable, "-m", "pytest", "--version"), check=False)
+    assert proc.returncode == 0
+
+
+@pytest.mark.requiresinternet
+def test_VirtualEnv_run_pip_install(tmp_path: Path) -> None:
+    # XXX: slow test
+    venv = VirtualEnv(tmp_path)
+    venv.create()
+
+    # install a dummy plugin
+    plugin_path = Path(__file__).parent / "setup_py-dummy-plugin"
+    dummy_plugin_path = os.fspath(plugin_path.resolve())
+    venv.run_pip_install(f"--editable={dummy_plugin_path}")
+
+    # Make our lektor available to the installed plugin
+    venv.addsitedir(sysconfig.get_path("purelib"))
+
+    # Check that we can load the plugin entry point
+    prog = inspect.cleandoc(
+        """
+        import sys
+        if sys.version_info < (3, 10):
+            # need "selectable" entry_points
+            import importlib_metadata as metadata
+        else:
+            from importlib import metadata
+
+        for ep in metadata.entry_points(group="lektor.plugins", name="dummy"):
+            print(ep.load().__name__)
+    """
+    )
+    proc = run((venv.executable, "-c", prog), stdout=PIPE, encoding="utf-8", check=True)
+    assert proc.stdout.strip() == "DummyPlugin"
+
+
+def test_VirtualEnv_run_pip_install_raises_runtime_error(
+    nested_venv: VirtualEnv, capfd: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        nested_venv.run_pip_install("--unknown-option")
+    assert excinfo.match("Failed to install")
+    assert "no such option" in capfd.readouterr().err
+
+
+def test_VirtualEnv_site_packages(tmp_path: Path) -> None:
+    site_packages = VirtualEnv(tmp_path).site_packages
+    relpath = os.fspath(Path(site_packages).relative_to(tmp_path))
+    assert re.match(r"(?i)lib(?=[/\\]).*[/\\]site-packages\Z", relpath)
+
+
+def test_VirtualEnv_executable(tmp_path: Path) -> None:
+    executable = VirtualEnv(tmp_path).executable
+    relpath = os.fspath(Path(executable).relative_to(tmp_path))
+    assert re.match(r"(?i)(?:bin|Scripts)[/\\]python(?:\.\w*)?\Z", relpath)
+
+
+def test_Requirements_add_requirement() -> None:
+    requirements = Requirements()
+    requirements.add_requirement("foo", "1.2")
+    requirements.add_requirement("bar")
+    assert len(requirements) == 2
+    assert set(requirements) == {"foo==1.2", "bar"}
+
+
+def test_Requirements_add_local_requirement() -> None:
+    requirements = Requirements()
+    plugin_path = Path(__file__).parent / "setup_py-dummy-plugin"
+    requirements.add_local_requirement(plugin_path)
+    assert set(requirements) == {f"--editable={os.fspath(plugin_path.resolve())}"}
+
+
+def test_Requirements_add_local_requirements_from(tmp_path: Path) -> None:
+    for fn in ["plugin1/pyproject.toml", "plugin2/setup.py", "notaplugin/README.md"]:
+        path = tmp_path / fn
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    requirements = Requirements()
+    requirements.add_local_requirements_from(tmp_path)
+    assert len(requirements) == 2
+    assert {req.rpartition(os.sep)[2] for req in requirements} == {"plugin1", "plugin2"}
+
+
+def test_Requirements_add_local_requirements_from_missing_dir(tmp_path: Path) -> None:
+    requirements = Requirements()
+    requirements.add_local_requirements_from(tmp_path / "missing")
+    assert len(requirements) == 0
+    assert not requirements
+
+
+def test_Requirements_hash() -> None:
+    requirements = Requirements()
+    assert requirements.hash() == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    requirements.add_requirement("foo", "42")
+    assert requirements.hash() == "a44f078eab8bc1aa1ddfd111d63e24ff65131b4b"
+
+
+def test_update_cache_installs_requirements(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    venv_path = tmp_path / "cache"
+    venv_path.mkdir()
+    VirtualEnv = mocker.patch("lektor.packages.VirtualEnv")
+    update_cache(venv_path, {"foo": "42"}, tmp_path / "packages")
+    assert mocker.call().run_pip_install("foo==42") in VirtualEnv.mock_calls
+    hash_file = venv_path / "lektor-requirements-hash.txt"
+    assert hash_file.read_text().strip() == "a44f078eab8bc1aa1ddfd111d63e24ff65131b4b"
+
+
+def test_update_cache_skips_install_if_up_to_date(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    venv_path = tmp_path / "cache"
+    venv_path.mkdir()
+    venv_path.joinpath("lektor-requirements-hash.txt").write_text(
+        "a44f078eab8bc1aa1ddfd111d63e24ff65131b4b\n"
+    )
+    VirtualEnv = mocker.patch("lektor.packages.VirtualEnv")
+    update_cache(venv_path, {"foo": "42"}, tmp_path / "packages")
+    assert VirtualEnv.mock_calls == []
+
+
+def test_update_cache_removes_package_cache_if_no_requirements(tmp_path: Path) -> None:
+    venv_path = tmp_path / "cache"
+    venv_path.mkdir()
+
+    update_cache(venv_path, {}, tmp_path / "missing")
+    assert not venv_path.exists()
+
+
+def test_load_packages_add_package_cache_to_sys_path(env: Environment) -> None:
+    load_packages(env)
+    venv_path = env.project.get_package_cache_path()
+    site_packages = VirtualEnv(venv_path).site_packages
+    assert site_packages in sys.path
+
+
+PackageCacheType = Project.PackageCacheType
+
+
+@pytest.mark.parametrize("cache_type", PackageCacheType)
+def test_load_packages_reinstall_wipes_cache(
+    env: Environment, cache_type: PackageCacheType
+) -> None:
+    project = env.project
+    cache_path = project.get_package_cache_path(cache_type)
+    cache_path.mkdir(parents=True, exist_ok=False)
+
+    load_packages(env, reinstall=True)
+    assert not cache_path.exists()

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -13,9 +13,9 @@ from lektor.cli import cli
 from lektor.compat import importlib_metadata as metadata
 from lektor.context import Context
 from lektor.packages import add_package_to_project
-from lektor.pluginsystem import _dist_name_for_module
+from lektor.pluginsystem import _check_dist_name
+from lektor.pluginsystem import _find_plugins
 from lektor.pluginsystem import get_plugin
-from lektor.pluginsystem import load_plugins
 from lektor.pluginsystem import Plugin
 from lektor.pluginsystem import PluginController
 
@@ -114,18 +114,11 @@ class DummyPluginFinder(metadata.DistributionFinder):
 
 
 @pytest.fixture
-def dummy_plugin_distribution_name():
-    return "lektor-dummy-plugin"
-
-
-@pytest.fixture
-def dummy_plugin_distribution(
-    dummy_plugin_distribution_name, save_sys_path, monkeypatch
-):
+def dummy_plugin_distribution(save_sys_path, monkeypatch):
     """Add a dummy plugin distribution to the current working_set."""
     dist = DummyDistribution(
         {
-            "Name": dummy_plugin_distribution_name,
+            "Name": "lektor-dummy-plugin",
             "Version": "1.23",
         }
     )
@@ -135,9 +128,11 @@ def dummy_plugin_distribution(
 
 
 @pytest.fixture
-def dummy_plugin(env):
+def dummy_plugin(env, dummy_plugin_distribution):
     """Instantiate and register a dummy plugin in env"""
-    env.plugin_controller.instanciate_plugin("dummy-plugin", DummyPlugin)
+    env.plugin_controller.instanciate_plugin(
+        "dummy-plugin", DummyPlugin, dummy_plugin_distribution
+    )
     return env.plugins["dummy-plugin"]
 
 
@@ -174,9 +169,11 @@ class TestPlugin:
         return scratch_project_data
 
     @pytest.fixture
-    def scratch_plugin(self, scratch_env):
+    def scratch_plugin(self, scratch_env, dummy_plugin_distribution):
         """Instantiate and register a dummy plugin with scratch_env"""
-        scratch_env.plugin_controller.instanciate_plugin("dummy-plugin", DummyPlugin)
+        scratch_env.plugin_controller.instanciate_plugin(
+            "dummy-plugin", DummyPlugin, dummy_plugin_distribution
+        )
         return scratch_env.plugins["dummy-plugin"]
 
     def test_env(self, dummy_plugin, env):
@@ -191,6 +188,12 @@ class TestPlugin:
 
     def test_version(self, dummy_plugin, dummy_plugin_distribution):
         assert dummy_plugin.version == dummy_plugin_distribution.version
+
+    def test_version_missing(self, env):
+        # Instantiate plugin without specifying distribution
+        env.plugin_controller.instanciate_plugin("dummy-plugin", DummyPlugin)
+        plugin = env.plugins["dummy-plugin"]
+        assert plugin.version is None
 
     def test_path(self, dummy_plugin):
         assert dummy_plugin.path == str(Path(__file__).parent)
@@ -261,14 +264,30 @@ class TestPlugin:
         }
 
 
-def test_load_plugins(dummy_plugin_distribution):
-    assert load_plugins() == {"dummy-plugin": DummyPlugin}
+def test_find_plugins(dummy_plugin_distribution):
+    (ep,) = dummy_plugin_distribution.entry_points
+    assert list(_find_plugins()) == [(dummy_plugin_distribution, ep)]
 
 
-@pytest.mark.parametrize("dummy_plugin_distribution_name", ["evil-dist-name"])
-def test_load_plugins_bad_distname(dummy_plugin_distribution):
-    with pytest.raises(RuntimeError, match=r"Disallowed distribution name"):
-        load_plugins()
+@pytest.mark.parametrize(
+    "dist_name, plugin_id",
+    [
+        ("Lektor-FOO", "Foo"),
+    ],
+)
+def test_check_dist_name(dist_name, plugin_id):
+    _check_dist_name(dist_name, plugin_id)
+
+
+@pytest.mark.parametrize(
+    "dist_name, plugin_id",
+    [
+        ("NotLektor-FOO", "Foo"),
+    ],
+)
+def test_check_dist_name_raises(dist_name, plugin_id):
+    with pytest.raises(RuntimeError):
+        _check_dist_name(dist_name, plugin_id)
 
 
 class TestPluginController:
@@ -344,12 +363,3 @@ def test_cli_integration(project, cli_runner, monkeypatch):
     )
     for call in DummyPlugin.calls:
         assert call["extra_flags"] == {"flag1": "flag1", "flag2": "value2"}
-
-
-def test_dist_name_form_module():
-    assert _dist_name_for_module("lektor.db") == "Lektor"
-
-
-def test_dist_name_form_module_raises_exception():
-    with pytest.raises(LookupError):
-        assert _dist_name_for_module("missing.module")

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ commands =
 deps =
     pylint==2.11.1
     pytest>=6
+    pytest-mock
+    importlib_metadata; python_version<"3.8"
 commands =
     pylint {posargs:lektor tests}
 


### PR DESCRIPTION
This PR back-ports #1065 (and #1061) to the 3.3-maintenance branch.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1127

This is one possible approach to fixing the breakage caused by the latest release of `pip` (which no longer supports the `--install-option` flag to `pip install`).

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
