### PR TITLE
Fix a couple of edge-case bugs in URL resolution

### DIFF
--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -129,6 +129,10 @@ class Directory(Asset):
             path += "/"
         return path
 
+    @property
+    def url_content_path(self):
+        return self.url_path
+
 
 class File(Asset):
     """Represents a static asset file."""

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -574,6 +574,17 @@ class Page(Record):
             return path.rstrip("/") + "/"
         return f"{path.rstrip('/')}/{pg.url_suffix.strip('/')}/{self.page_num:d}/"
 
+    @property
+    def url_content_path(self):
+        """URL path to the directory that contains children of this record."""
+        url_path = self.url_path
+        if url_path.endswith("/"):
+            return url_path
+        # See https://www.getlektor.com/docs/content/urls/#content-below-dotted-slugs
+        head, sep, tail = url_path.rpartition("/")
+        assert "." in tail
+        return f"{head}{sep}_{tail}/"
+
     def resolve_url_path(self, url_path):
         pg = self.datamodel.pagination_config
 

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -61,6 +61,18 @@ def _norm_join(a, b):
 
 
 def join_path(a, b):
+    """Join two DB-paths.
+
+    It is assumed that both paths are already normalized in that
+    neither contains an extra "." or ".." components, double-slashes,
+    etc.
+    """
+    # NB: This function is really only during URL resolution.  The only
+    # place that references it is lektor.source.SourceObject._resolve_url.
+
+    if posixpath.isabs(b):
+        return b
+
     a_p, a_v = split_virtual_path(a)
     b_p, b_v = split_virtual_path(b)
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -377,8 +377,35 @@ class DummyVirtualSource(VirtualSourceObject):
         ("/", "/path/virtual/", "../../"),
         ("/index.html", "/path/virtual/", "../../index.html"),
         ("rel", "/path/virtual/", "rel"),
+        ("rel", "/path/virtual.html", "_virtual.html/rel"),
     ],
 )
 def test_url_from_virtual(pad, path, url_path, expected):
     virtual = DummyVirtualSource(pad.get("/extra"), url_path)
     assert virtual.url_to(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("a", "_file.ext/a"),
+        ("/", "../"),
+        ("/projects", "../projects/"),
+    ],
+)
+def test_url_from_page_with_dotted_name(pad, path, expected):
+    record = pad.get("/extra/file.ext")
+    assert record.url_to(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("a", "a"),
+        ("/", "../"),
+        ("/projects", "../projects/"),
+    ],
+)
+def test_url_from_attachment(pad, path, expected):
+    record = pad.get("/extra/hello.txt")
+    assert record.url_to(path) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,32 +15,36 @@ from lektor.utils import slugify
 from lektor.utils import unique_everseen
 
 
-def test_join_path():
-
-    assert join_path("a", "b") == "a/b"
-    assert join_path("/a", "b") == "/a/b"
-    assert join_path("a@b", "c") == "a@b/c"
-    assert join_path("a@b", "") == "a@b"
-    assert join_path("a@b", "@c") == "a@c"
-    assert join_path("a@b/c", "a@b") == "a/a@b"
-
-    assert join_path("blog@archive", "2015") == "blog@archive/2015"
-    assert join_path("blog@archive/2015", "..") == "blog@archive"
-    assert join_path("blog@archive/2015", "@archive") == "blog@archive"
-    assert join_path("blog@archive", "..") == "blog"
-    assert join_path("blog@archive", ".") == "blog@archive"
-    assert join_path("blog@archive", "") == "blog@archive"
-
-    # special behavior: parent of pagination paths is always the actual
-    # page parent.
-    assert join_path("/blog@1", "..") == "/"
-    assert join_path("/blog@2", "..") == "/"
-
-    # But joins on the same level keep the path
-    assert join_path("/blog@1", ".") == "/blog@1"
-    assert join_path("/blog@2", ".") == "/blog@2"
-    assert join_path("/blog@1", "") == "/blog@1"
-    assert join_path("/blog@2", "") == "/blog@2"
+@pytest.mark.parametrize(
+    "head, tail, expected",
+    [
+        ("a", "b", "a/b"),
+        ("/a", "b", "/a/b"),
+        ("a@b", "c", "a@b/c"),
+        ("a@b", "", "a@b"),
+        ("a@b", "@c", "a@c"),
+        ("a@b/c", "a@b", "a/a@b"),
+        #
+        ("blog@archive", "2015", "blog@archive/2015"),
+        ("blog@archive/2015", "..", "blog@archive"),
+        ("blog@archive/2015", "@archive", "blog@archive"),
+        ("blog@archive", "..", "blog"),
+        ("blog@archive", ".", "blog@archive"),
+        ("blog@archive", "", "blog@archive"),
+        #
+        # special behavior: parent of pagination paths is always the actual
+        # page parent.
+        ("/blog@1", "..", "/"),
+        ("/blog@2", "..", "/"),
+        # But joins on the same level keep the path
+        ("/blog@1", ".", "/blog@1"),
+        ("/blog@2", ".", "/blog@2"),
+        ("/blog@1", "", "/blog@1"),
+        ("/blog@2", "", "/blog@2"),
+    ],
+)
+def test_join_path(head, tail, expected):
+    assert join_path(head, tail) == expected
 
 
 def test_is_path_child_of():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,12 @@ from lektor.utils import unique_everseen
         ("a@b", "@c", "a@c"),
         ("a@b/c", "a@b", "a/a@b"),
         #
