### PR TITLE
Fix local plugin installation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,20 @@ These are all the changes in Lektor since the first public release.
 
 ## 3.3.9 (unreleased)
 
+### Bit-Rot
+
+- Fix installation of local plugins (from the `packages/`
+  subdirectory). This was broken by release 23.1 of `pip` which
+  dropped support for the `--install-option` flag to `pip install`.
+  ([#1129], [#1127])
+
 ### Bugs
 
 - Implement better input validation for the date/time-formatting jinja
   filters. Prior to this, passing a `jinja2.Undefined` value to the
   `date`, `time`, or `datetime` filters would elicit an assertion
   error. ([#1122], [#1121])
+
 - Fix for spurious rebuilds. Recent versions of watchdog (>=2.3.0)
   enabled tracking of IN_OPEN events. These fire when a file is opened
   — even just for reading. Now we're pickier about only responding to
@@ -18,6 +26,8 @@ These are all the changes in Lektor since the first public release.
 [#1117]: https://github.com/lektor/lektor/pull/1117
 [#1121]: https://github.com/lektor/lektor/issues/1121
 [#1122]: https://github.com/lektor/lektor/pull/1122
+[#1127]: https://github.com/lektor/lektor/issues/1127
+[#1129]: https://github.com/lektor/lektor/pull/1129
 
 ## 3.3.8 (2023-02-28)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,11 +45,11 @@ install_requires =
     Jinja2>=3.0
     markupsafe
     mistune>=0.7.0,<2
-    pip
+    pip>=21.1
     python-slugify
     pytz
     requests
-    setuptools
+    setuptools>=45.2
     watchdog
     Werkzeug<3
 

--- a/tests/setup_py-dummy-plugin/lektor_dummy_plugin.py
+++ b/tests/setup_py-dummy-plugin/lektor_dummy_plugin.py
@@ -1,0 +1,9 @@
+"""Dummy test plugin"""
+from lektor.pluginsystem import Plugin
+
+
+class DummyPlugin(Plugin):
+    """Dummy test plugin."""
+
+    # pylint: disable=too-few-public-methods
+    name = "dummy"

--- a/tests/setup_py-dummy-plugin/setup.py
+++ b/tests/setup_py-dummy-plugin/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name="lektor-dummy-plugin",
+    description="setup.py test plugin",
+    version="0.1a42",
+    py_modules=["lektor_dummy_plugin"],
+    entry_points={
+        "lektor.plugins": [
+            "dummy-plugin = lektor_dummy_plugin:DummyPlugin",
+        ]
+    },
+)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from lektor.packages import add_site
+from lektor.packages import install_local_package
+from lektor.pluginsystem import load_plugins
+
+
+@pytest.mark.usefixtures("save_sys_path")
+def test_install_local_package(tmp_path):
+    package_root = os.fspath(tmp_path / "package_root")
+    dummy_plugin_path = os.fspath(Path(__file__).parent / "setup_py-dummy-plugin")
+    install_local_package(package_root, dummy_plugin_path)
+    add_site(package_root)
+    plugins = load_plugins()
+    assert plugins["dummy-plugin"].name == "dummy"


### PR DESCRIPTION
The most recent version of pip (23.1) removes support for the `--install-option` parameter to `pip install`.  This breaks our `install_local_package` function, which uses `--install-option` because `pip install --target` didn't used to work with `pip install --editable`.

As it turns out, recent versions of pip support the use of `--target` with `--editable`.  So here we make use of that.

Note that this also relieves us of the need to parse our local plugin requirements ourselves (thus, hopefully, fixing e.g. #865.)

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1127

### Related Issues / Links

This is a (more minimal) alternative to PR #1128.

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)
       We did not have a test that detects the breakage caused by the recent `pip` update. We now have one.


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
