### PR TITLE
Fix.1200 thumbnail xmp metadata

### DIFF
--- a/lektor/imagetools/thumbnail.py
+++ b/lektor/imagetools/thumbnail.py
@@ -374,8 +374,9 @@ def _create_thumbnail(
     # Convert from any embedded ICC color profile to sRGB.
     _convert_icc_profile_to_srgb(thumbnail)
 
-    # Do not propate comment tag to thumbnail
+    # Do not propagate comment tag, or XMP data to thumbnail
     thumbnail.info.pop("comment", None)
+    thumbnail.info.pop("xmp", None)
 
     return thumbnail
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ deps =
     tzdata: tzdata
     pillow6: pillow<7.0
     pillow7: pillow<7.1.0
-    pillow < 11  # https://github.com/lektor/lektor/issues/1200
 depends =
     py{38,39,310,311,312}: cover-clean
     cover-report: py{38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1200

<!---

### Related Issues / Links

Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

Ensure the any XMP metadata in images is not propagated to generated thumbnails.
