### PR TITLE
CI: omit repeated slow tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ norecursedirs = ["venv", ".tox", ".git", "node_modules"]
 addopts = "--strict-markers"
 markers = [
     "requiresinternet: marks tests requiring an internet connection",
+    "slowtest: marks particularly slow tests that do not need to be run for every testenv variant",
 ]
 
 

--- a/tests/test_build_frontend.py
+++ b/tests/test_build_frontend.py
@@ -97,6 +97,7 @@ def test_initialize_aborts_if_no_source(frontend_build_hook, mocker):
 
 @pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")
 @pytest.mark.requiresinternet
+@pytest.mark.slowtest
 @pytest.mark.usefixtures("frontend_src")
 def test_initialize_builds_frontend(frontend_build_hook, tmp_root):
     frontend_build_hook.initialize("standard", build_data={})

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -34,6 +34,7 @@ def module(request):
     return request.param
 
 
+@pytest.mark.slowtest
 def test_import(module):
     python = sys.executable
     assert run([python, "-c", f"import {module}"], check=False).returncode == 0

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -54,6 +54,7 @@ def test_VirtualEnv_addsitedir(nested_venv: VirtualEnv) -> None:
 
 
 @pytest.mark.requiresinternet
+@pytest.mark.slowtest
 def test_VirtualEnv_run_pip_install(tmp_path: Path) -> None:
     # XXX: slow test
     venv = VirtualEnv(tmp_path)

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -197,6 +197,7 @@ class TestPlugin:
         assert dummy_plugin.path == str(Path(__file__).parent)
 
     @pytest.mark.requiresinternet
+    @pytest.mark.slowtest
     @pytest.mark.usefixtures("save_sys_path")
     def test_path_installed_plugin_is_none(self, scratch_project):
         # XXX: this test is slow and fragile. (It won't run

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -89,7 +89,7 @@ class WatcherTest:
                 # The FSEventObserver (used on macOS) seems to send events for things that
                 # happened before is was started.  Here, we wait a little bit for things to
                 # start, then discard any pre-existing events.
-                time.sleep(0.1)
+                time.sleep(0.2)
                 watcher.wait(blocking=False)
 
             yield self.watched_path

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ passenv = USERNAME
 setenv =
     # skip building frontend js/css
     HATCH_BUILD_NO_HOOKS=true
+    # do not run marked slow tests in every variant testenv
+    {mistune0,noutils,pytz,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
 deps =
     pytest>=6
     pytest-click

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ python =
 
 [testenv]
 commands =
-    coverage run -m pytest {posargs:tests -ra}
+    coverage run -m pytest {posargs:tests -ra --durations=20}
 passenv = USERNAME
 setenv =
     # skip building frontend js/css
@@ -63,7 +63,7 @@ download = true
 # break PATH in noutils environment(s).
 allowlist_externals = env
 commands =
-    env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra}
+    env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
 [testenv:lint]
 use_develop = true


### PR DESCRIPTION
There are a few of our pytest tests that are particularly slow (especially on the macOS and Windows runners).

We run several *testenvs* on each runner:
- `pyXX`: the default set of tests
- `pyXX-mistune0`: run with a `mistune<1.0` pin to test under mistune 0.x
- `pyXX-notuils`: discovery of external utilities (e.g. ffmpeg, git) via PATH disabled to test that things degrade gracefully when to utitilies are not available (currently only run on the python 3.11 runners)
- `pyXX-pytz`: run with `pytz` installed (currently only run on the python 3.11 runners)
- `pyXX-tzdata`: run with `tzdata` explicitly installed (currently only run on the python 3.11 runners)

The slow tests are slow because due to internet access, or spawning of new processes.  We don't really get any benefit by repeating them on all of the above testenv variants.

This PR adds a `slowtest` pytest marker and applies it to those particularly slow tests which may be safely skipped in the variant testenvs.  `Tox.ini` is adjusted so that those tests are skipped for all but the main `pyXX` testenvs.

This appears to speed the macOS job by a minute or more per testenv.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

CI tests are very slow

<!---
### Related Issues / Links


Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->
<!--
### Description of Changes
-->

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
