### PR TITLE
📦 Upload dists to PyPI in a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   ############################################################################
-  # Package and (Possibly) Publish to PyPI
+  # Build distribution packages
   ############################################################################
-  deploy:
-    needs: ["lint", "node-tests", "python-tests"]
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -177,14 +176,38 @@ jobs:
           HATCH_BUILD_CLEAN: "true"
         run: python -m build
 
-      - name: Save release artifacts (for inspection)
+      - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: python-package-distributions
           path: dist/
 
-      - name: Publish release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  ############################################################################
+  # (Possibly) Publish to PyPI
+  ############################################################################
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
+    needs:
+      - build
+      - lint
+      - node-tests
+      - python-tests
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Lektor
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This is important because it allows migrating to Trusted Publishing safely [[1]]. Which in turn will enable the maintainers to revoke the API token secret making the publishing tokenless and will start uploading digital attestations.

The environment called `pypi` will have to be set up as trusted on the PyPI side and might benefit from having manual approvals within the repository settings.

[1]: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/