### PR TITLE
Fix and update CI tests in the 3.3-maintenance branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,21 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Install node dependencies
         run: make frontend/node_modules
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          # pylint==2.11.1 (pinned in tox.ini) will only run with python <=3.10
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "**/setup.cfg"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -66,8 +67,8 @@ jobs:
           - node: "current"
             os: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
@@ -107,8 +108,8 @@ jobs:
           - python: "3.11"
             install-imagemagick: true
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
@@ -154,4 +155,6 @@ jobs:
           coverage combine --append || true
           coverage xml
       - name: Publish coverage data to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,25 +87,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          - os: "macos-latest"
-            python: "3.8"
-          - os: "macos-latest"
-            python: "3.9"
-          - os: "macos-latest"
-            python: "3.10"
-          - os: "windows-latest"
-            python: "3.8"
-          - os: "windows-latest"
-            python: "3.9"
-          - os: "windows-latest"
-            python: "3.10"
+        os: ["ubuntu-latest"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - python: "3.6"
             os: "ubuntu-20.04"
-          - python: "3.11"
+          - python: "3.7"
+            os: "macos-latest"
+          - python: "3.12"
+            os: "macos-latest"
+          - python: "3.7"
+            os: "windows-latest"
+          - python: "3.12"
+            os: "windows-latest"
+
+          - python: "3.12"
             install-imagemagick: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         include:
           - python: "3.6"
             os: "ubuntu-20.04"
-          - python: "3.7"
+          - python: "3.8"
             os: "macos-latest"
           - python: "3.12"
             os: "macos-latest"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Build frontend

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -101,7 +101,7 @@ class WatcherTest:
                 # The FSEventObserver (used on macOS) seems to send events for things that
                 # happened before is was started.  Here, we wait a little bit for things to
                 # start, then discard any pre-existing events.
-                time.sleep(0.1)
+                time.sleep(1)
                 event.clear()
 
             yield self.watched_path

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 # workaround pip-cache issues when running 'tox parallel' (py37+)

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ commands =
     env PATH="{envbindir}" pytest --cov={envsitepackagesdir}/lektor {posargs:tests -ra}
 
 [testenv:lint]
+# pylint==2.11.1 (pinned below) will only run with python <=3.10
+base_python = py310
 deps =
     pylint==2.11.1
     pytest>=6

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
-minversion = 3.3
-envlist = lint,py36,py37,py38,py39,py310,py311{,-noutils}
+minversion = 3.28
+requires =
+    # https://tox.wiki/en/4.9.0/faq.html#testing-end-of-life-python-versions
+    virtualenv<20.22.0
+    tox-gh-actions
+# needed for tox3 (when running under py36)
 isolated_build = true
+
+envlist = lint,py36,py37,py38,py39,py310,py311,py312{,-noutils}
 
 [gh-actions]
 python =


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

Fixes various issues of bitrot with the CI tests for the 3.3-maintenance branch:

- Update to latest versions of workflow actions
- Add python 3.12 to the test matrix
- Python 3.7 seems no longer supported on the macos runner. Run Python 3.8 instead.
- Fix tox.ini so that the eol python tests will still run.
