### PR TITLE
fix: `bag()` should get `site` from jinja context

### DIFF
--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -182,9 +182,11 @@ class CustomJinjaEnvironment(jinja2.Environment):
             raise
 
 
-def lookup_from_bag(*args):
+@jinja2.pass_context
+def lookup_from_bag(jinja_ctx, *args):
     pieces = ".".join(x for x in args if x)
-    return site_proxy.databags.lookup(pieces)
+    site = jinja_ctx.get("site", default=site_proxy)
+    return site.databags.lookup(pieces)
 
 
 class Environment:


### PR DESCRIPTION
Jinja global functions should obtain `site` from the Jinja context rather than the Lektor build Context.

Sometimes `site` is explicitly set in the jinja context. In that case, that is the value that should be used.  Furthermore, outside of an artifact build, a Lektor build Context is not available.

This mostly fixes #614, allowing the use of databags as the `source` for a `checkboxes` or `select` field.
Note that one will likely still have to specify a non-default value for `item_key`.  The default is `{{ this._id }}`, so unless the items from the databag have an `_id`, that won't work.


## Notes

We may want to consider deprecating `site_proxy` and `config_proxy`.  (Instead, compute defaults for `site` and `config` from the current Lektor context in `Environment.make_default_tmpl_values`.)


<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #614

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
