### PR TITLE
Use symlinks when creating virtual environments — fixes #1159

### DIFF
--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -87,6 +87,12 @@ def remove_package_from_project(project, name):
     return None
 
 
+if os.name == "nt":
+    _default_venv_symlinks = False
+else:
+    _default_venv_symlinks = True
+
+
 class VirtualEnv:
     """A helper for manipulating our private package cache virtual environment.
 
@@ -100,7 +106,12 @@ class VirtualEnv:
     def __init__(self, path: StrPath):
         self.path = Path(path)
 
-    def create(self, with_pip: bool = True, upgrade_deps: bool = True) -> None:
+    def create(
+        self,
+        with_pip: bool = True,
+        upgrade_deps: bool = True,
+        symlinks: bool = _default_venv_symlinks,
+    ) -> None:
         """(Re-)Create a new virtual environment.
 
         This will remove any existing virtual environment and create a new one.
@@ -120,7 +131,11 @@ class VirtualEnv:
         #
         # Note that, e.g., pip>=21.3 is required to support PEP660 editable
         # installs.
-        options: Dict[str, Any] = {"clear": True, "with_pip": with_pip}
+        options: Dict[str, Any] = {
+            "clear": True,
+            "with_pip": with_pip,
+            "symlinks": symlinks,
+        }
         if sys.version_info >= (3, 9):
             EnvBuilder(upgrade_deps=upgrade_deps, **options).create(self.path)
         else:

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -53,6 +53,12 @@ def test_VirtualEnv_addsitedir(nested_venv: VirtualEnv) -> None:
     assert proc.returncode == 0
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows")
+def test_VirtualEnv_uses_symlinks(nested_venv: VirtualEnv) -> None:
+    executable = Path(nested_venv.executable)
+    assert executable.resolve(strict=True).parent != executable.parent
+
+
 @pytest.mark.requiresinternet
 @pytest.mark.slowtest
 def test_VirtualEnv_run_pip_install(tmp_path: Path) -> None:


### PR DESCRIPTION
This changes things to use symlinks when constructing Lektor's private virtual environment.

By default, `python -m venv` uses symlinks, except when running on Windows (where symlinks can be problematic).  However when creating a virtual environment programmatically, `venv.EnvBuilder` defaults to not using symlinks.

Using symlinks is better (everywhere except maybe on Windows) because:

- It uses less disk space
- That's what `python -m venv` does
- Apparently, that's what Python on macOS expects, at least when involved via Homebrew (see #1159)

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1159

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
