### PR TITLE
CI: Fix(?) for macos test runner hang

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,9 @@ deps =
     mistune0: mistune<2
     pytz: pytz
     tzdata: tzdata
+    # This pin is a heuristic fix for spurious hanging of our CI tests
+    # on macOS. For more notes, see https://github.com/lektor/lektor/pull/1132
+    coverage[toml]<7.0.2; sys_platform == "darwin"
 depends =
     py{37,38,39,310,311}{,-mistune0,-noutils}: cover-clean
     cover-report: py{37,38,39,310,311}{,-mistune0,-noutils}


### PR DESCRIPTION
Our CI tests have been hanging recently.

The `macos-latest py3.11`  job sometimes hangs during running of the `tox` tests.  When this happens, it gets stuck and just spins until the job is cancelled or times out (after three hours.)
This seems to have started somewhere around f8a4b3f82fb139242988178033e5c91bfeaa5def.

It seems to be getting stuck in the tests in `test_watcher.py` (or possibly in `test_videotools.py` — the last output in the logs when it get stuck is from test_videotools; test_watcher is the next test file).

I've been flailing on this for a few days now, changing parameters and seeing what triggers the hang.

Currently, all of the following seem to be required for the problem to occur:

- It only happens on the macOS runner
- It only happens under python 3.11 (but happens under any of 3.11.1, 3.11.2, or 3.11.3).

Furthermore, diagnosing the issue is hindered by the facts:

- If pytest is run with the `-v` (verbose) flag, it doesn't hang.
- If pytest is run with the `-s` (don't capture stdout/err) flag, it doesn't hang.
- If [pytest-timeout](https://pypi.org/project/pytest-timeout/) is used to impose a time-limit on each test (using either the *thread* or *signal* timeout method), it doesn't hang.

It also seems heuristically true that:

- If only one testenv is run during the tox run, it doesn't hang.  It always seems to hang during the run of the second testenv that includes the ffmpeg tests.
- If `ffmpeg` is not installed, it doesn't hang.
- If the tests in `test_videotools.py` are skipped, it doesn't hang.
- If the tests in `test_images.py` are skipped, it doesn't hang.
- If the one test `tests/test_watcher.py::TestBasicWatcher::test_creates_observer` is disabled, it doesn't hang.  (The other tests in `test_watcher.py` can be skipped, as long a `test_creates_observer` is still enabled, it hangs.)
- If the tests using `watchdog`'s *fsevents*-based native observer are skipped (testing only with `PollingObserver`) it doesn't hang.
- If the usage of `coverage` (to collect coverage data) is omitted, it doesn't hang.
- <del>If `coverage` is pinned to `<7.0.2`, it doesn't hang.</del> [Edit: okay, that's not true. It still hangs sometimes with `coverage<7.0.2`.]


At this point, I have a vague hunch that the issue has something to do with watchdog's fsevents observer. (This is the only bit of watchdog that uses an extension written in C, and it is only used on macOS.) 

But really, I have no idea.

Anyhow, as things stand, pinning `coverage` on macOS seems to "fix" the issue, at least for now.

So that's what this PR does.

<!--- Thanks for your help making Lektor better for everyone! --->
