### PR TITLE
Random buglet fixes in lektor.builder

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -749,9 +749,7 @@ class Artifact:
             self._new_artifact_file = filename
 
     def render_template_into(self, template_name, this, **extra):
-        """Renders a template into the artifact.  The default behavior is to
-        catch the error and render it into the template with a failure marker.
-        """
+        """Renders a template into the artifact."""
         rv = self.build_state.env.render_template(
             template_name, self.build_state.pad, this=this, **extra
         )

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -573,12 +573,13 @@ class FileInfo(_ArtifactSourceInfo):
         if not isinstance(other, FileInfo):
             raise TypeError("'other' must be a FileInfo, not %r" % other)
 
+        if self.mtime != other.mtime or self.size != other.size:
+            return False
         # If mtime and size match, we skip the checksum comparison which
         # might require a file read which we do not want in those cases.
         # (Except if it's a directory, then we won't do that)
-        if not self.is_dir and self.mtime == other.mtime and self.size == other.size:
+        if not self.is_dir:
             return True
-
         return self.checksum == other.checksum
 
     def is_changed(self, build_state: BuildState) -> bool:

--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -1131,8 +1131,9 @@ class Builder:
 
     def touch_site_config(self):
         """Touches the site config which typically will trigger a rebuild."""
+        project_file = self.env.project.project_file
         try:
-            os.utime(os.path.join(self.env.root_path, "site.ini"), None)
+            os.utime(project_file)
         except OSError:
             pass
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -392,6 +392,15 @@ def test_second_build_all_builds_nothing(scratch_builder, scratch_project_data):
 ################################################################
 
 
+def test_Artifact_open_encoding(builder):
+    build_state = builder.new_build_state()
+    artifact = build_state.new_artifact("dummy-artifact", sources=())
+    with artifact.open("w", encoding="iso-8859-1") as fp:
+        fp.write("Ciarán")
+    with artifact.open("r", encoding="iso-8859-1") as fp:
+        assert fp.read() == "Ciarán"
+
+
 def test_FileInfo_unchanged(env, tmp_path):
     file_path = tmp_path / "file"
     file_path.write_text("foo")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from lektor.builder import FileInfo
 from lektor.reporter import NullReporter
 
 
@@ -386,3 +387,21 @@ def test_second_build_all_builds_nothing(scratch_builder, scratch_project_data):
 
     with AssertBuildsNothingReporter():
         scratch_builder.build_all()
+
+
+################################################################
+
+
+def test_FileInfo_unchanged(env, tmp_path):
+    file_path = tmp_path / "file"
+    file_path.write_text("foo")
+
+    file_info = FileInfo(env, file_path)
+    # cache size, mtime, but *not* checksum
+    assert file_info.size == 3
+
+    file_path.write_text("foobar")
+    file_info2 = FileInfo(env, file_path)
+    assert file_info2.size != 3
+
+    assert not file_info.unchanged(file_info2)


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

- Logic flaw in `FileInfo.unchanged` caused a source file to be considered unchanged in certain edge-cases even when its size (and therefore its contents) have changed.
- `Builder.touch_site_config` wasn't actually touching the site config.
- The `encoding` parameter to `Artifact.open` was being ignored in certain circumstances. (Since `encoding` defaults to *utf-8* — which is normally what is wanted — this was mostly harmless.)
- Updated a stale comment.

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->
<!--
Fixes #
-->
### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
