### PR TITLE
Fix #908: Omit shadowed assets from build

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -138,7 +138,7 @@ class ArtifactServer:
         Raise NotFound if no index is found.
         """
         for name in "index.html", "index.htm":
-            index = directory.get_child(name, from_url=True)
+            index = directory.resolve_url_path([name])
             if index is not None:
                 break
         else:

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -92,10 +92,6 @@ class Asset(SourceObject):
             return self.parent.artifact_name.rstrip("/") + "/" + self.url_name
         return self.url_path
 
-    def build_asset(self, f) -> None:
-        # FIXME: unused? delete?
-        pass
-
     @property
     def children(self) -> Iterable[Asset]:
         return ()

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import posixpath
+import warnings
 from contextlib import suppress
 from itertools import takewhile
 from operator import methodcaller

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -33,7 +33,7 @@ def get_asset_root(pad: Pad, asset_roots: Iterable[StrPath]) -> Directory:
     are silently ignored.
     """
     root_paths = tuple(
-        Path(root).resolve() for root in asset_roots if Path(root).is_dir()
+        Path(root).absolute() for root in asset_roots if Path(root).is_dir()
     )
     return Directory(pad, parent=None, name="", paths=root_paths)
 

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
+from __future__ import annotations
+
 import errno
 import functools
 import hashlib
@@ -13,6 +14,7 @@ from itertools import chain
 from itertools import islice
 from operator import methodcaller
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 from jinja2 import is_undefined
@@ -48,6 +50,10 @@ from lektor.utils import split_virtual_path
 from lektor.utils import untrusted_to_os_path
 from lektor.videotools import get_video_info
 from lektor.videotools import make_video_thumbnail
+
+if TYPE_CHECKING:
+    from lektor.environment import Environment
+    from lektor.environment.config import Config
 
 # pylint: disable=no-member
 
@@ -1578,18 +1584,18 @@ def _split_alt_from_url(config, clean_path):
 
 
 class Pad:
-    def __init__(self, db):
+    def __init__(self, db: Database):
         self.db = db
         self.cache = RecordCache(db.config["EPHEMERAL_RECORD_CACHE_SIZE"])
         self.databags = Databags(db.env)
 
     @property
-    def config(self):
+    def config(self) -> Config:
         """The config for this pad."""
         return self.db.config
 
     @property
-    def env(self):
+    def env(self) -> Environment:
         """The env for this pad."""
         return self.db.env
 

--- a/lektor/db.py
+++ b/lektor/db.py
@@ -1689,7 +1689,7 @@ class Pad:
 
     root = property(get_root)
 
