### PR TITLE
CI: Provide explicit API token to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           TOX_SKIP_ENV: ${{ matrix.tox_skip_env }}
       - name: Publish coverage data to codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   ############################################################################
   # Package and (Possibly) Publish to PyPI


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

In #1191 the codecov action was upgrade to the latest version.  This broken codecov reporting because the latest version of the action now requires an explicit API token.

This is an alternative PR to #1192, which just removes the codecov.io reporting altogether.


