### PR TITLE
Remove pin on werkzeug <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "requests",
     "tzdata; python_version>='3.9' and sys_platform == 'win32'",
     "watchfiles>=0.12",
-    "Werkzeug>=2.1.0,<3",
+    "Werkzeug>=2.1.0",
 ]
 optional-dependencies.ipython = [
     "ipython",


### PR DESCRIPTION

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1171

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

The latest version of Werkzeug (3.0.1) includes changes to address a vulnerability which could potential be used for DoS attacks.  Though it is not clear that that particular vulnerability is really an issue in common usage of Lektor, removing the `werkzeug<3` pin thus addresses that vulnerability.

### Issues

Should an upper pin to prevent unexpected breakage by new releases of Werkzeug be reinstated?

Both the Flask and Werkzeug projects do seem to zealously deprecate, rename, and remove certain APIs leading to breakage on some minor version bumps, even.  (E.g. see #911, #1018, #1051, #1142 as well as [this blog post](https://blog.miguelgrinberg.com/post/we-have-to-talk-about-flask) and [followup](https://blog.miguelgrinberg.com/post/some-more-to-talk-about-flask).)

Should we add a pin on `werkzeug<3.1` or `werkzeug<4`?
[Decision, for now: no.  See [comments](https://github.com/lektor/lektor/issues/1171#issuecomment-1793256186) on #1171.]

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
