### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,18 +89,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-          - os: "macos-latest"
-            python: "3.8"
           - os: "macos-latest"
             python: "3.9"
           - os: "macos-latest"
             python: "3.10"
           - os: "macos-latest"
             python: "3.11"
-          - os: "windows-latest"
-            python: "3.8"
           - os: "windows-latest"
             python: "3.9"
           - os: "windows-latest"

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import warnings
+from importlib import metadata
 from itertools import chain
 
 import click
@@ -13,7 +14,6 @@ from lektor.cli_utils import pass_context
 from lektor.cli_utils import pruneflag
 from lektor.cli_utils import ResolvedPath
 from lektor.cli_utils import validate_language
-from lektor.compat import importlib_metadata as metadata
 from lektor.project import Project
 from lektor.utils import secure_url
 

--- a/lektor/compat.py
+++ b/lektor/compat.py
@@ -13,7 +13,7 @@ from urllib.parse import urlsplit
 from werkzeug import urls as werkzeug_urls
 from werkzeug.datastructures import MultiDict
 
-__all__ = ["TemporaryDirectory", "importlib_metadata", "werkzeug_urls_URL"]
+__all__ = ["TemporaryDirectory", "werkzeug_urls_URL"]
 
 
 def _ensure_tree_writeable(path: str) -> None:
@@ -59,10 +59,8 @@ class FixedTemporaryDirectory(tempfile.TemporaryDirectory):
 
 if sys.version_info >= (3, 8):
     TemporaryDirectory = tempfile.TemporaryDirectory
-    from importlib import metadata as importlib_metadata
 else:
     TemporaryDirectory = FixedTemporaryDirectory
-    import importlib_metadata
 
 
 class _CompatURL(urllib.parse.SplitResult):

--- a/lektor/compat.py
+++ b/lektor/compat.py
@@ -1,66 +1,13 @@
 from __future__ import annotations
 
-import os
-import stat
-import sys
-import tempfile
 import urllib.parse
-from functools import partial
-from itertools import chain
 from typing import Any
 from urllib.parse import urlsplit
 
 from werkzeug import urls as werkzeug_urls
 from werkzeug.datastructures import MultiDict
 
-__all__ = ["TemporaryDirectory", "werkzeug_urls_URL"]
-
-
-def _ensure_tree_writeable(path: str) -> None:
-    """Attempt to ensure that all files in the tree rooted at path are writeable."""
-    dirscans = []
-
-    def fix_mode(path, statfunc):
-        try:
-            # paranoia regarding symlink attacks
-            current_mode = statfunc(follow_symlinks=False).st_mode
-            if not stat.S_ISLNK(current_mode):
-                isdir = stat.S_ISDIR(current_mode)
-                fixed_mode = current_mode | (0o700 if isdir else 0o200)
-                if current_mode != fixed_mode:
-                    os.chmod(path, fixed_mode)
-                if isdir:
-                    dirscans.append(os.scandir(path))
-        except FileNotFoundError:
-            pass
-
-    fix_mode(path, partial(os.stat, path))
-    for entry in chain.from_iterable(dirscans):
-        fix_mode(entry.path, entry.stat)
-
-
-class FixedTemporaryDirectory(tempfile.TemporaryDirectory):
-    """A version of tempfile.TemporaryDirectory that works if dir contains read-only files.
-
-    On python < 3.8 under Windows, if any read-only files are created
-    in a TemporaryDirectory, TemporaryDirectory will throw an
-    exception when it tries to remove them on cleanup. See
-    https://bugs.python.org/issue26660
-
-    This can create issues, e.g., with temporary git repositories since
-    git creates read-only files in its object store.
-
-    """
-
-    def cleanup(self) -> None:
-        _ensure_tree_writeable(self.name)
-        super().cleanup()
-
-
-if sys.version_info >= (3, 8):
-    TemporaryDirectory = tempfile.TemporaryDirectory
-else:
-    TemporaryDirectory = FixedTemporaryDirectory
+__all__ = ["werkzeug_urls_URL"]
 
 
 class _CompatURL(urllib.parse.SplitResult):

