### PR TITLE
Markdown backward compatibility improvements

### DIFF
--- a/lektor/markdown/mistune0.py
+++ b/lektor/markdown/mistune0.py
@@ -13,7 +13,7 @@ from lektor.sourceobj import SourceObject
 from lektor.utils import deprecated
 
 
-def _escape(text: str) -> str:
+def escape(text: str) -> str:
     return mistune.escape(text, quote=True)
 
 
@@ -36,14 +36,14 @@ class ImprovedRenderer(
     def link(self, link: str, title: Optional[str], text: str) -> str:
         url = self.lektor.resolve_url(link)
         if not title:
-            return f'<a href="{_escape(url)}">{text}</a>'
-        return f'<a href="{_escape(url)}" title="{_escape(title)}">{text}</a>'
+            return f'<a href="{escape(url)}">{text}</a>'
+        return f'<a href="{escape(url)}" title="{escape(title)}">{text}</a>'
 
     def image(self, src: str, title: Optional[str], text: str) -> str:
-        url = _escape(self.lektor.resolve_url(src))
+        url = escape(self.lektor.resolve_url(src))
         if not title:
-            return f'<img src="{url}" alt="{_escape(text)}">'
-        return f'<img src="{url}" alt="{_escape(text)}" title="{_escape(title)}">'
+            return f'<img src="{url}" alt="{escape(text)}">'
+        return f'<img src="{url}" alt="{escape(text)}" title="{escape(title)}">'
 
 
 class MarkdownConfig:

--- a/lektor/markdown/mistune2.py
+++ b/lektor/markdown/mistune2.py
@@ -11,7 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 
-import mistune  # type: ignore[import]
+import mistune.util
 
 from lektor.markdown.controller import MarkdownController
 from lektor.markdown.controller import RendererHelper
@@ -19,8 +19,21 @@ from lektor.markdown.controller import UnknownPluginError
 from lektor.utils import unique_everseen
 
 
+def escape(text: str) -> str:
+    # This is only here to provide the implementation for the
+    # deprecated lektor.markdown.escape method.
+    #
+    # (We don't use it below and it can be deleted once access
+    # to lektor.markdown.escape is removed.)
+    return mistune.util.escape(text, quote=True)
+
+
 class ImprovedRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
     lektor: ClassVar = RendererHelper()
+
+    # The deprecated .record and .meta attributes are not made available here, since old
+    # renderer mixins (written for Lektor<3.4 and mistune 0.x) are not going to work
+    # with mistune 2.x anyway.
 
     def link(
         self, link: str, text: Optional[str] = None, title: Optional[str] = None

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -5,6 +5,7 @@ from typing import Union
 import pytest
 from markupsafe import Markup
 
+import lektor.markdown
 from lektor.context import Context
 from lektor.markdown import controller_class
 from lektor.markdown import get_controller
@@ -224,25 +225,6 @@ def improved_renderer():
     return ImprovedRenderer()
 
 
-@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
-@pytest.mark.usefixtures("renderer_context")
-def test_ImprovedRenderer_record(record, improved_renderer):
-    with pytest.deprecated_call(
-        match=r"Use .*Renderer\.lektor.record instead"
-    ) as warnings:
-        assert improved_renderer.record is record
-    assert all(w.filename == __file__ for w in warnings)
-
-
-@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
-def test_ImprovedRenderer_meta(renderer_context, improved_renderer):
-    with pytest.deprecated_call(
-        match=r"Use .*Renderer\.lektor.meta instead"
-    ) as warnings:
-        assert improved_renderer.meta is renderer_context.meta
-    assert all(w.filename == __file__ for w in warnings)
-
-
 @pytest.mark.parametrize(
     "link, title, text, expected",
     [
@@ -289,21 +271,6 @@ def test_ImprovedRenderer_image(src, title, alt, expected, improved_renderer):
     else:
         result = improved_renderer.image(src, title, alt)
     assert re.match(expected, result.rstrip())
-
-
-def test_make_markdown(env):
-    with pytest.deprecated_call() as warnings:
-        md = make_markdown(env)
-    assert all(w.filename == __file__ for w in warnings)
-    assert md("foo").strip() == "<p>foo</p>"
-
-
-@pytest.mark.usefixtures("context")
-def test_markdown_to_html(record, field_options):
-    with pytest.deprecated_call() as warnings:
-        result = markdown_to_html("goober", record, field_options)
-    assert all(w.filename == __file__ for w in warnings)
-    assert result.html.rstrip() == "<p>goober</p>"
 
 
 def plugin_linkcount(md):
@@ -496,3 +463,98 @@ def test_field_options_integration(record, field_options):
     two_links = "[one](x.html), [two](y.html)"
     markdown = Markdown(two_links, record, field_options)
     assert markdown.meta["nlinks"] == 22
+
+
+################################################################
+#
+# Tests for the bits that are provided for backward compatibility
+# with plugins written for Lektor < 3.4.
+#
+def test_deprecated_ImprovedRenderer(improved_renderer):
+    with pytest.deprecated_call(
+        match=r"lektor\.markdown\.ImprovedRenderer\b.* deprecated"
+    ) as warnings:
+        # pylint: disable-next=import-outside-toplevel,no-name-in-module
+        from lektor.markdown import ImprovedRenderer
+    assert all(w.filename == __file__ for w in warnings)
+    assert ImprovedRenderer is type(improved_renderer)
+
+
+@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+@pytest.mark.usefixtures("renderer_context")
+def test_deprecated_ImprovedRenderer_record(record):
+    with pytest.deprecated_call():
+        # pylint: disable-next=import-outside-toplevel,no-name-in-module
+        from lektor.markdown import ImprovedRenderer
+    improved_renderer = ImprovedRenderer()
+
+    with pytest.deprecated_call(
+        match=r"Use .*Renderer\.lektor\.record instead"
+    ) as warnings:
+        assert improved_renderer.record is record
+    assert all(w.filename == __file__ for w in warnings)
+
+
+@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+def test_deprecated_ImprovedRenderer_meta(renderer_context):
+    with pytest.deprecated_call():
+        # pylint: disable-next=import-outside-toplevel,no-name-in-module
+        from lektor.markdown import ImprovedRenderer
+    improved_renderer = ImprovedRenderer()
+
+    with pytest.deprecated_call(
+        match=r"Use .*Renderer\.lektor\.meta instead"
+    ) as warnings:
+        assert improved_renderer.meta is renderer_context.meta
+    assert all(w.filename == __file__ for w in warnings)
+
+
+def test_deprecated_MarkdownConfig(improved_renderer):
+    with pytest.deprecated_call(
+        match=r"lektor\.markdown\.MarkdownConfig\b.* deprecated"
+    ) as warnings:
+        config = lektor.markdown.MarkdownConfig()
+    assert all(w.filename == __file__ for w in warnings)
+    assert config.renderer_base is type(improved_renderer)
+
+
+def test_deprecated_escape(improved_renderer):
+    with pytest.deprecated_call(
+        match=r"lektor\.markdown\.escape\b.* deprecated"
+    ) as warnings:
+        assert lektor.markdown.escape("<") == "&lt;"
+    assert all(w.filename == __file__ for w in warnings)
+
+
+def test_getattr_raises():
+    with pytest.raises(AttributeError, match="no attribute 'goober'"):
+        lektor.markdown.goober  # pylint: disable=pointless-statement
+
+
+def test_dir():
+    expected = {
+        "MISTUNE_VERSION",
+        "Markdown",
+        "get_controller",
+        "escape",
+        "ImprovedRenderer",
+        "MarkdownConfig",
+        "make_markdown",
+        "markdown_to_html",
+    }
+    assert expected.issubset(dir(lektor.markdown))
+
+
+def test_deprecated_make_markdown(env):
+    with pytest.deprecated_call() as warnings:
+        md = make_markdown(env)
+    assert all(w.filename == __file__ for w in warnings)
+    assert md("foo").strip() == "<p>foo</p>"
+
+
+@pytest.mark.usefixtures("context")
+def test_deprecated_markdown_to_html(record, field_options):
+    with pytest.deprecated_call() as warnings:
+        result = markdown_to_html("goober", record, field_options)
+    assert all(w.filename == __file__ for w in warnings)
+    assert result.html.rstrip() == "<p>goober</p>"


### PR DESCRIPTION
This PR makes `lektor.markdown.ImprovedRenderer` (along with `escape` and `MarkdownConfig`) available once again.

These were removed in #992 in the changes made to support running with either mistune 0.x or mistune 2.x.

With this PR, those items are back (though their use will elicit an DeprecationWarning).

The hope is that markdown-customizing plugins that were written for Lektor<3.4 will continue to work (so long as mistune is pinned to 0.x — getting old plugins to work without modification under mistune 2.x is a whole different kettle of fish, since mistune fairly completely change the call signatures of the important renderer methods between versions.)

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->



### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
