### PR TITLE
refactor!: remove the --profile option from the build command

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -15,7 +15,6 @@ from lektor.cli_utils import ResolvedPath
 from lektor.cli_utils import validate_language
 from lektor.compat import importlib_metadata as metadata
 from lektor.project import Project
-from lektor.utils import profile_func
 from lektor.utils import secure_url
 
 
@@ -90,7 +89,6 @@ def cli(ctx, project=None, language=None):
     "`.lektor` inside the output path.",
 )
 @extraflag
-@click.option("--profile", is_flag=True, help="Enable build profiler.")
 @pass_context
 def build_cmd(
     ctx,
@@ -100,7 +98,6 @@ def build_cmd(
     verbosity,
     source_info_only,
     buildstate_path,
-    profile,
     extra_flags,
 ):
     """Builds the entire project into the final artifacts.
@@ -152,10 +149,7 @@ def build_cmd(
                 builder.update_all_source_infos()
                 success = True
             else:
-                if profile:
-                    failures = profile_func(builder.build_all)
-                else:
-                    failures = builder.build_all()
+                failures = builder.build_all()
                 if prune:
                     builder.prune()
                 success = failures == 0

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -664,24 +664,6 @@ def get_relative_path(source, target):
     raise AssertionError("This should not happen")
 
 
-def profile_func(func):
-    # pylint: disable=import-outside-toplevel
-
-    from cProfile import Profile
-    from pstats import Stats
-
-    p = Profile()
-    rv = []
-    p.runcall(lambda: rv.append(func()))
-    p.dump_stats("/tmp/lektor-%s.prof" % func.__name__)
-
-    stats = Stats(p, stream=sys.stderr)
-    stats.sort_stats("time", "calls")
-    stats.print_stats()
-
-    return rv[0]
-
-
 def deg_to_dms(deg):
     d = int(deg)
     md = abs(deg - d) * 60


### PR DESCRIPTION
Running `lektor build --profile` just runs `Builder.build_all` under `cProfile`, then prints the stats.

The profile information is only really interesting to Lektor developers.  Lektor can be profiled directly like this:

    python -m cProfile -o prof.out -m lektor build
    python -m pstats prof.out

