### PR TITLE
Fix: "FATAL: exception not rethrown" from `lektor server`

### DIFF
--- a/lektor/admin/context.py
+++ b/lektor/admin/context.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 from typing import Any
 from typing import NamedTuple
-from typing import Optional
-from typing import Sequence
 from typing import TYPE_CHECKING
-from typing import Union
 
 from flask import current_app
 from flask import Flask
@@ -20,14 +19,14 @@ from lektor.environment.config import Config
 from lektor.reporter import CliReporter
 
 if TYPE_CHECKING:
-    import os
+    from _typeshed import StrPath
 
 
 class LektorInfo(NamedTuple):
     env: Environment
-    output_path: Union[str, "os.PathLike[Any]"]
+    output_path: StrPath
     verbosity: int = 0
-    extra_flags: Optional[Sequence[str]] = None
+    extra_flags: dict[str, str] | None = None
 
 
 class LektorContext(LektorInfo):

--- a/lektor/admin/webui.py
+++ b/lektor/admin/webui.py
@@ -1,7 +1,6 @@
-from typing import Optional
-from typing import Sequence
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
-from typing import Union
 from wsgiref.util import shift_path_info
 
 from flask import Flask
@@ -16,8 +15,7 @@ from lektor.admin.modules import serve
 from lektor.environment import Environment
 
 if TYPE_CHECKING:
-    import os
-    from typing import Any
+    from _typeshed import StrPath
     from _typeshed.wsgi import WSGIApplication
 
 
@@ -29,14 +27,14 @@ def _common_configuration(app: Flask, debug: bool = False) -> None:
 def make_app(
     env: Environment,
     debug: bool = False,
-    output_path: Optional[Union[str, "os.PathLike[Any]"]] = None,
+    output_path: StrPath | None = None,
     ui_lang: str = "en",
     verbosity: int = 0,
-    extra_flags: Optional[Sequence[str]] = None,
+    extra_flags: dict[str, str] | None = None,
     reload: bool = True,
     *,
     admin_path: str = "/admin",
-    static_folder: Optional[Union[str, "os.PathLike[Any]"]] = "static",  # testing
+    static_folder: StrPath | None = "static",  # testing
 ) -> LektorApp:
     if output_path is None:
         output_path = env.project.get_output_path()

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -113,7 +113,7 @@ def run_server(
         reload=reload,
     )
 
-    if browse:
+    if browse and not wz_as_main:
         browse_to_address(bindaddr)
 
     try:

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 import traceback
@@ -5,7 +6,6 @@ from contextlib import ExitStack
 
 from werkzeug.serving import is_running_from_reloader
 from werkzeug.serving import run_simple
-from werkzeug.serving import WSGIRequestHandler
 
 from lektor.admin import WebAdmin
 from lektor.builder import Builder
@@ -13,11 +13,6 @@ from lektor.db import Database
 from lektor.reporter import CliReporter
 from lektor.utils import process_extra_flags
 from lektor.watcher import watch_project
-
-
-class SilentWSGIRequestHandler(WSGIRequestHandler):
-    def log(self, type, message, *args):
-        pass
 
 
 class BackgroundBuilder(threading.Thread):
@@ -100,6 +95,8 @@ def run_server(
     extra_flags = process_extra_flags(extra_flags)
     if lektor_dev:
         env.jinja_env.add_extension("jinja2.ext.debug")
+    else:
+        logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
     app = WebAdmin(
         env,
@@ -137,7 +134,4 @@ def run_server(
             use_debugger=True,
             threaded=True,
             use_reloader=lektor_dev,
-            request_handler=WSGIRequestHandler
-            if lektor_dev
-            else SilentWSGIRequestHandler,
         )

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Any
 from typing import Generator
 from typing import TYPE_CHECKING
@@ -11,11 +10,12 @@ import watchfiles
 from lektor.utils import get_cache_dir
 
 if TYPE_CHECKING:
+    from _typeshed import StrPath
     from lektor.environment import Environment
 
 
 def watch_project(
-    env: Environment, output_path: str | Path, **kwargs: Any
+    env: Environment, output_path: StrPath, **kwargs: Any
 ) -> Generator[set[watchfiles.FileChange], None, None]:
     """Watch project source files for changes.
 

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 def watch_project(
     env: Environment, output_path: str | Path, **kwargs: Any
-) -> Generator[[watchfiles.Change, str], None, None]:
+) -> Generator[set[watchfiles.FileChange], None, None]:
     """Watch project source files for changes.
 
     Returns an generator that yields sets of changes as they are noticed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ ignore_missing_imports = true
 # Packages and modules we want to check
 module = [
     "lektor.constants",
+    "lektor.devserver",
     "lektor.packages",
     "lektor.admin.*",
     "lektor.imagetools",
@@ -216,6 +217,7 @@ disallow_untyped_calls = false
 [[tool.mypy.overrides]]
 module = [
     "lektor.admin.*",
+    "lektor.devserver",
     "lektor.imagetools",
 ]
 disallow_untyped_calls = false


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

When `lektor server` is terminated (e.g. via SIGINT) a "FATAL: exception not rethrown" error is displayed and a core dump is attempted.

This was introduced by #1136. The error arises when `watchfiles.watcher` is run in a daemon thread. When the thread is killed (when the main thread terminates) something is not getting cleaned up properly. The solution taken here is to run the watcher in a non-daemon thread, making sure to shut down the thread on exit.


### Related Issues / Links

- samuelcolvin/watchfiles#128, samuelcolvin/watchfiles#132

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

I've also cleaned up the code in `lektor.devserver` a bit.

<!--- Thanks for your help making Lektor better for everyone! --->
