### PR TITLE
Update to pylint 3.3

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -666,6 +666,7 @@ class Artifact:
         artifact_name,
         dst_filename,
         sources,
+        *,
         source_obj=None,
         extra=None,
         config_hash=None,

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -92,6 +92,7 @@ def cli(ctx, project=None, language=None):
 @pass_context
 def build_cmd(
     ctx,
+    *,
     output_path,
     watch,
     prune,
@@ -175,7 +176,7 @@ def build_cmd(
 @click.confirmation_option(help="Confirms the cleaning.")
 @extraflag
 @pass_context
-def clean_cmd(ctx, output_path, verbosity, extra_flags):
+def clean_cmd(ctx, *, output_path, verbosity, extra_flags):
     """Cleans the entire build folder.
 
     If not build folder is provided, the default build folder of the project
@@ -229,7 +230,7 @@ def clean_cmd(ctx, output_path, verbosity, extra_flags):
 )
 @extraflag
 @pass_context
-def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
+def deploy_cmd(ctx, *, server, output_path, extra_flags, **credentials):
     """This command deploys the entire contents of the build folder
     (`--output-path`) onto a configured remote server.  The name of the
     server must fit the name from a target in the project configuration.
@@ -324,7 +325,7 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 @extraflag
 @click.option("--browse", is_flag=True)
 @pass_context
-def server_cmd(ctx, host, port, output_path, prune, verbosity, extra_flags, browse):
+def server_cmd(ctx, *, host, port, output_path, prune, verbosity, extra_flags, browse):
     """The server command will launch a local server for development.
 
     Lektor's development server will automatically build all files into
@@ -382,7 +383,7 @@ def server_cmd(ctx, host, port, output_path, prune, verbosity, extra_flags, brow
     help="Print the path to the package cache.",
 )
 @pass_context
-def project_info_cmd(ctx, as_json, **opts):
+def project_info_cmd(ctx, *, as_json, **opts):
     """Prints out information about the project.  This is particular
     useful for script usage or for discovering information about a
     Lektor project that is not immediately obvious (like the paths
@@ -412,7 +413,7 @@ def project_info_cmd(ctx, as_json, **opts):
 @click.option("as_json", "--json", is_flag=True, help="Prints out the data as json.")
 @click.argument("files", nargs=-1, type=click.Path(dir_okay=False))
 @pass_context
-def content_file_info_cmd(ctx, files, as_json):
+def content_file_info_cmd(ctx, files, *, as_json):
     """Given a list of files this returns the information for those files
     in the context of a project.  If the files are from different projects
     an error is generated.
@@ -539,7 +540,7 @@ def plugins_remove_cmd(ctx, name):
     help="Increases the verbosity of the output.",
 )
 @pass_context
-def plugins_list_cmd(ctx, as_json, verbosity):
+def plugins_list_cmd(ctx, *, as_json, verbosity):
     """This returns a list of all currently actively installed plugins
     in the project.  By default it only prints out the plugin IDs and
     version numbers but the entire information can be returned by

--- a/lektor/datamodel.py
+++ b/lektor/datamodel.py
@@ -19,6 +19,7 @@ from lektor.utils import slugify
 class ChildConfig:
     def __init__(
         self,
+        *,
         enabled=None,
         slug_format=None,
         model=None,
@@ -47,7 +48,9 @@ class ChildConfig:
 
 
 class PaginationConfig:
-    def __init__(self, env, enabled=None, per_page=None, url_suffix=None, items=None):
+    def __init__(
+        self, env, *, enabled=None, per_page=None, url_suffix=None, items=None
+    ):
         self.env = env
         if enabled is None:
             enabled = False
@@ -153,7 +156,7 @@ class PaginationConfig:
 
 
 class AttachmentConfig:
-    def __init__(self, enabled=None, model=None, order_by=None, hidden=None):
+    def __init__(self, *, enabled=None, model=None, order_by=None, hidden=None):
         if enabled is None:
             enabled = True
         if hidden is None:
@@ -231,6 +234,7 @@ class DataModel:
         env,
         id,
         name_i18n,
+        *,
         label_i18n=None,
         filename=None,
         hidden=None,
@@ -394,6 +398,7 @@ class FlowBlockModel:
         env,
         id,
         name_i18n,
+        *,
         filename=None,
         fields=None,
         order=None,

--- a/lektor/devserver.py
+++ b/lektor/devserver.py
@@ -93,6 +93,7 @@ def run_server(
     bindaddr: BindAddr,
     env: Environment,
     output_path: StrPath,
+    *,
     prune: bool = True,
     verbosity: int = 0,
     lektor_dev: bool = False,

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -106,13 +106,13 @@ def make_editor_session(pad, path, is_attachment=None, alt=PRIMARY_ALT, datamode
         pad,
         id,
         str(path),
-        raw_data,
-        raw_data_fallback,
-        datamodel,
-        record,
-        exists,
-        is_attachment,
-        alt,
+        original_data=raw_data,
+        fallback_data=raw_data_fallback,
+        datamodel=datamodel,
+        record=record,
+        exists=exists,
+        is_attachment=is_attachment,
+        alt=alt,
     )
 
 
@@ -143,6 +143,7 @@ class EditorSession:
         pad,
         id,
         path,
+        *,
         original_data,
         fallback_data,
         datamodel,

--- a/lektor/imagetools/thumbnail.py
+++ b/lektor/imagetools/thumbnail.py
@@ -410,6 +410,7 @@ def make_image_thumbnail(
     ctx: Context,
     source_image: str | Path,
     source_url_path: str,
+    *,
     width: int | None = None,
     height: int | None = None,
     mode: ThumbnailMode = ThumbnailMode.DEFAULT,

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -149,6 +149,7 @@ class Command(AbstractContextManager["Command"]):
     def __init__(
         self,
         argline: Iterable[str],
+        *,
         cwd: StrOrBytesPath | None = None,
         env: Mapping[str, str] | None = None,
         capture: bool = True,

--- a/lektor/sourceobj.py
+++ b/lektor/sourceobj.py
@@ -105,6 +105,7 @@ class SourceObject:
     def url_to(
         self,
         path,  # : Union[str, "SourceObject", "SupportsUrlPath"]
+        *,
         alt: str | None = None,
         absolute: bool | None = None,
         external: bool | None = None,

--- a/lektor/videotools.py
+++ b/lektor/videotools.py
@@ -280,6 +280,7 @@ def make_video_thumbnail(
     source_video,
     source_url_path,
     seek,
+    *,
     width=None,
     height=None,
     mode=ThumbnailMode.DEFAULT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,12 @@ max-module-lines = 2000
 
 [tool.pylint.design]
 max-attributes = 20
+max-positional-arguments = 7   # default is 5
 max-locals = 30
 max-branches = 20
 max-nested-blocks = 8
 max-returns = 8
+
 
 [tool.pylint."messages control"]
 disable = [

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 base_python = py313,py312,py311,py310,py39
 use_develop = true
 deps =
-    pylint==3.3.1
+    pylint==3.3.2
     pytest>=6
     pytest-mock
     importlib_metadata; python_version<"3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 base_python = py313,py312,py311,py310,py39
 use_develop = true
 deps =
-    pylint==3.2.7
+    pylint==3.3.1
     pytest>=6
     pytest-mock
     importlib_metadata; python_version<"3.10"


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

This updates the version of pylint we use to 3.3.1 (the latest).

### Issue(s) Resolved

Pylint 3.2.x does not support running under python 3.13 (see, e.g., pylint-dev/pylint#10000).


<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Related Issues / Links

Pylint 3.3 introduces a new check [too-many-positional-arguments] that looks for functions with (drum roll) too many (by default, more than five) positional arguments.

This does seem to be a valid stylistic concern.

Currently, to address this new warning, this PR does two things:
- Increases `max-positional-arguments` to 7 (from the default of 5).
- For a number of existing functions that currently accept large numbers of positional arguments, mark excess arguments as keyword-only.
 
Most of the functions whose signatures are modified are internal-use only.  None are documented API.  I think the chance of breaking user code is minimal.

An alternative to making these changes would be to simply ignore the new check. 


[too-many-positional-arguments]: https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html
