### PR TITLE
Test under python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         exclude:
           - os: "macos-latest"
             python: "3.8"
@@ -105,6 +105,8 @@ jobs:
             python: "3.10"
         include:
           - python: "3.11"
+            install-ffmpeg: true
+          - python: "3.12-dev"
             install-ffmpeg: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: "macos-latest"
             python: "3.8"
@@ -97,16 +97,18 @@ jobs:
             python: "3.9"
           - os: "macos-latest"
             python: "3.10"
+          - os: "macos-latest"
+            python: "3.11"
           - os: "windows-latest"
             python: "3.8"
           - os: "windows-latest"
             python: "3.9"
           - os: "windows-latest"
             python: "3.10"
+          - os: "windows-latest"
+            python: "3.11"
         include:
-          - python: "3.11"
-            install-ffmpeg: true
-          - python: "3.12-dev"
+          - python: "3.12"
             install-ffmpeg: true
     steps:
       - uses: actions/checkout@v3

--- a/build_frontend.py
+++ b/build_frontend.py
@@ -65,16 +65,20 @@ class FrontendBuildHook(BuildHookInterface):
             app.display_info(f"{APP_JS} exists, skipping frontend build")
             return
 
-        npm = shutil.which("npm")
-        if npm is None:
-            app.abort("npm is not available. can not build frontend")
+        try:
+            proc = subprocess.run(
+                "npm -v", capture_output=True, text=True, shell=True, check=True
+            )
+        except subprocess.CalledProcessError as exc:
+            app.abort(f"{exc.cmd!r} failed (is node/npm installed?)")
+        app.display_info(f"found npm version {proc.stdout.strip()}")
 
         frontend = Path(root, FRONTEND)
         if not frontend.is_dir():
             app.abort("frontend source is missing. can not build frontend")
 
         app.display_info("npm install")
-        subprocess.run((npm, "install"), cwd=frontend, check=True)
+        subprocess.run("npm install", cwd=frontend, shell=True, check=True)
         app.display_info("npm run build")
-        subprocess.run((npm, "run", "build"), cwd=frontend, check=True)
+        subprocess.run("npm run build", cwd=frontend, shell=True, check=True)
         app.display_success("built frontend static files")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tests/test_build_frontend.py
+++ b/tests/test_build_frontend.py
@@ -1,4 +1,5 @@
 """Tests for the hatch build hooks in ../build_frontend.py."""
+import os
 import shutil
 import sys
 from importlib.util import module_from_spec
@@ -81,8 +82,10 @@ def test_initialize_skips_build_if_output_exists(
 
 
 @pytest.mark.usefixtures("frontend_src")
-def test_initialize_aborts_if_no_npm(frontend_build_hook, mocker):
-    mocker.patch("shutil.which").return_value = None
+def test_initialize_aborts_if_no_npm(
+    frontend_build_hook, frontend_build_module, monkeypatch
+):
+    monkeypatch.setitem(os.environ, "PATH", "")
     with pytest.raises(SystemExit) as exc_info:
         frontend_build_hook.initialize("standard", build_data={})
     assert exc_info.value.args[0] == 1

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.1
 envlist =
     lint
-    {py37,py38,py39,py310,py311}{,-mistune0}
+    {py37,py38,py39,py310,py311,py312}{,-mistune0}
     py311-noutils
     py311-pytz
     py311-tzdata
@@ -18,6 +18,7 @@ python =
     3.9: py39, cover
     3.10: py310, cover
     3.11: py311, cover
+    3.12: py312, cover
 
 [testenv]
 commands =
@@ -42,8 +43,8 @@ deps =
     pillow6: pillow<6.1.0
     pillow7: pillow<7.1.0
 depends =
-    py{37,38,39,310,311}: cover-clean
-    cover-report: py{37,38,39,310,311}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}
+    py{37,38,39,310,311,312}: cover-clean
+    cover-report: py{37,38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}
 # XXX: I've been experiencing sporadic failures when running tox in parallel mode.
 # The crux of the error messages when this happens appears to be something like:
 #
@@ -63,7 +64,7 @@ depends =
 # Hopefully, at some point this can be removed.
 download = true
 
-[testenv:py{37,38,39,310,311}-noutils]
+[testenv:py{37,38,39,310,311,312}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env


### PR DESCRIPTION
Python 3.12rc3 — the final release candidate — is out.
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

