### PR TITLE
🧪💅 Unify running linters via pre-commit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      TOXENV: pre-commit
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -44,15 +46,35 @@ jobs:
       - name: Install python dependencies
         id: pip
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox pre-commit
+          python -m pip install tox
           python -m pip freeze --local
-      - name: Run pylint
-        run: tox -e lint
-      - name: Run pre-commit
-        # run pre-commit check even if pylint check fails
-        if: steps.pip.outcome == 'success'
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Pre-populate ${{ env.TOXENV }} tox env
+        run: >-
+          python -Im
+          tox
+          --parallel auto
+          --parallel-live
+          --skip-missing-interpreters false
+          --notest
+      - name: Initialize ${{ env.TOXENV }} envs
+        run: >-
+          python -Im
+          tox
+          exec
+          --skip-pkg-install
+          --quiet
+          --
+          python -Im pre_commit install-hooks
+      - name: Run ${{ env.TOXENV }}
+        id: tox-run
+        run: >-
+          python -Im
+          tox
+          --parallel auto
+          --parallel-live
+          --skip-missing-interpreters false
+          --skip-pkg-install
+          --quiet
 
   ############################################################################
   # Node tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,34 @@ repos:
         entry: ./frontend/node_modules/prettier/bin/prettier.cjs --write --list-different
         require_serial: true
         files: \.(ts|tsx|js|less|ya?ml|md)$
+
+  - repo: https://github.com/PyCQA/pylint.git
+    # rev: v3.3.1
+    rev: v3.2.7
+    hooks:
+      - id: pylint
+        additional_dependencies:
+          - hatchling # distribution package build backend
+          - Babel # runtime
+          - click >= 6.0 # runtime
+          - Flask # runtime
+          - inifile >= 0.4.1 # runtime
+          - Jinja2 >= 3.0 # runtime
+          - MarkupSafe # runtime
+          - marshmallow # runtime
+          - marshmallow_dataclass >= 8.5.9 # runtime
+          - mistune >=0.7.0, <3 # runtime
+          - Pillow >= 6 # runtime
+          - pip # runtime
+          - python-slugify # runtime
+          - requests # runtime
+          - typing-extensions >= 3.10; python_version < '3.10' # runtime
+          - tzdata; sys_platform == 'win32' # runtime
+          - watchfiles >= 0.12 # runtime
+          - Werkzeug >= 2.1.0 # runtime
+          - ipython # runtime, additional through `ipython` extra
+          - traitlets # runtime, additional through `ipython` extra
+          - pytest >= 6 # tests
+          - pytest-mock # tests
+          - importlib_metadata; python_version < "3.10" # tests
+          - iniconfig # tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,17 @@
 [tox]
 minversion = 4.1
 envlist =
-    lint
+    pre-commit
     {py39,py310,py311,py312,py313}{,-mistune0}
     py311-noutils
     py311-tzdata
     cover-{clean,report}
 isolated_build = true
+
+[python-cli-options]
+byte-errors = -bb
+max-isolation = -E -s -I
+warnings-to-errors = -Werror
 
 [gh-actions]
 python =
@@ -64,17 +69,128 @@ allowlist_externals = env
 commands =
     env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
-[testenv:lint]
-base_python = py313,py312,py311,py310,py39
-use_develop = true
-deps =
-    pylint==3.2.7
-    pytest>=6
-    pytest-mock
-    importlib_metadata; python_version<"3.10"
-    iniconfig
+[testenv:pre-commit]
+description =
+  Run the quality checks under {basepython}; run as
+  `SKIP=check-id1,check-id2 tox r -e pre-commit` to instruct the underlying
+  `pre-commit` invocation avoid running said checks; Use
+  `tox r -e pre-commit -- check-id1 --all-files` to select checks matching IDs
+  aliases{:} `tox r -e pre-commit -- mypy --all-files` will run 3 MyPy
+  invocations, but `tox r -e pre-commit -- mypy-py313 --all-files` runs one.
 commands =
