### PR TITLE
dash blueprint: quote add-child endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,10 @@ jobs:
         include:
           - python: "3.12"
             install-ffmpeg: true
+          - os: "macos-latest"
+            # Omit test with older pillow versions on macOS.
+            # (Binary wheels not available?)
+            tox_skip_env: ".*-pillow"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -141,6 +145,8 @@ jobs:
           python -m pip install tox tox-gh-actions coverage[toml]
       - name: Run python tests
         run: tox
+        env:
+          TOX_SKIP_ENV: ${{ matrix.tox_skip_env }}
       - name: Publish coverage data to codecov
         uses: codecov/codecov-action@v3
 

--- a/lektor/admin/modules/dash.py
+++ b/lektor/admin/modules/dash.py
@@ -10,7 +10,7 @@ bp = Blueprint("dash", __name__, url_prefix="/admin")
 
 
 @bp.route("/", defaults={"page": ""})
-@bp.route("/<any(edit, delete, preview, add-child, upload):page>", endpoint="app")
+@bp.route("/<any(edit, delete, preview, 'add-child', upload):page>", endpoint="app")
 def app_view(**kwargs: Any) -> str:
     """Render the React admin GUI app."""
     # Note: client side app handles redirect from page='' to page='edit'


### PR DESCRIPTION
The add-child endpoint must be quoted, otherwise parsing fails and the endpoint will not be accessible.
For werkzeug < 3.0.2, parsing fails silently, for later versions, it fails with an exception.