### PR TITLE
Drop python 3.8 support, add python 3.13 support, update linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,28 +88,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: "macos-latest"
-            python: "3.9"
-          - os: "macos-latest"
-            python: "3.10"
-          - os: "macos-latest"
-            python: "3.11"
-          - os: "windows-latest"
-            python: "3.9"
-          - os: "windows-latest"
-            python: "3.10"
-          - os: "windows-latest"
-            python: "3.11"
+        os: ["ubuntu-latest"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         include:
-          - python: "3.12"
-            install-ffmpeg: true
-          - os: "macos-latest"
-            # Omit test with older pillow versions on macOS.
-            # (Binary wheels not available?)
-            tox_skip_env: ".*-pillow"
+          - { os: "macos-latest", python: "3.9" }
+          - { os: "macos-latest", python: "3.12", install-ffmpeg: true }
+          - { os: "windows-latest", python: "3.9" }
+          - { os: "windows-latest", python: "3.12", install-ffmpeg: true }
+          - { python: "3.12", install-ffmpeg: true }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: make frontend/node_modules
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.x"
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
       - uses: actions/cache@v4
@@ -89,13 +89,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - { os: "macos-latest", python: "3.9" }
-          - { os: "macos-latest", python: "3.12", install-ffmpeg: true }
+          - { os: "macos-latest", python: "3.13", install-ffmpeg: true }
           - { os: "windows-latest", python: "3.9" }
-          - { os: "windows-latest", python: "3.12", install-ffmpeg: true }
-          - { python: "3.12", install-ffmpeg: true }
+          - { os: "windows-latest", python: "3.13", install-ffmpeg: true }
+          - { python: "3.13", install-ffmpeg: true }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,22 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: "23.7.0"
+    # black >= 24 is incompatible with reorder-python-imports
+    # See https://github.com/psf/black/issues/4175
+    rev: "23.12.1"
     hooks:
       - id: black
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: "v3.10.0"
+    rev: "v3.14.0"
     hooks:
       - id: reorder-python-imports
         args: ["--py38-plus"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.15.0"
+    rev: "v3.19.0"
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/pycqa/flake8
-    rev: "6.1.0"
+    rev: "7.1.1"
     hooks:
       - id: flake8
         language_version: python3
@@ -22,7 +24,7 @@ repos:
           # NB: autoupdate does not pick up flake8-bugbear since it is a
           # transitive dependency. Make sure to update flake8-bugbear
           # manually on a regular basis.
-          - flake8-bugbear==23.7.10
+          - flake8-bugbear==24.10.31
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
     rev: "v3.14.0"
     hooks:
       - id: reorder-python-imports
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
   - repo: https://github.com/asottile/pyupgrade
     rev: "v3.19.0"
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
   - repo: https://github.com/pycqa/flake8
     rev: "7.1.1"
     hooks:

--- a/lektor/admin/modules/api.py
+++ b/lektor/admin/modules/api.py
@@ -1,14 +1,13 @@
 import os
 import posixpath
+from collections.abc import Iterator
+from collections.abc import Mapping
 from dataclasses import dataclass
 from dataclasses import field
 from functools import wraps
 from typing import Any
 from typing import Callable
 from typing import cast
-from typing import Dict
-from typing import Iterator
-from typing import Mapping
 from typing import Optional
 from typing import TypeVar
 
@@ -40,7 +39,7 @@ bp = Blueprint("api", __name__, url_prefix="/admin/api")
 
 @bp.url_value_preprocessor
 def pass_lektor_context(
-    endpoint: Optional[str], values: Optional[Dict[str, Any]]
+    endpoint: Optional[str], values: Optional[dict[str, Any]]
 ) -> None:
     """Pass LektorContext to each view callable in a `ctx` parameter"""
     assert isinstance(values, dict)
@@ -282,7 +281,7 @@ def get_new_record_info(validated: _PathAndAlt, ctx: LektorContext) -> Response:
     alt = validated.alt
     tree_item = ctx.tree.get(validated.path)
 
-    def describe_model(model: DataModel) -> Dict[str, Any]:
+    def describe_model(model: DataModel) -> dict[str, Any]:
         primary_field = None
         if model.primary_field is not None:
             f = model.field_map.get(model.primary_field)
@@ -356,7 +355,7 @@ def upload_new_attachments(validated: _PathAndAlt, ctx: LektorContext) -> Respon
 class _NewRecordParams:
     id: str
     model: Optional[str]
-    data: Dict[str, Optional[str]]
+    data: dict[str, Optional[str]]
     path: _PathType
     alt: _AltType = PRIMARY_ALT
 
@@ -400,7 +399,7 @@ def delete_record(validated: _DeleteRecordParams, ctx: LektorContext) -> Respons
 
 @dataclass
 class _UpdateRawRecordParams:
-    data: Dict[str, Optional[str]]
+    data: dict[str, Optional[str]]
     path: _PathType
     alt: _AltType = PRIMARY_ALT
 
@@ -451,7 +450,7 @@ class _PublishBuildParams:
 @_with_validated(_PublishBuildParams)
 def publish_build(validated: _PublishBuildParams, ctx: LektorContext) -> Response:
     @eventstream
-    def generator() -> Iterator[Dict[str, str]]:
+    def generator() -> Iterator[dict[str, str]]:
         try:
             event_iter = (
                 publish(

--- a/lektor/admin/modules/livereload.py
+++ b/lektor/admin/modules/livereload.py
@@ -22,7 +22,7 @@ version_id = secrets.token_urlsafe(16)
 
 @bp.route("/events")
 @eventstream
-def events() -> Generator[dict[str, str], None, None]:
+def events() -> Generator[dict[str, str]]:
     updated_artifacts: queue.Queue[Artifact] = queue.Queue()
     with reporter.on_build_change(updated_artifacts.put):
         while True:

--- a/lektor/admin/modules/livereload.py
+++ b/lektor/admin/modules/livereload.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import queue
 import secrets
-from typing import Generator
+from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 from flask import Blueprint

--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 bp = Blueprint("serve", __name__)
 
 
-Filename = Union[str, os.PathLike]
+Filename = Union[str, os.PathLike[str]]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/lektor/admin/utils.py
+++ b/lektor/admin/utils.py
@@ -1,9 +1,9 @@
+from collections.abc import Iterable
+from collections.abc import Iterator
 from functools import update_wrapper
 from itertools import chain
 from typing import Any
 from typing import Callable
-from typing import Iterable
-from typing import Iterator
 
 from flask import json
 from flask import Response

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -66,7 +66,7 @@ class Asset(SourceObject):
         self.parent = parent
         self._paths = paths
 
-    def iter_source_filenames(self) -> Generator[str, None, None]:
+    def iter_source_filenames(self) -> Generator[str]:
         yield from map(str, self._paths)
 
     @property
@@ -128,7 +128,7 @@ class Directory(Asset):
     def _children_by_name(self) -> dict[str, Asset]:
         return {asset.name: asset for asset in self._iter_children()}
 
-    def _iter_children(self) -> Generator[Asset, None, None]:
+    def _iter_children(self) -> Generator[Asset]:
         env = self.pad.env
         candidates_by_name = defaultdict(list)
         for path in self._paths:

--- a/lektor/assets.py
+++ b/lektor/assets.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import posixpath
 import warnings
 from collections import defaultdict
+from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Sequence
 from contextlib import suppress
 from itertools import takewhile
 from operator import methodcaller
 from pathlib import Path
-from typing import Generator
-from typing import Iterable
-from typing import Sequence
 from typing import TYPE_CHECKING
 
 from werkzeug.utils import cached_property

--- a/lektor/context.py
+++ b/lektor/context.py
@@ -196,7 +196,7 @@ class Context:
         """Decorator version of :func:`add_sub_artifact`."""
 
         def decorator(f):
-            self.add_sub_artifact(build_func=f, *args, **kwargs)
+            self.add_sub_artifact(*args, build_func=f, **kwargs)
             return f
 
         return decorator

--- a/lektor/imagetools/_compat.py
+++ b/lektor/imagetools/_compat.py
@@ -1,11 +1,11 @@
 """Compatibility with various versions of Pillow."""
 from __future__ import annotations
 
+from collections.abc import Iterable
+from collections.abc import Mapping
 from enum import IntEnum
 from types import ModuleType
 from types import SimpleNamespace
-from typing import Iterable
-from typing import Mapping
 
 import PIL.ExifTags
 import PIL.Image

--- a/lektor/imagetools/exif.py
+++ b/lektor/imagetools/exif.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import numbers
 import sys
+from collections.abc import Mapping
 from datetime import datetime
 from fractions import Fraction
 from functools import wraps
 from pathlib import Path
 from typing import Any
 from typing import Callable
-from typing import Mapping
-from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
@@ -101,8 +100,8 @@ def _to_string(value: str) -> str:
 
 # NB: Older versions of Pillow return (numerator, denominator) tuples
 # for EXIF rational numbers.  New versions return a Fraction instance.
-ExifRational: TypeAlias = Union[numbers.Rational, Tuple[int, int]]
-ExifReal: TypeAlias = Union[numbers.Real, Tuple[int, int]]
+ExifRational: TypeAlias = Union[numbers.Rational, tuple[int, int]]
+ExifReal: TypeAlias = Union[numbers.Real, tuple[int, int]]
 
 
 def _to_rational(value: ExifRational) -> numbers.Rational:

--- a/lektor/imagetools/image_info.py
+++ b/lektor/imagetools/image_info.py
@@ -6,14 +6,14 @@ import enum
 import re
 import sys
 import warnings
+from collections.abc import Generator
+from collections.abc import Mapping
 from contextlib import contextmanager
 from contextlib import ExitStack
 from contextlib import suppress
 from pathlib import Path
 from typing import BinaryIO
 from typing import Final
-from typing import Generator
-from typing import Mapping
 from typing import NamedTuple
 from typing import TYPE_CHECKING
 from typing import Union

--- a/lektor/imagetools/image_info.py
+++ b/lektor/imagetools/image_info.py
@@ -174,7 +174,7 @@ def _PIL_image_info(
 
 
 @contextmanager
-def _save_position(fp: BinaryIO) -> Generator[BinaryIO, None, None]:
+def _save_position(fp: BinaryIO) -> Generator[BinaryIO]:
     position = fp.tell()
     try:
         yield fp

--- a/lektor/imagetools/thumbnail.py
+++ b/lektor/imagetools/thumbnail.py
@@ -5,17 +5,17 @@ import dataclasses
 import io
 import math
 import posixpath
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from enum import Enum
 from functools import partial
 from pathlib import Path
 from typing import Any
 from typing import ClassVar
 from typing import Final
-from typing import Iterable
-from typing import Iterator
-from typing import Mapping
 from typing import NamedTuple
-from typing import Sequence
 from typing import TYPE_CHECKING
 
 import PIL.Image

--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -3,9 +3,7 @@ import warnings
 from collections.abc import Hashable
 from importlib import metadata
 from typing import Any
-from typing import Dict
 from typing import Optional
-from typing import Type
 from typing import TYPE_CHECKING
 from weakref import ref as weakref
 
@@ -23,7 +21,7 @@ from lektor.utils import DeprecatedWarning
 if TYPE_CHECKING:  # pragma: no cover
     from lektor.environment import Environment
 
-controller_class: Type[MarkdownController]
+controller_class: type[MarkdownController]
 
 
 MISTUNE_VERSION = metadata.version("mistune")
@@ -45,7 +43,7 @@ class Markdown:
         self.source = source
         self.__record = weakref(record) if record is not None else None
         self.__field_options = field_options
-        self.__cache: Dict[Hashable, RenderResult] = {}
+        self.__cache: dict[Hashable, RenderResult] = {}
 
     def __bool__(self) -> bool:
         return bool(self.source)

--- a/lektor/markdown/controller.py
+++ b/lektor/markdown/controller.py
@@ -2,12 +2,11 @@ import threading
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Hashable
+from collections.abc import Mapping
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import Mapping
-from typing import MutableMapping
 from typing import NamedTuple
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -30,7 +29,7 @@ class _Threadlocal(threading.local):
 
 _threadlocal = _Threadlocal()
 
-Meta = Dict[str, Any]
+Meta = dict[str, Any]
 FieldOptions = Mapping[str, str]
 
 

--- a/lektor/markdown/mistune0.py
+++ b/lektor/markdown/mistune0.py
@@ -1,7 +1,6 @@
 """MarkdownController implementation for mistune 0.x"""
 import threading
 from typing import ClassVar
-from typing import List
 from typing import Optional
 
 import mistune  # type: ignore[import]
@@ -52,7 +51,7 @@ class MarkdownConfig:
             "escape": False,
         }
         self.renderer_base = ImprovedRenderer
-        self.renderer_mixins: List[type] = []
+        self.renderer_mixins: list[type] = []
 
     def make_renderer(self) -> ImprovedRenderer:
         bases = tuple(self.renderer_mixins) + (self.renderer_base,)

--- a/lektor/markdown/mistune2.py
+++ b/lektor/markdown/mistune2.py
@@ -1,10 +1,10 @@
 """MarkdownController implementation for mistune 2.x"""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from importlib import import_module
 from typing import Callable
 from typing import ClassVar
-from typing import Sequence
 from typing import TypedDict
 
 import mistune.util

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -7,10 +7,10 @@ import site
 import subprocess
 import sys
 import sysconfig
+from collections.abc import Iterable
+from collections.abc import Iterator
 from collections.abc import Sized
 from pathlib import Path
-from typing import Iterable
-from typing import Iterator
 from typing import TYPE_CHECKING
 from venv import EnvBuilder
 

--- a/lektor/packages.py
+++ b/lektor/packages.py
@@ -9,7 +9,6 @@ import sys
 import sysconfig
 from collections.abc import Sized
 from pathlib import Path
-from typing import Any
 from typing import Iterable
 from typing import Iterator
 from typing import TYPE_CHECKING
@@ -128,17 +127,13 @@ class VirtualEnv:
         #
         # Note that, e.g., pip>=21.3 is required to support PEP660 editable
         # installs.
-        options: dict[str, Any] = {
-            "clear": True,
-            "with_pip": with_pip,
-            "symlinks": symlinks,
-        }
-        if sys.version_info >= (3, 9):
-            EnvBuilder(upgrade_deps=upgrade_deps, **options).create(self.path)
-        else:
-            EnvBuilder(**options).create(self.path)
-            if upgrade_deps:
-                self.run_pip_install("--upgrade", "pip", "setuptools")
+        env_builder = EnvBuilder(
+            clear=True,
+            with_pip=with_pip,
+            upgrade_deps=upgrade_deps,
+            symlinks=symlinks,
+        )
+        env_builder.create(self.path)
 
     def addsitedir(self, sitedir: str) -> None:
         """Add an additional sitedir to sys.path for virtual environment.

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
+from contextlib import AbstractContextManager
 from contextlib import contextmanager
 from contextlib import ExitStack
 from contextlib import suppress
@@ -25,7 +26,6 @@ from subprocess import STDOUT
 from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Callable
-from typing import ContextManager
 from typing import NoReturn
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -96,7 +96,7 @@ class PublishError(LektorException):
     """Raised by publishers if something goes wrong."""
 
 
-class Command(ContextManager["Command"]):
+class Command(AbstractContextManager["Command"]):
     """A wrapper around subprocess.Popen to facilitate streaming output via generator.
 
     :param argline: Command with arguments to execute.
@@ -638,7 +638,7 @@ class FtpTlsPublisher(FtpPublisher):
     connection_class = FtpTlsConnection
 
 
-class GitRepo(ContextManager["GitRepo"]):
+class GitRepo(AbstractContextManager["GitRepo"]):
     """A temporary git repository.
 
     This class provides some lower-level utility methods which may be

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -6,6 +6,11 @@ import io
 import os
 import posixpath
 import urllib.parse
+from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Mapping
+from collections.abc import Sequence
 from contextlib import contextmanager
 from contextlib import ExitStack
 from contextlib import suppress
@@ -21,12 +26,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Callable
 from typing import ContextManager
-from typing import Generator
-from typing import Iterable
-from typing import Iterator
-from typing import Mapping
 from typing import NoReturn
-from typing import Sequence
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 from warnings import warn

--- a/lektor/types/primitives.py
+++ b/lektor/types/primitives.py
@@ -150,7 +150,8 @@ class DateTimeType(SingleInputType):
             try:
                 tz = get_timezone(timezone)
                 zoneoffset = None
-            except LookupError:
+            # NB: under py39 on windows with tzdata, zoneinfo.ZoneInfo can raise ValueError
+            except (LookupError, ValueError):
                 if zoneoffset is None:
                     return raw.bad_value(f"Unknown timezone {timezone!r}")
 

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -14,6 +14,7 @@ import urllib.parse
 import uuid
 import warnings
 from collections.abc import Hashable
+from collections.abc import Iterable
 from contextlib import contextmanager
 from contextlib import suppress
 from dataclasses import dataclass
@@ -24,7 +25,6 @@ from pathlib import PurePosixPath
 from typing import Any
 from typing import Callable
 from typing import ClassVar
-from typing import Iterable
 from typing import overload
 from typing import TypeVar
 

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -481,7 +481,7 @@ def is_unsafe_to_delete(path, base):
     a = os.path.abspath(path)
     b = os.path.abspath(base)
     diff = os.path.relpath(a, b)
-    first = diff.split(os.path.sep)[0]
+    first = diff.split(os.path.sep, maxsplit=1)[0]
     return first in (os.path.curdir, os.path.pardir)
 
 

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Generator
 from typing import Any
-from typing import Generator
 from typing import TYPE_CHECKING
 
 import watchfiles

--- a/lektor/watcher.py
+++ b/lektor/watcher.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 def watch_project(
     env: Environment, output_path: StrPath, **kwargs: Any
-) -> Generator[set[watchfiles.FileChange], None, None]:
+) -> Generator[set[watchfiles.FileChange]]:
     """Watch project source files for changes.
 
     Returns an generator that yields sets of changes as they are noticed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -32,7 +31,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "Babel",
     "click>=6.0",
@@ -46,10 +45,9 @@ dependencies = [
     "Pillow>=6",
     "pip",
     "python-slugify",
-    "pytz; python_version<'3.9'",  # favor zoneinfo for python>=3.9
     "requests",
     "typing-extensions>=3.10; python_version<'3.10'",
-    "tzdata; python_version>='3.9' and sys_platform == 'win32'",
+    "tzdata; sys_platform == 'win32'",
     "watchfiles>=0.12",
     "Werkzeug>=2.1.0",
 ]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -5,11 +5,11 @@ import shutil
 import sys
 import threading
 import warnings
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
-from typing import Generator
 
 import pytest
 from watchfiles import Change

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -58,7 +58,7 @@ class WatcherTest:
     def __call__(
         self,
         timeout: float = 1.2,
-    ) -> Generator[WatchResult, None, None]:
+    ) -> Generator[WatchResult]:
         """Run watch_project in a separate thread, wait for a file change event.
 
         This is a context manager that runs watch_project in a separate thread.
@@ -80,7 +80,7 @@ class WatcherTest:
     def watch(
         self,
         timeout: float,
-    ) -> Generator[WatchResult, None, None]:
+    ) -> Generator[WatchResult]:
         """Run watch_project in a separate thread, wait for a file change event."""
         running = threading.Event()
         stop = threading.Event()

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,14 @@
 minversion = 4.1
 envlist =
     lint
-    {py38,py39,py310,py311,py312}{,-mistune0}
+    {py39,py310,py311,py312}{,-mistune0}
     py311-noutils
-    py311-pytz
     py311-tzdata
-    py38-pillow6
-    py38-pillow7
     cover-{clean,report}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38, cover
     3.9: py39, cover
     3.10: py310, cover
     3.11: py311, cover
@@ -27,7 +23,7 @@ setenv =
     # skip building frontend js/css
     HATCH_BUILD_NO_HOOKS=true
     # do not run marked slow tests in every variant testenv
-    {mistune0,noutils,pytz,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
+    {mistune0,noutils,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
 deps =
     pytest>=6
     pytest-click
@@ -37,13 +33,10 @@ deps =
     iniconfig
     hatchling
     mistune0: mistune<2
-    pytz: pytz
     tzdata: tzdata
-    pillow6: pillow<7.0
-    pillow7: pillow<7.1.0
 depends =
-    py{38,39,310,311,312}: cover-clean
-    cover-report: py{38,39,310,311,312}{,-mistune0,-noutils,-pytz,-tzdata,-pillow6,-pillow7}
+    py{39,310,311,312}: cover-clean
+    cover-report: py{39,310,311,312}{,-mistune0,-noutils,-tzdata}
 # XXX: I've been experiencing sporadic failures when running tox in parallel mode.
 # The crux of the error messages when this happens appears to be something like:
 #
@@ -63,7 +56,7 @@ depends =
 # Hopefully, at some point this can be removed.
 download = true
 
-[testenv:py{38,39,310,311,312}-noutils]
+[testenv:py{39,310,311,312}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.1
 envlist =
     lint
-    {py39,py310,py311,py312}{,-mistune0}
+    {py39,py310,py311,py312,py313}{,-mistune0}
     py311-noutils
     py311-tzdata
     cover-{clean,report}
@@ -14,6 +14,7 @@ python =
     3.10: py310, cover
     3.11: py311, cover
     3.12: py312, cover
+    3.13: py313, cover
 
 [testenv]
 commands =
@@ -35,8 +36,8 @@ deps =
     mistune0: mistune<2
     tzdata: tzdata
 depends =
-    py{39,310,311,312}: cover-clean
-    cover-report: py{39,310,311,312}{,-mistune0,-noutils,-tzdata}
+    py{39,310,311,312,313}: cover-clean
+    cover-report: py{39,310,311,312,313}{,-mistune0,-noutils,-tzdata}
 # XXX: I've been experiencing sporadic failures when running tox in parallel mode.
 # The crux of the error messages when this happens appears to be something like:
 #
@@ -56,7 +57,7 @@ depends =
 # Hopefully, at some point this can be removed.
 download = true
 
-[testenv:py{39,310,311,312}-noutils]
+[testenv:py{39,310,311,312,313}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env
@@ -64,7 +65,7 @@ commands =
     env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
 [testenv:lint]
-base_python = py312,py311,py310,py39
+base_python = py313,py312,py311,py310,py39
 use_develop = true
 deps =
     pylint==3.2.7


### PR DESCRIPTION
This PR drops support for python 3.8 (which is EOL), and adds testing under python 3.13.
It also updates the versions of pylint and various pre-commit hooks, and adjusts the code to keep those linters happy.
