### PR TITLE
Fix "re.error: bad escape \u"

### DIFF
--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -80,7 +80,10 @@ def _inject_tooldrawer(
             tooldrawer_config=dataclasses.asdict(tooldrawer_config),
             tooldrawer_js=url_for("static", filename="tooldrawer.js"),
         ).encode("utf-8")
-        html = re.sub(rb"(?i)(?=</\s*head\s*>|\Z)", tooldrawer_html, html, count=1)
+        match = re.search(rb"(?i)</\s*head\s*>|\Z", html)
+        assert match is not None
+        head_end = match.start()
+        html = html[:head_end] + tooldrawer_html + html[head_end:]
     return html
 
 


### PR DESCRIPTION
We were using `re.sub()` to [inject the tooldrawer HTML][1].  `Re.sub` treats backslashes in the replacement string specially.  When the injected HTML includes a backslash (e.g. in JSON string data), this results in a "bad escape \u" exception.

[1]: https://github.com/lektor/lektor/blob/81d8e31c5aeee8ef7e8ffed55e5b2a6ba2977c41/lektor/admin/modules/serve.py#L83


<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->



<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes


- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
