### PR TITLE
refactor: Disuse `watchdog` in favor of `watchfiles`.

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -130,27 +130,7 @@ def build_cmd(
 
     env = ctx.get_env()
 
-    def _build():
-        builder = Builder(
-            env.new_pad(),
-            output_path,
-            buildstate_path=buildstate_path,
-            extra_flags=extra_flags,
-        )
-        if source_info_only:
-            builder.update_all_source_infos()
-            return True
-
-        if profile:
-            failures = profile_func(builder.build_all)
-        else:
-            failures = builder.build_all()
-        if prune:
-            builder.prune()
-        return failures == 0
-
-    reporter = CliReporter(env, verbosity=verbosity)
-    with reporter:
+    with CliReporter(env, verbosity=verbosity):
         builds = ["first"]
         if watch:
             from lektor.watcher import watch_project
@@ -162,7 +142,24 @@ def build_cmd(
 
         success = False
         for _ in builds:
-            success = _build()
+            builder = Builder(
+                env.new_pad(),
+                output_path,
+                buildstate_path=buildstate_path,
+                extra_flags=extra_flags,
+            )
+            if source_info_only:
+                builder.update_all_source_infos()
+                success = True
+            else:
+                if profile:
+                    failures = profile_func(builder.build_all)
+                else:
+                    failures = builder.build_all()
+                if prune:
+                    builder.prune()
+                success = failures == 0
+
         return sys.exit(0 if success else 1)
 
 

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -47,7 +47,8 @@ class BackgroundBuilder(threading.Thread):
         builds = chain(["first"], watch_project(self.env, self.output_path))
         with CliReporter(self.env, verbosity=self.verbosity):
             for n, _ in enumerate(builds):
-                self.build(update_source_info_first=n == 0)
+                is_first_build = n == 0
+                self.build(update_source_info_first=is_first_build)
 
 
 def browse_to_address(addr):

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -1,169 +1,43 @@
 from __future__ import annotations
 
 import os
-import threading
-from collections import OrderedDict
-from dataclasses import dataclass
-from itertools import zip_longest
-from typing import Callable
+from pathlib import Path
+from typing import Any
+from typing import Generator
+from typing import TYPE_CHECKING
 
-import click
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
-from watchdog.observers.api import DEFAULT_OBSERVER_TIMEOUT
-from watchdog.observers.polling import PollingObserver
+import watchfiles
 
 from lektor.utils import get_cache_dir
 
-
-@dataclass(frozen=True)
-class EventHandler(FileSystemEventHandler):
-    notify: Callable[[str], None]
-
-    def __post_init__(self):
-        super().__init__()
-
-    # Generally we only care about changes (modification, creation, deletion) to files
-    # within the monitored tree. Changes in directories do not directly affect Lektor
-    # output. So, in general, we ignore directory events.
-    #
-    # However, the "efficient" (i.e. non-polling) observers do not seem to generate
-    # events for files contained in directories that are moved out of the watched tree.
-    # The only events generated in that case are for the directory — generally a
-    # DirDeletedEvent is generated — so we can't ignore those.
-    #
-    # (Moving/renaming a directory does not seem to reliably generate a DirMovedEvent,
-    # but we might as well track those, too.)
-
-    def on_created(self, event):
-        if not event.is_directory:
-            self.notify(event.src_path)
-
-    def on_deleted(self, event):
-        self.notify(event.src_path)
-
-    def on_modified(self, event):
-        if not event.is_directory:
-            self.notify(event.src_path)
-
-    def on_moved(self, event):
-        self.notify(event.src_path)
-        self.notify(event.dest_path)
+if TYPE_CHECKING:
+    from lektor.environment import Environment
 
 
-def _fullname(cls):
-    """Return the full name of a class (including the module name)."""
-    return f"{cls.__module__}.{cls.__qualname__}"
+def watch_project(
+    env: Environment, output_path: str | Path, **kwargs: Any
+) -> Generator[[watchfiles.Change, str], None, None]:
+    """Watch project source files for changes.
+
+    Returns an generator that yields sets of changes as they are noticed.
+
+    Changes to files within ``output_path`` are ignored, along with other files
+    deemed not to be Lektor source files.
+
+    """
+    watch_paths = [env.root_path, *env.theme_paths]
+    ignore_paths = [os.path.abspath(p) for p in (get_cache_dir(), output_path)]
+    watch_filter = WatchFilter(env, ignore_paths=ignore_paths)
+
+    return watchfiles.watch(*watch_paths, watch_filter=watch_filter, **kwargs)
 
 
-def _unique_everseen(seq):
-    """Return the unique elements in sequence, preserving order."""
-    return OrderedDict.fromkeys(seq).keys()
-
-
-class BasicWatcher:
-    def __init__(
-        self,
-        paths,
-        observer_classes=(Observer, PollingObserver),
-        observer_timeout=DEFAULT_OBSERVER_TIMEOUT,  # testing
-    ):
-        self.paths = paths
-        self.observer_classes = observer_classes
-        self.observer_timeout = observer_timeout
-        self.observer = None
-        self.semaphore = threading.BoundedSemaphore(1)
-        # pylint: disable=consider-using-with
-        assert self.semaphore.acquire(blocking=False)
-
-    def start(self):
-        # Remove duplicates since there is no point in trying a given
-        # observer class more than once. (This also simplifies the logic
-        # for presenting sensible warning messages about broken
-        # observers.)
-        observer_classes = list(_unique_everseen(self.observer_classes))
-        for observer_class, next_observer_class in zip_longest(
-            observer_classes, observer_classes[1:]
-        ):
-            try:
-                self._start_observer(observer_class)
-                return
-            except Exception as exc:
-                if next_observer_class is None:
-                    raise
-                click.secho(
-                    f"Creation of {_fullname(observer_class)} failed with exception:\n"
-                    f"  {exc.__class__.__name__}: {exc!s}\n"
-                    "This may be due to a configuration or other issue with your system.\n"
-                    f"Falling back to {_fullname(next_observer_class)}.",
-                    fg="red",
-                    bold=True,
-                )
-
-    def stop(self):
-        self.observer.stop()
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, ex_type, ex_value, ex_tb):
-        self.stop()
-
-    def _start_observer(self, observer_class=Observer):
-        if self.observer is not None:
-            raise RuntimeError("Watcher already started.")
-        observer = observer_class(timeout=self.observer_timeout)
-        event_handler = EventHandler(self._notify)
-        for path in self.paths:
-            observer.schedule(event_handler, path, recursive=True)
-        observer.daemon = True
-        observer.start()
-        self.observer = observer
-
-    def is_interesting(self, path: str) -> bool:
-        # pylint: disable=no-self-use
-        return True
-
-    def _notify(self, path):
-        """Called by EventHandler when file change event is received."""
-        # pylint: disable=consider-using-with
-        if self.semaphore.acquire(blocking=False):
-            # was set (unread change pending): just put it back
-            self.semaphore.release()
-        elif self.is_interesting(path):
-            # was not set, but got an change event, set it
-            self.semaphore.release()
-
-    def wait(self, blocking: bool = True, timeout: float | None = None):
-        """Wait for watched filesystem change.
-
-        This waits for a “new” non-ignored filesystem change.  Here “new” means that
-        the change happened since the last return from ``wait``.
-
-        Waits a maximum of ``timeout`` seconds (or forever if ``timeout`` is ``None``).
-
-        Returns ``True`` if a change occurred, ``False`` on timeout.
-        """
-        return self.semaphore.acquire(blocking, timeout)
-
-
-class Watcher(BasicWatcher):
-    def __init__(self, env, output_path=None):
-        BasicWatcher.__init__(self, paths=[env.root_path] + env.theme_paths)
+class WatchFilter(watchfiles.DefaultFilter):
+    def __init__(self, env: Environment, **kwargs: Any):
+        super().__init__(**kwargs)
         self.env = env
-        self.output_path = output_path
-        self.cache_dir = os.path.abspath(get_cache_dir())
 
-    def is_interesting(self, path: str) -> bool:
-        path = os.path.abspath(path)
-
+    def __call__(self, change: watchfiles.Change, path: str) -> bool:
         if self.env.is_uninteresting_source_name(os.path.basename(path)):
             return False
-        if path.startswith(self.cache_dir):
-            return False
-        if self.output_path is not None and path.startswith(
-            os.path.abspath(self.output_path)
-        ):
-            return False
-        return True
+        return super().__call__(change, path)

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -25,7 +25,7 @@ def watch_project(
     deemed not to be Lektor source files.
 
     """
-    watch_paths = [env.root_path, *env.theme_paths]
+    watch_paths = [env.root_path, env.project.project_file, *env.theme_paths]
     ignore_paths = [os.path.abspath(p) for p in (get_cache_dir(), output_path)]
     watch_filter = WatchFilter(env, ignore_paths=ignore_paths)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "pytz; python_version<'3.9'",  # favor zoneinfo for python>=3.9
     "requests",
     "tzdata; python_version>='3.9' and sys_platform == 'win32'",
-    "watchdog",
+    "watchfiles",
     "Werkzeug>=2.1.0,<3",
 ]
 optional-dependencies.ipython = [

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import threading
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 from typing import Generator
 
 import pytest
@@ -17,21 +20,68 @@ from lektor.watcher import watch_project
 from lektor.watcher import WatchFilter
 
 
+RunInThread = Callable[[Callable[[], None]], None]
+
+
+@pytest.fixture
+def run_in_thread() -> RunInThread:
+    threads = []
+
+    def run_thread(target: Callable[[], None]) -> None:
+        t = threading.Thread(target=target)
+        t.start()
+        threads.append(t)
+
+    try:
+        yield run_thread
+    finally:
+        for t in threads:
+            t.join(10.0)
+        for t in threads:
+            assert not t.is_alive()
+
+
+@dataclass
+class WatchResult:
+    change_seen: bool = False
+
+    def __bool__(self):
+        return self.change_seen
+
+
 @dataclass
 class WatcherTest:
     env: Environment
-
-    @property
-    def watched_path(self) -> Path:
-        return Path(self.env.root_path)
+    run_in_thread: RunInThread
 
     @contextmanager
     def __call__(
         self,
-        should_set_event: bool = True,
         timeout: float = 1.2,
-    ) -> Generator[Path, None, None]:
+    ) -> Generator[WatchResult, None, None]:
+        """Run watch_project in a separate thread, wait for a file change event.
 
+        This is a context manager that runs watch_project in a separate thread.
+        After the context exits, it will wait at most ``timeout`` seconds before returning.
+        If a file system change is seen, it will return immediately.
+
+        The context manager returns a WatchResult value.  After the context has been
+        exited, the result will be True-ish if a file system change was noticed,
+        False-ish otherwise.
+
+        """
+        if sys.platform == "darwin":
+            self.macos_pause_for_calm()
+
+        with self.watch(timeout) as change_seen:
+            yield change_seen
+
+    @contextmanager
+    def watch(
+        self,
+        timeout: float,
+    ) -> Generator[WatchResult, None, None]:
+        """Run watch_project in a separate thread, wait for a file change event."""
         running = threading.Event()
         stop = threading.Event()
         changed = threading.Event()
@@ -45,114 +95,140 @@ class WatcherTest:
                 changed.set()
                 return
 
-        t = threading.Thread(target=run)
-        t.start()
+        self.run_in_thread(run)
+        result = WatchResult()
         running.wait()
         try:
-            yield self.watched_path
-            changed.wait(timeout)
+            yield result
+            result.change_seen = changed.wait(timeout)
         finally:
             stop.set()
-            t.join()
 
-        if should_set_event:
-            assert changed.is_set()
-        else:
-            assert not changed.is_set()
+    def macos_pause_for_calm(self) -> None:
+        # Wait a bit for the dust to settle.
+        # For whatever reason, on macOS, the watcher sometimes seems to return
+        # filesystem events that happened shortly before it was started.
+        for n in range(5):
+            with self.watch(timeout=0.1) as change_seen:
+                pass
+            if not change_seen:
+                break
+            warnings.warn(f"macOS settle loop {n}: {change_seen}")
 
 
 @pytest.fixture
-def watcher_test(scratch_env: Environment) -> WatcherTest:
-    return WatcherTest(scratch_env)
+def watcher_test(scratch_env: Environment, run_in_thread: RunInThread) -> WatcherTest:
+    return WatcherTest(scratch_env, run_in_thread)
+
+
+@pytest.fixture
+def watched_path(scratch_env: Environment) -> Path:
+    return Path(scratch_env.root_path)
 
 
 def test_watcher_test(watcher_test: WatcherTest) -> None:
-    with watcher_test(should_set_event=False, timeout=0.2):
+    with watcher_test(timeout=0.2) as change_seen:
         pass
+    assert not change_seen
 
 
-def test_sees_created_file(watcher_test: WatcherTest) -> None:
-    with watcher_test() as watched_path:
-        watched_path.joinpath("created").touch()
+def test_sees_created_file(watcher_test: WatcherTest, watched_path: Path) -> None:
+    with watcher_test() as change_seen:
+        Path(watched_path, "created").touch()
+    assert change_seen
 
 
-def test_sees_deleted_file(watcher_test: WatcherTest) -> None:
-    deleted_path = watcher_test.watched_path / "deleted"
+def test_sees_deleted_file(watcher_test: WatcherTest, watched_path: Path) -> None:
+    deleted_path = watched_path / "deleted"
     deleted_path.touch()
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         deleted_path.unlink()
+    assert change_seen
 
 
-def test_sees_modified_file(watcher_test: WatcherTest) -> None:
-    modified_path = watcher_test.watched_path / "modified"
+def test_sees_modified_file(watcher_test: WatcherTest, watched_path: Path) -> None:
+    modified_path = watched_path / "modified"
     modified_path.touch()
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         with modified_path.open("a") as fp:
             fp.write("addition")
+    assert change_seen
 
 
-def test_sees_file_moved_in(watcher_test: WatcherTest, tmp_path: Path) -> None:
+def test_sees_file_moved_in(
+    watcher_test: WatcherTest, watched_path: Path, tmp_path: Path
+) -> None:
     orig_path = tmp_path / "orig_path"
     orig_path.touch()
-    final_path = watcher_test.watched_path / "final_path"
+    final_path = watched_path / "final_path"
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         orig_path.rename(final_path)
+    assert change_seen
 
 
-def test_sees_file_moved_out(watcher_test: WatcherTest, tmp_path: Path) -> None:
-    orig_path = watcher_test.watched_path / "orig_path"
+def test_sees_file_moved_out(
+    watcher_test: WatcherTest, watched_path: Path, tmp_path: Path
+) -> None:
+    orig_path = watched_path / "orig_path"
     orig_path.touch()
     final_path = tmp_path / "final_path"
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         orig_path.rename(final_path)
+    assert change_seen
 
 
-def test_sees_deleted_directory(watcher_test: WatcherTest) -> None:
+def test_sees_deleted_directory(watcher_test: WatcherTest, watched_path: Path) -> None:
     # We only really care about deleted directories that contain at least a file.
-    deleted_path = watcher_test.watched_path / "deleted"
+    deleted_path = watched_path / "deleted"
     deleted_path.mkdir()
     watched_file = deleted_path / "file"
     watched_file.touch()
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         shutil.rmtree(deleted_path)
+    assert change_seen
 
 
 def test_sees_file_in_directory_moved_in(
-    watcher_test: WatcherTest, tmp_path: Path
+    watcher_test: WatcherTest, watched_path: Path, tmp_path: Path
 ) -> None:
     # We only really care about directories that contain at least a file.
     orig_dir_path = tmp_path / "orig_dir_path"
     orig_dir_path.mkdir()
     Path(orig_dir_path, "file").touch()
-    final_dir_path = watcher_test.watched_path / "final_dir_path"
+    final_dir_path = watched_path / "final_dir_path"
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         orig_dir_path.rename(final_dir_path)
+    assert change_seen
 
 
-def test_sees_directory_moved_out(watcher_test: WatcherTest, tmp_path: Path) -> None:
+def test_sees_directory_moved_out(
+    watcher_test: WatcherTest, watched_path: Path, tmp_path: Path
+) -> None:
     # We only really care about directories that contain at least one file.
-    orig_dir_path = watcher_test.watched_path / "orig_dir_path"
+    orig_dir_path = watched_path / "orig_dir_path"
     orig_dir_path.mkdir()
     Path(orig_dir_path, "file").touch()
     final_dir_path = tmp_path / "final_dir_path"
 
-    with watcher_test():
+    with watcher_test() as change_seen:
         orig_dir_path.rename(final_dir_path)
+    assert change_seen
 
 
-def test_ignores_opened_file(watcher_test: WatcherTest) -> None:
-    file_path = watcher_test.watched_path / "file"
+def test_ignores_opened_file(watcher_test: WatcherTest, watched_path: Path) -> None:
+    file_path = watched_path / "file"
     file_path.touch()
 
-    with watcher_test(should_set_event=False):
+    with watcher_test() as change_seen:
         with file_path.open() as fp:
             fp.read()
+    assert not change_seen
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -2,119 +2,68 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
-import time
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 from typing import Generator
-from typing import Type
 
-import py
 import pytest
-from watchdog.observers.api import BaseObserver
-from watchdog.observers.polling import PollingObserver
+from watchfiles import Change
 
-from lektor import utils
-from lektor.watcher import BasicWatcher
-from lektor.watcher import Watcher
-
-
-class BrokenObserver(PollingObserver):
-    # The InotifyObserver, when it fails due to insufficient system
-    # inotify resources, does not fail until an attempt is made to start it.
-    def start(self):
-        raise OSError("crapout")
-
-
-class TestBasicWatcher:
-    # pylint: disable=no-self-use
-
-    @pytest.fixture
-    def paths(self, tmp_path):
-        return [str(tmp_path)]
-
-    def test_creates_observer(self, paths):
-        with BasicWatcher(paths) as watcher:
-            assert isinstance(watcher.observer, BaseObserver)
-
-    def test_default_observer_broken(self, paths, capsys):
-        observer_classes = (BrokenObserver, PollingObserver)
-        with BasicWatcher(paths, observer_classes=observer_classes) as watcher:
-            assert watcher.observer.__class__ is PollingObserver
-        assert "crapout" in capsys.readouterr().out
-
-    def test_default_observer_is_polling(self, paths, capsys):
-        observer_classes = (BrokenObserver, BrokenObserver)
-        with pytest.raises(OSError, match=r"crapout"):
-            with BasicWatcher(paths, observer_classes=observer_classes):
-                pass
-        assert capsys.readouterr() == ("", "")
-
-    def test_perverse_usage(self, paths):
-        # This exercises a bug which occurred when BasicWatcher was
-        # called with repeated (failing) values in observer_classes.
-        observer_classes = (BrokenObserver, BrokenObserver, PollingObserver)
-        with BasicWatcher(paths, observer_classes=observer_classes) as watcher:
-            assert isinstance(watcher.observer, BaseObserver)
-
-    def test_raises_error_if_started_twice(self, paths):
-        with BasicWatcher(paths) as watcher:
-            with pytest.raises(RuntimeError, match="already started"):
-                watcher.start()
+from lektor.environment import Environment
+from lektor.project import Project
+from lektor.watcher import watch_project
+from lektor.watcher import WatchFilter
 
 
 @dataclass
 class WatcherTest:
-    watched_path: Path
+    env: Environment
+
+    @property
+    def watched_path(self) -> Path:
+        return Path(self.env.root_path)
 
     @contextmanager
     def __call__(
         self,
-        observer_class: Type[BaseObserver] | None = None,
         should_set_event: bool = True,
         timeout: float = 1.2,
     ) -> Generator[Path, None, None]:
 
-        kwargs: dict[str, Any] = {}
-        if observer_class is not None:
-            kwargs.update(
-                observer_classes=(observer_class,),
-                observer_timeout=0.1,  # fast polling timer to speed tests
+        running = threading.Event()
+        stop = threading.Event()
+        changed = threading.Event()
+
+        def run() -> None:
+            watcher = watch_project(
+                self.env, "non-existant-output-path", stop_event=stop
             )
+            running.set()
+            for _ in watcher:
+                changed.set()
+                return
 
-        with BasicWatcher([os.fspath(self.watched_path)], **kwargs) as watcher:
-            if sys.platform == "darwin":
-                # The FSEventObserver (used on macOS) seems to send events for things that
-                # happened before is was started.  Here, we wait a little bit for things to
-                # start, then discard any pre-existing events.
-                time.sleep(0.2)
-                watcher.wait(blocking=False)
-
+        t = threading.Thread(target=run)
+        t.start()
+        running.wait()
+        try:
             yield self.watched_path
+            changed.wait(timeout)
+        finally:
+            stop.set()
+            t.join()
 
-            if should_set_event:
-                assert watcher.wait(timeout=timeout)
-            else:
-                assert not watcher.wait(timeout=timeout)
-
-
-@pytest.fixture(
-    params=[
-        pytest.param(None, id="default observer"),
-        PollingObserver,
-    ]
-)
-def observer_class(request: pytest.FixtureRequest) -> bool:
-    return request.param
+        if should_set_event:
+            assert changed.is_set()
+        else:
+            assert not changed.is_set()
 
 
 @pytest.fixture
-def watcher_test(tmp_path: Path) -> WatcherTest:
-    watched_path = tmp_path / "watched_path"
-    watched_path.mkdir()
-    return WatcherTest(watched_path)
+def watcher_test(scratch_env: Environment) -> WatcherTest:
+    return WatcherTest(scratch_env)
 
 
 def test_watcher_test(watcher_test: WatcherTest) -> None:
@@ -122,71 +71,59 @@ def test_watcher_test(watcher_test: WatcherTest) -> None:
         pass
 
 
-def test_BasicWatcher_sees_created_file(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None
-) -> None:
-    with watcher_test(observer_class=observer_class) as watched_path:
-        Path(watched_path, "created").touch()
+def test_sees_created_file(watcher_test: WatcherTest) -> None:
+    with watcher_test() as watched_path:
+        watched_path.joinpath("created").touch()
 
 
-def test_BasicWatcher_sees_deleted_file(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None
-) -> None:
+def test_sees_deleted_file(watcher_test: WatcherTest) -> None:
     deleted_path = watcher_test.watched_path / "deleted"
     deleted_path.touch()
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         deleted_path.unlink()
 
 
-def test_BasicWatcher_sees_modified_file(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None
-) -> None:
+def test_sees_modified_file(watcher_test: WatcherTest) -> None:
     modified_path = watcher_test.watched_path / "modified"
     modified_path.touch()
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         with modified_path.open("a") as fp:
             fp.write("addition")
 
 
-def test_BasicWatcher_sees_file_moved_in(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None, tmp_path: Path
-) -> None:
+def test_sees_file_moved_in(watcher_test: WatcherTest, tmp_path: Path) -> None:
     orig_path = tmp_path / "orig_path"
     orig_path.touch()
     final_path = watcher_test.watched_path / "final_path"
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         orig_path.rename(final_path)
 
 
-def test_BasicWatcher_sees_file_moved_out(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None, tmp_path: Path
-) -> None:
+def test_sees_file_moved_out(watcher_test: WatcherTest, tmp_path: Path) -> None:
     orig_path = watcher_test.watched_path / "orig_path"
     orig_path.touch()
     final_path = tmp_path / "final_path"
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         orig_path.rename(final_path)
 
 
-def test_BasicWatcher_sees_deleted_directory(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None
-) -> None:
+def test_sees_deleted_directory(watcher_test: WatcherTest) -> None:
     # We only really care about deleted directories that contain at least a file.
     deleted_path = watcher_test.watched_path / "deleted"
     deleted_path.mkdir()
     watched_file = deleted_path / "file"
     watched_file.touch()
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         shutil.rmtree(deleted_path)
 
 
-def test_BasicWatcher_sees_file_in_directory_moved_in(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None, tmp_path: Path
+def test_sees_file_in_directory_moved_in(
+    watcher_test: WatcherTest, tmp_path: Path
 ) -> None:
     # We only really care about directories that contain at least a file.
     orig_dir_path = tmp_path / "orig_dir_path"
@@ -194,24 +131,22 @@ def test_BasicWatcher_sees_file_in_directory_moved_in(
     Path(orig_dir_path, "file").touch()
     final_dir_path = watcher_test.watched_path / "final_dir_path"
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         orig_dir_path.rename(final_dir_path)
 
 
-def test_BasicWatcher_sees_directory_moved_out(
-    watcher_test: WatcherTest, observer_class: Type[BaseObserver] | None, tmp_path: Path
-) -> None:
+def test_sees_directory_moved_out(watcher_test: WatcherTest, tmp_path: Path) -> None:
     # We only really care about directories that contain at least one file.
     orig_dir_path = watcher_test.watched_path / "orig_dir_path"
     orig_dir_path.mkdir()
     Path(orig_dir_path, "file").touch()
     final_dir_path = tmp_path / "final_dir_path"
 
-    with watcher_test(observer_class=observer_class):
+    with watcher_test():
         orig_dir_path.rename(final_dir_path)
 
 
-def test_BasicWatcher_ignores_opened_file(watcher_test: WatcherTest) -> None:
+def test_ignores_opened_file(watcher_test: WatcherTest) -> None:
     file_path = watcher_test.watched_path / "file"
     file_path.touch()
 
@@ -220,18 +155,15 @@ def test_BasicWatcher_ignores_opened_file(watcher_test: WatcherTest) -> None:
             fp.read()
 
 
-def test_is_interesting(env):
-    # pylint: disable=no-member
-    cache_dir = py.path.local(utils.get_cache_dir())
-    build_dir = py.path.local("build")
+@pytest.fixture(scope="session")
+def watch_filter(project: Project) -> WatchFilter:
+    env = Environment(project, load_plugins=False)
+    return WatchFilter(env)
 
-    w = Watcher(env, str(build_dir))
-    is_interesting = w.is_interesting
 
-    assert is_interesting("a.file")
-    assert not is_interesting(".file")
-    assert not is_interesting(str(cache_dir / "another.file"))
-    assert not is_interesting(str(build_dir / "output.file"))
-
-    w.output_path = None
-    assert is_interesting(str(build_dir / "output.file"))
+@pytest.mark.parametrize("path", [".dotfile", "webpack/node_modules"])
+def test_WatchFilter_false(
+    watch_filter: WatchFilter, path: str, project: Project
+) -> None:
+    abspath = os.path.abspath(os.path.join(project.tree, path))
+    assert not watch_filter(Change.added, abspath)


### PR DESCRIPTION
[Watchfiles](https://github.com/samuelcolvin/watchfiles) has a much cleaner API.
It has a (Rust-based) extension module, but wheels are distributed for a [wide variety](https://pypi.org/project/watchfiles/#files) of targets.

Also, it's a flail, but I hope it might help with the hanging CI tests (see #1132) on macOS (which seem to be related to watchdog.)


<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

It simplifies our code quite a bit.

It might fix the CI test hangage on macOS.

Fixes #550
Fixes #1116

### Related Issues / Links

#1132 
#861

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