--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -1,5 +1,6 @@
 import sys
 import warnings
+from importlib import metadata
 from typing import Any
 from typing import Dict
 from typing import Hashable
@@ -10,7 +11,6 @@ from weakref import ref as weakref
 
 from markupsafe import Markup
 
-from lektor.compat import importlib_metadata as metadata
 from lektor.markdown.controller import ControllerCache
 from lektor.markdown.controller import FieldOptions
 from lektor.markdown.controller import MarkdownController

--- a/lektor/markdown/mistune2.py
+++ b/lektor/markdown/mistune2.py
@@ -1,15 +1,13 @@
 """MarkdownController implementation for mistune 2.x"""
 from __future__ import annotations
 
-import sys
 from importlib import import_module
-from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import TypedDict
 
 import mistune.util
 
@@ -46,16 +44,10 @@ class ImprovedRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
         return super().image(src, alt, title)
 
 
-if sys.version_info < (3, 8):
-    # No typing.TypedDict → punt
-    ParserConfigDict = Dict[str, Any]
-else:
-    from typing import TypedDict
-
-    class ParserConfigDict(TypedDict, total=False):
-        block: mistune.BlockParser
-        inline: mistune.InlineParser
-        plugins: Sequence[Callable[[mistune.Markdown], None]]
+class ParserConfigDict(TypedDict, total=False):
+    block: mistune.BlockParser
+    inline: mistune.InlineParser
+    plugins: Sequence[Callable[[mistune.Markdown], None]]
 
 
 MistunePlugin = Callable[[mistune.Markdown], None]

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -4,13 +4,13 @@ import inspect
 import os
 import sys
 import warnings
+from importlib import metadata
 from pathlib import Path
 from typing import Type
 from weakref import ref as weakref
 
 from inifile import IniFile
 
-from lektor.compat import importlib_metadata as metadata
 from lektor.context import get_ctx
 from lektor.utils import process_extra_flags
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -17,6 +17,7 @@ from subprocess import CompletedProcess
 from subprocess import DEVNULL
 from subprocess import PIPE
 from subprocess import STDOUT
+from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Callable
 from typing import ContextManager
@@ -35,7 +36,6 @@ from warnings import warn
 
 from werkzeug.datastructures import MultiDict
 
-from lektor.compat import TemporaryDirectory
 from lektor.compat import werkzeug_urls_URL
 from lektor.exception import LektorException
 from lektor.utils import bool_from_string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -33,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "Babel",
     "click>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "EXIFRead",
     "filetype>=1.0.7",
     "Flask",
-    "importlib_metadata; python_version<'3.8'",
     "inifile>=0.4.1",
     "Jinja2>=3.0",
     "MarkupSafe",

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,9 +1,36 @@
+import importlib
+import tempfile
 from urllib.parse import urlsplit
 
 import pytest
 from werkzeug import urls as werkzeug_urls
 
 from lektor.compat import _CompatURL
+
+
+@pytest.mark.parametrize(
+    "name, expected_value, replacement",
+    [
+        (
+            "TemporaryDirectory",
+            tempfile.TemporaryDirectory,
+            "tempfile.TemporaryDirectory",
+        ),
+        ("importlib_metadata", importlib.metadata, "importlib.metadata"),
+    ],
+)
+def test_deprecated_attr(name, expected_value, replacement):
+    lektor_compat = importlib.import_module("lektor.compat")
+    with pytest.deprecated_call(match=f"use {replacement} instead") as warnings:
+        value = getattr(lektor_compat, name)
+    assert value is expected_value
+    assert warnings[0].filename == __file__
+
+
+def test_missing_attr():
+    lektor_compat = importlib.import_module("lektor.compat")
+    with pytest.raises(AttributeError):
+        lektor_compat.MISSING  # pylint: disable=pointless-statement
 
 
 def make_CompatURL(url: str) -> _CompatURL:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,38 +1,9 @@
-import os
-from pathlib import Path
 from urllib.parse import urlsplit
 
 import pytest
 from werkzeug import urls as werkzeug_urls
 
 from lektor.compat import _CompatURL