-    pylint {posargs:lektor tests}
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -m pre_commit \
+      run \
+      --color=always \
+      --show-diff-on-failure \
+      {posargs:--all-files}
+
+  # Print out the advice on how to install pre-commit from this env into Git:
+  -{envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'cmd = "{envpython} -m pre_commit install"; \
+      scr_width = len(cmd) + 10; \
+      sep = "=" * scr_width; \
+      cmd_str = "    $ \{cmd\}";' \
+      'print(f"\n\{sep\}\nTo install pre-commit hooks into the Git repo, run:\
+      \n\n\{cmd_str\}\n\n\{sep\}\n")'
+commands_post =
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import os, pathlib, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      project_root_path = pathlib.Path(r"{toxinidir}"); \
+      test_results_dir = pathlib.Path(r"{temp_dir}") / ".test-results"; \
+      coverage_result_files = ",".join(\
+        str(xml_path.relative_to(project_root_path)) \
+        for xml_path in test_results_dir.glob("mypy--py-*{/}cobertura.xml")\
+      ); \
+      gh_output_fd = open(\
+        os.environ["GITHUB_OUTPUT"], encoding="utf-8", mode="a",\
+      ); \
+      print(\
+        f"cov-report-files={coverage_result_files !s}", file=gh_output_fd\
+      ); \
+      print("codecov-flags=MyPy", file=gh_output_fd); \
+      gh_output_fd.close()'
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import itertools, os, pathlib, shlex, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      test_results_dir = pathlib.Path(r"{temp_dir}") / ".test-results"; \
+      text_and_json_reports = itertools.chain( \
+        test_results_dir.glob("mypy--py-*{/}*.json"), \
+        test_results_dir.glob("mypy--py-*{/}*.txt"), \
+      ); \
+      report_contents = { \
+        report{:} report.read_text() \
+        for report in text_and_json_reports \
+      }; \
+      reports_summary_text_blob = "\n\n".join( \
+        f"\N\{NUMBER SIGN\}\N\{NUMBER SIGN\} {report_path.parent.name}{:} " \
+        f"`{report_path.name}`\n\n" \
+        f"```{report_path.suffix[1:]}\n{report_text}\n```\n" \
+        for report_path, report_text in report_contents.items() \
+      ); \
+      gh_summary_fd = open( \
+        os.environ["GITHUB_STEP_SUMMARY"], encoding="utf-8", mode="a", \
+      ); \
+      print(reports_summary_text_blob, file=gh_summary_fd); \
+      gh_summary_fd.close()'
+  # Print out the output coverage dir and a way to serve html:
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c\
+      'import os, pathlib, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" and sys.exit(); \
+      len(sys.argv) >= 3 and all(\
+        arg != "mypy" and not arg.startswith("mypy-py3") \
+        for arg in sys.argv \
+      ) and sys.exit(); \
+      project_root_path = pathlib.Path(r"{toxinidir}"); \
+      test_results_dir = pathlib.Path(r"{temp_dir}") / ".test-results"; \
+      coverage_html_report_urls = [\
+        f"file://\{xml_path !s\}" \
+        for xml_path in test_results_dir.glob("mypy--py-*{/}index.html")\
+      ]; \
+      coverage_html_report_urls or sys.exit(); \
+      coverage_html_report_open_cmds = [\
+      f"python3 -Im webbrowser \N\{QUOTATION MARK\}\{html_url !s\}\N\{QUOTATION MARK\}" \
+      for html_url in coverage_html_report_urls\
+      ]; \
+      coverage_html_report_open_cmds_blob = "\n\n\t".join(\
+        coverage_html_report_open_cmds,\
+      ); \
+      print(\
+        f"\nTo open the HTML coverage reports, run\n\n\
+        \t\{coverage_html_report_open_cmds_blob !s\}\n"\
+      ); \
+      print(\
+        f"[*] Find rest of JSON and text reports, are in the same directories."\
+      )\
+      ' \
+    {posargs:--all-files}
+deps =
+  pre-commit >= 4, < 5
+isolated_build = true
+package = skip
+pass_env =
+  {[testenv]pass_env}
+  SKIP  # set this variable
 
 [testenv:cover-clean]
 deps = coverage[toml]


### PR DESCRIPTION
Previously, pylint was specialcased. However, there are a lot of advantages to having a unified invocation. For example, a single tox env run that can be integrated into many places. Or, enabling pre-commit.ci eventually.

The only downside is having to keep track of a copy of the direct runtime dependencies in another config.