### PR TITLE
Conftest.restore_import_state should restore sys.meta_path as well as sys.path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,7 +243,7 @@ def scratch_builder(tmp_path, scratch_pad):
 # Builder for child-sources-test-project, a project to test that child sources
 # are built even if they're filtered out by a pagination query.
 @pytest.fixture(scope="function")
-def child_sources_test_project_builder(tmp_path, data_path):
+def child_sources_test_project_builder(tmp_path, data_path, save_sys_path):
     output_path = tmp_path / "output"
     output_path.mkdir()
     project = Project.from_path(data_path / "child-sources-test-project")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,21 @@ def restore_import_state():
         sys.path_importer_cache.clear()
 
 
+_initial_path_key = object()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    item.stash[_initial_path_key] = sys.path.copy()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item):
+    # Check that tests don't alter sys.path
+    initial_path = item.stash[_initial_path_key]
+    assert sys.path == initial_path
+
+
 @pytest.fixture
 def save_sys_path():
     with restore_import_state():

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -28,7 +28,7 @@ def project_path(tmp_path_factory, data_path):
 
 
 @pytest.fixture
-def pad(project_path):
+def pad(project_path, save_sys_path):
     return Project.from_path(project_path).make_env().new_pad()
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,39 @@
+import sys
+from contextlib import suppress
+from importlib import import_module
+
+from lektor.compat import importlib_metadata
+
+# pylint: disable-next=wrong-import-order
+from conftest import restore_import_state  # noreorder
+
+
+def test_restore_import_state_restores_meta_path():
+    # Various modules (e.g. setuptools, importlib_metadata), when imported,
+    # add their own finders to sys.meta_path.
+    meta_path = sys.meta_path.copy()
+
+    with restore_import_state(), suppress(ModuleNotFoundError):
+        import_module("importlib_metadata")
+
+    assert sys.meta_path == meta_path
+
+
+def test_restore_import_state_restores_unneutered_PathFinder():
+    # When importlib_metadata is imported, it neuters the stdlib
+    # distribution find, and then adds its own finder to meta_path.
+    #
+    # This tests that restore_import_state manages to unneuter
+    # this find.
+    distributions_pre = [
+        dist.metadata["name"] for dist in importlib_metadata.distributions()
+    ]
+
+    with restore_import_state(), suppress(ModuleNotFoundError):
+        import_module("importlib_metadata")
+
+    distributions_post = [
+        dist.metadata["name"] for dist in importlib_metadata.distributions()
+    ]
+    assert len(distributions_pre) == len(distributions_post)
+    assert set(distributions_pre) == set(distributions_post)

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -114,7 +114,7 @@ class DummyPluginFinder(metadata.DistributionFinder):
 
 
 @pytest.fixture
-def dummy_plugin_distribution(save_sys_path, monkeypatch):
+def dummy_plugin_distribution(save_sys_path):
     """Add a dummy plugin distribution to the current working_set."""
     dist = DummyDistribution(
         {
@@ -123,7 +123,8 @@ def dummy_plugin_distribution(save_sys_path, monkeypatch):
         }
     )
     finder = DummyPluginFinder(__name__, dist)
-    monkeypatch.setattr("sys.meta_path", [finder] + sys.meta_path)
+    # The save_sys_path fixture will restore meta_path at end of test
+    sys.meta_path.insert(0, finder)
     return dist
 
 

--- a/tests/test_prev_next_sibling.py
+++ b/tests/test_prev_next_sibling.py
@@ -21,7 +21,7 @@ def pntest_project(tmp_path, data_path):
 
 
 @pytest.fixture
-def pntest_env(pntest_project):
+def pntest_env(pntest_project, save_sys_path):
     return Environment(pntest_project)
 
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -49,7 +49,7 @@ def theme_project(theme_project_tmpdir, request):
 
 
 @pytest.fixture(scope="function")
-def theme_env(theme_project):
+def theme_env(theme_project, save_sys_path):
 
     return Environment(theme_project)
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -9,6 +9,9 @@ from lektor.constants import PRIMARY_ALT
 from lektor.db import Tree
 from lektor.project import Project
 
+# pylint: disable-next=wrong-import-order
+from conftest import restore_import_state  # noreorder
+
 
 @pytest.fixture(scope="session")
 def no_alt_pad(tmp_path_factory, data_path):
@@ -29,7 +32,8 @@ def no_alt_pad(tmp_path_factory, data_path):
                 child.unlink()
 
     project = Project.from_path(no_alt_project)
-    return project.make_env().new_pad()
+    with restore_import_state():
+        return project.make_env().new_pad()
 
 
 @pytest.fixture(params=[False, True])

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -7,7 +7,7 @@ from lektor.reporter import BufferReporter
 
 
 @pytest.fixture
-def pad(data_path):
+def pad(data_path, save_sys_path):
     proj = Project.from_path(data_path / "ünicöde-project")
     return proj.make_env().new_pad()
 


### PR DESCRIPTION
The `restore_import_state` context manager (in conftest.py) is used to isolate tests with respect to any changes they may make in `sys.path` and any modules they may import.

It turns out that `sys.meta_path` needs to be restored as well.  If that's not done, there are a couple of insidious bugs (spurious test failures) that crop up.






<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

Spurious test failures.


### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->
#### Restore `sys.meta_path`.

Some modules, when imported, add their own custom finders to [sys.meta_path](https://docs.python.org/3/reference/import.html#the-meta-path).  If such a module is imported within a test that is protected by `restore_import_state`, it is in effect, "unimported" at the end of the test.  If another test also imports that module, it can add its finder to meta_path again.

(This can result in a `RuntimeError: Plugin "webpack-support" is already registered`, since, with a duplicate finder on meta_path, import.metadata.distributions() can list all distributions twice.)

#### Demangle the finders on `sys.meta_path`

It gets worse.

It turns out that when `importlib_metadata` is imported, it neuters the stdlib PathFinder (by [deleting its find_distributions method](https://github.com/python/importlib_metadata/blob/705a7571ec7c5abec4d4b008da3a58df7e5c94e7/importlib_metadata/_compat.py#L31)).  It then adds its own custom finder to handle distribution lookup instead.

If `importlib_metadata` is imported within a test that is protected by `restore_import_state`, its custom finder gets removed from sys.meta_path at the end of the test. But the stdlib finder has been crippled at this point, so now attempts to list installed distributions fail.

So here, we make a copy of the stdlib PathFinder before the test run and restore that at the end of the test.
<!--- Thanks for your help making Lektor better for everyone! --->
