### PR TITLE
Tests: Update to latest pylint (3.2.7)

### DIFF
--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -1,9 +1,9 @@
 import sys
 import warnings
+from collections.abc import Hashable
 from importlib import metadata
 from typing import Any
 from typing import Dict
-from typing import Hashable
 from typing import Optional
 from typing import Type
 from typing import TYPE_CHECKING

--- a/lektor/markdown/controller.py
+++ b/lektor/markdown/controller.py
@@ -1,11 +1,11 @@
 import threading
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import Hashable
 from typing import Mapping
 from typing import MutableMapping
 from typing import NamedTuple

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -7,11 +7,11 @@ import site
 import subprocess
 import sys
 import sysconfig
+from collections.abc import Sized
 from pathlib import Path
 from typing import Any
 from typing import Iterable
 from typing import Iterator
-from typing import Sized
 from typing import TYPE_CHECKING
 from venv import EnvBuilder
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -85,9 +85,11 @@ def _ssh_command(
         if key_file:
             args.append(f' -i "{key_file}" -o IdentitiesOnly=yes')
         if args:
-            yield "ssh" + " ".join(args)
+            ssh_command = "ssh" + " ".join(args)
         else:
-            yield None
+            ssh_command = None
+
+        yield ssh_command
 
 
 class PublishError(LektorException):

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -13,6 +13,7 @@ import unicodedata
 import urllib.parse
 import uuid
 import warnings
+from collections.abc import Hashable
 from contextlib import contextmanager
 from contextlib import suppress
 from dataclasses import dataclass
@@ -23,7 +24,6 @@ from pathlib import PurePosixPath
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Hashable
 from typing import Iterable
 from typing import overload
 from typing import TypeVar
@@ -410,6 +410,8 @@ class Url(urllib.parse.SplitResult):
     the IRI (internationalized) version of the query.
 
     """
+
+    url: str
 
     def __new__(cls, value: str):
         # XXX: deprecate use of constructor so that eventually we can make its signature

--- a/tox.ini
+++ b/tox.ini
@@ -71,10 +71,10 @@ commands =
     env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
 [testenv:lint]
-base_python = py311,py310,py39
+base_python = py312,py311,py310,py39
 use_develop = true
 deps =
-    pylint==2.17.5
+    pylint==3.2.7
     pytest>=6
     pytest-mock
     importlib_metadata; python_version<"3.10"


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

We were pinned to pylint 2.17.5, which doesn't seem to even run under Python 3.12.


### Description of Changes

Also fixed are a few minor issues surfaced by the newer pylint.