-    @property
+    @cached_property
     def asset_root(self):
         """The root of the asset tree.
 

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import posixpath
 from typing import Optional
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl
 from urllib.parse import urlsplit
 from weakref import ref as weakref
@@ -10,6 +13,9 @@ from lektor.reporter import reporter
 from lektor.utils import is_path_child_of
 from lektor.utils import join_path
 
+if TYPE_CHECKING:
+    from lektor.db import Pad
+
 
 class SourceObject:
     source_classification = "generic"
@@ -18,7 +24,7 @@ class SourceObject:
     # to be from another place.
     __module__ = "db"
 
-    def __init__(self, pad):
+    def __init__(self, pad: Pad):
         self._pad = weakref(pad)
 
     @property
@@ -71,7 +77,7 @@ class SourceObject:
         return None
 
     @property
-    def pad(self):
+    def pad(self) -> Pad:
         """The associated pad of this source object."""
         rv = self._pad()
         if rv is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 # Packages and modules we want to check
 module = [
+    "lektor.assets",
     "lektor.constants",
     "lektor.devserver",
     "lektor.packages",

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from lektor.assets import _is_valid_path_component
 from lektor.assets import Directory
 from lektor.assets import File
 from lektor.assets import get_asset
@@ -185,46 +184,6 @@ def test_resolve_url_path(asset, url_path, expected):
 )
 def test_asset_repr(asset, expected):
     assert repr(asset) == expected
-
-
-@pytest.mark.parametrize(
-    "comp",
-    [
-        "x",
-        "a.b",
-        "a_b",
-        "a@b",
-    ],
-)
-def test_is_valid_path_component_true(comp):
-    assert _is_valid_path_component(comp)
-
-
-@pytest.mark.parametrize(
-    "comp",
-    [
-        "",
-        ".",
-        "..",
-        "../x",
-        # abspath
-        "/x",
-        "//x",
-        r"\x",
-        r"\\x",
-        # pathsep
-        "x/y",
-        r"x\y",
-        # Windows drive
-        "c:foo",
-        "c:",
-        # Windows restricted file names
-        "nul",
-        "c:nul",
-    ],
-)
-def test_is_valid_path_component_false(comp):
-    assert not _is_valid_path_component(comp)
 
 
 @pytest.fixture

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -4,6 +4,7 @@ import shutil
 
 import pytest
 
+from lektor.assets import _is_valid_path_component
 from lektor.assets import Directory
 from lektor.assets import File
 from lektor.assets import get_asset_root
@@ -145,6 +146,46 @@ def test_resolve_url_path(asset, url_path, expected):
 )
 def test_asset_repr(asset, expected):
     assert repr(asset) == expected
+
+
+@pytest.mark.parametrize(
+    "comp",
+    [
+        "x",
+        "a.b",
+        "a_b",
+        "a@b",
+    ],
+)
+def test_is_valid_path_component_true(comp):
+    assert _is_valid_path_component(comp)
+
+
+@pytest.mark.parametrize(
+    "comp",
+    [
+        "",
+        ".",
+        "..",
+        "../x",
+        # abspath
+        "/x",
+        "//x",
+        r"\x",
+        r"\\x",
+        # pathsep
+        "x/y",
+        r"x\y",
+        # Windows drive
+        "c:foo",
+        "c:",
+        # Windows restricted file names
+        "nul",
+        "c:nul",
+    ],
+)
+def test_is_valid_path_component_false(comp):
+    assert not _is_valid_path_component(comp)
 
 
 @pytest.fixture

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import shutil
 
 import pytest
@@ -109,13 +108,6 @@ def test_asset_get_child(asset, name, from_url, child_name):
         assert asset.get_child(name, from_url).name == child_name
 
 
-fs_ignores_case = all(os.path.exists(fn) for fn in (__file__.upper(), __file__.lower()))
-xfail_if_fs_cs = pytest.mark.xfail(
-    not fs_ignores_case,
-    reason="FIXME: fails on case-sensitive filesystems",
-)
-
-
 @pytest.mark.parametrize(
     "asset_path, url_path, expected",
     [
@@ -125,7 +117,7 @@ xfail_if_fs_cs = pytest.mark.xfail(
         ("/", ("foo-prefix-makes-me-excluded",), None),
         ("/", ("foo-prefix-makes-me-excluded", "static"), None),
         ("/static", ("demo.css",), "/static/demo.css"),
-        pytest.param("/", ("TEST.txt",), "/TEST.txt", marks=xfail_if_fs_cs),
+        ("/", ("TEST.txt",), "/TEST.txt"),
     ],
 )
 def test_resolve_url_path(asset, url_path, expected):


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #908
Fixes #1111 

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->

<!--- Explain what you've done and why --->
The issue described in #908 happens when themes (and so multiple asset trees) are in play.  If there is an asset in one asset tree at the same path as an asset in a second asset tree, both are currently built.  Besides being inefficient (one overwrites the other) the order of building seems not to be completely deterministic, so that it's not clear which version wins.

Currently, when themes are in play, so that there are multiple on-disk directory trees of assets to be merged to a single output tree, Lektor keeps a list of the multiple assets tree roots, and traverses each of those separately to find all the assets to be built.

In this PR we refactor `lektor.assets.Directory` so that it can represent a logically merged asset directory.  After this PR a single `lektor.assets.Directory` instance can represent an overlayed set of directories.  This gets us back to having a single *asset root* which represents the merged asset tree.

<!--- Thanks for your help making Lektor better for everyone! --->


