### PR TITLE
🧪🚑 Cap Pillow below v11 in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     tzdata: tzdata
     pillow6: pillow<7.0
     pillow7: pillow<7.1.0
+    pillow < 11  # https://github.com/lektor/lektor/issues/1200
 depends =
     py{38,39,310,311,312}: cover-clean
     cover-report: py{38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}


### PR DESCRIPTION
TODO: Revert this commit as soon as compatibility with the latest version of Pillow is restored.

Ref #1200