### PR TITLE
🧪 Introduce a unified gate/check GHA job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -170,17 +170,40 @@ jobs:
           path: dist/
 
   ############################################################################
-  # (Possibly) Publish to PyPI
+  # Branch protection gate
   ############################################################################
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
+  check: # This job does nothing and is only used for the branch protection
+    name: All tests passed
+    if: always()
+
     needs:
       - build
       - lint
       - node-tests
       - python-tests
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+  ############################################################################
+  # (Possibly) Publish to PyPI
+  ############################################################################
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: >- # only publish to PyPI on tag pushes
+      always()
+      && github.ref_type == 'tag'
+      && needs.check.result == 'success'
+    needs:
+      - check
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

I was curious about the spread of use. And I've just discovered that it is now in use in aiohttp (and other aio-libs projects), CherryPy, some of the Ansible repositories, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some PyCQA and pytest projects, a few AWS Labs projects (to my surprise), CPython and many others. Admitedly, I maintain some of these but it does address some of the real pain folks have:
https://github.com/jaraco/skeleton/pull/55#issuecomment-1106638475.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.