### PR TITLE
Refactor: Name thumbnail files based on final thumbnail parameters

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -116,7 +116,7 @@ def mock_build_context(mocker, pad):
 def test_url_to_thumbnail(pad, mock_build_context):
     extra_de = pad.get("/extra", alt="de")
     thumbnail = pad.get("/test.jpg").thumbnail(42)
-    assert extra_de.url_to(thumbnail) == "../../test@42.jpg"
+    assert extra_de.url_to(thumbnail) == "../../test@42x56.jpg"
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously, thumbnail artifact names were generated by adding suffix that serializes the parameters passed to `make_image_thumbnail`.

Especially when using "fit" mode, there are many different sets of parameters to `make_image_thumbnail` that can generate the same thumbnail.

E.g. given a 1024x1024 source image, `.thumbnail(width=50)`, `.thumbnail(height=50)`, `.thumbnail(50, 100)`, `.thumbnail(100, 50)`, and `.thumbnail(50, 50, mode="stretch")` will all generate the same 50x50 thumbnail.

Here we change the method of generating the thumbnail suffix so that it serializes the parameters to ThumbnailBuilder. These include the full dimension of the thumbnail (both width and height).

This can prevent the generation of multiple identical thumbnails (with different names). I think the resulting code is cleaner, as well.

It is a possibly *breaking change* since the generated thumbnails will have different names than they did previously. (Though no one should have been assuming any specific thumbnail names.)  Anyhow, I think the chance of causing trouble is minimal.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->


### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