+        ("/a", "/", "/"),
+        ("/a", "/b", "/b"),
+        ("a@b", "/", "/"),
+        ("a@b", "/c", "/c"),
+        ("a@b", "/c@d", "/c@d"),
+        #
         ("blog@archive", "2015", "blog@archive/2015"),
         ("blog@archive/2015", "..", "blog@archive"),
         ("blog@archive/2015", "@archive", "blog@archive"),


### PR DESCRIPTION
This fixes a couple of bugs (introduced, I think, in #992 or thereabouts).

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

#### DB-path Resolution of Relative Paths from VirtualSourceObjects

This has to do with how relative db-paths are interpreted from a VirtualSourceObject.
VirtualSourceObjects have *paths* like `/path/to/parent@virtual/path`, where `/path/to/parent` is the DB-path to the (non-virtual) parent record of the virtual object.

When interpreting a relative path, the path was joined with the virtual path.  That seems correct.
E.g. `/parent@virtual/bit` / `foo` ⇒  `/parent@virtual/bit/foo`.

However, when interpreting an absolute path, that absoluteness was being applied to the virtual path, not to the non-virtual part of the path. I.e. `/parent@virtual` / `/abs` ⇒ `/parent@/abs`.  That makes no sense.  (`/abs` is not even a valid virtual path.)
Worse yet, `/parent@virtual` / `/` ⇒ `/parent@/`.

So in this PR we fix things so that `/parent@virtual` / `/abs` ⇒ `/abs`.
  
#### Relative URL-path Resolution for Pages with "." in Their Slug

Usually, Lektor *Pages* have a URL path like `/pagename/`.  The actual HTML for the page gets written to `/pagename/index.html`.  When interpreting a relative URL path, say `pic.jpg` from the page, that relative path is just joined to the page's URL path: `/pagename/` / `pic.jpg` ⇒ `/pagename/pic.jpg`.

If the page's slug contains a *dot*, say `page.name`, things are different.  The URL page for the page is then `/page.name`, and the HTML for the page gets written directly to `/page.name`.  In that case, children of the page get written to a directory whose slug is the page slug prefixed with an underscore, e.g. in this case, `/_page.name/`.  (See [docs](https://www.getlektor.com/docs/content/urls/#content-below-dotted-slugs).)

In the dotted-slug case, we need to interpret relative URL paths relative to the underscored slug, not the page slug.  That wasn't happening.

##### The Edge-Cases have Edge-Cases

Okay, that doesn't really work for attachments and other record types which do not contain child records.  Since they never have children, there is never an underscore-prefixed directory.  So what to do?

In this PR, when interpreting relative URL paths from records that don't have children, we interpret the path relative to the parent of the URL path of the record.  E.g. for an attachment with a URL path of `/page/pic.jpg`, we will interpret relative URLS relative to a base of `/page/` — e.g. `/page/pic.jpg` / `file.txt` => `/page/file.txt`.

This *is* confusing, since it's different than how we handle relative URL paths for *pages* with dotted slugs, but, I don't think this is something that will come up very often.  (When does one compute URLs relative to an attachment?)  In any case, this PR also issues a warning when this case comes up.


### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