-from lektor.compat import _ensure_tree_writeable
-from lektor.compat import FixedTemporaryDirectory
-from lektor.compat import TemporaryDirectory
-
-
-def test_ensure_tree_writeable(tmp_path):
-    topdir = tmp_path / "topdir"
-    subdir = topdir / "subdir"
-    regfile = subdir / "regfile"
-    subdir.mkdir(parents=True)
-    regfile.touch(mode=0)
-    subdir.chmod(0)
-    topdir.chmod(0)
-
-    _ensure_tree_writeable(topdir)
-
-    for p in topdir, subdir, regfile:
-        assert os.access(p, os.W_OK)
-
-
-@pytest.mark.parametrize("tmpdir_class", [FixedTemporaryDirectory, TemporaryDirectory])
-def test_TemporaryDirectory(tmpdir_class):
-    with tmpdir_class() as tmpdir:
-        file = Path(tmpdir, "test-file")
-        file.touch(mode=0)
-        os.chmod(tmpdir, 0)
-    assert not os.path.exists(tmpdir)
 
 
 def make_CompatURL(url: str) -> _CompatURL:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,8 +1,7 @@
 import sys
 from contextlib import suppress
 from importlib import import_module
-
-from lektor.compat import importlib_metadata
+from importlib import metadata
 
 # pylint: disable-next=wrong-import-order
 from conftest import restore_import_state  # noreorder
@@ -25,15 +24,11 @@ def test_restore_import_state_restores_unneutered_PathFinder():
     #
     # This tests that restore_import_state manages to unneuter
     # this find.
-    distributions_pre = [
-        dist.metadata["name"] for dist in importlib_metadata.distributions()
-    ]
+    distributions_pre = [dist.metadata["name"] for dist in metadata.distributions()]
 
     with restore_import_state(), suppress(ModuleNotFoundError):
         import_module("importlib_metadata")
 
-    distributions_post = [
-        dist.metadata["name"] for dist in importlib_metadata.distributions()
-    ]
+    distributions_post = [dist.metadata["name"] for dist in metadata.distributions()]
     assert len(distributions_pre) == len(distributions_post)
     assert set(distributions_pre) == set(distributions_post)

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import sys
+from importlib import metadata
 from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -12,7 +13,6 @@ from unittest import mock
 import pytest
 
 from lektor.cli import cli
-from lektor.compat import importlib_metadata as metadata
 from lektor.context import Context
 from lektor.packages import add_package_to_project
 from lektor.pluginsystem import _check_dist_name

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     mistune0: mistune<2
     pytz: pytz
     tzdata: tzdata
-    pillow6: pillow<6.1.0
+    pillow6: pillow<7.0
     pillow7: pillow<7.1.0
 depends =
     py{38,39,310,311,312}: cover-clean

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.1
 envlist =
     lint
-    {py37,py38,py39,py310,py311,py312}{,-mistune0}
+    {py38,py39,py310,py311,py312}{,-mistune0}
     py311-noutils
     py311-pytz
     py311-tzdata
@@ -13,7 +13,6 @@ isolated_build = true
 
 [gh-actions]
 python =
-    3.7: py37, cover
     3.8: py38, cover
     3.9: py39, cover
     3.10: py310, cover
@@ -43,8 +42,8 @@ deps =
     pillow6: pillow<6.1.0
     pillow7: pillow<7.1.0
 depends =
-    py{37,38,39,310,311,312}: cover-clean
-    cover-report: py{37,38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}
+    py{38,39,310,311,312}: cover-clean
+    cover-report: py{38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}
 # XXX: I've been experiencing sporadic failures when running tox in parallel mode.
 # The crux of the error messages when this happens appears to be something like:
 #
@@ -64,7 +63,7 @@ depends =
 # Hopefully, at some point this can be removed.
 download = true
 
-[testenv:py{37,38,39,310,311,312}-noutils]
+[testenv:py{38,39,310,311,312}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env


### PR DESCRIPTION
Python 3.7 was EOLed on June 27, 2023.

This PR removes testing under python 3.7.  It also includes some code cleanups that can be made if we no longer wish to support running under python 3.7.



### Description of Changes

- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
