### PR TITLE
Fix file mode of created files

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -6,7 +6,6 @@ import shutil
 import sqlite3
 import stat
 import sys
-import tempfile
 from collections import deque
 from collections import namedtuple
 from contextlib import contextmanager
@@ -23,6 +22,7 @@ from lektor.constants import PRIMARY_ALT
 from lektor.context import Context
 from lektor.reporter import reporter
 from lektor.sourcesearch import find_files
+from lektor.utils import create_temp
 from lektor.utils import fs_enc
 from lektor.utils import process_extra_flags
 from lektor.utils import prune_file_and_folder
@@ -725,9 +725,11 @@ class Artifact:
 
         if ensure_dir:
             self.ensure_dir()
-        fd, self._new_artifact_file = tempfile.mkstemp(
-            dir=os.path.dirname(self.dst_filename),
+
+        fd, self._new_artifact_file = create_temp(
             prefix=".__trans",
+            dir=os.path.dirname(self.dst_filename),
+            text="b" not in mode,
         )
         return open(fd, mode, encoding=encoding)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -431,6 +431,22 @@ def test_Artifact_open_encoding(builder):
         assert fp.read() == "Ciarán"
 
 
+def test_Artifact_file_mode(builder, tmp_path):
+    # Check that created artifacts have same file mode as normally created files.
+    new_file = tmp_path / "dummy-test-file"
+    new_file.touch()
+    new_file_mode = new_file.stat().st_mode
+
+    build_state = builder.new_build_state()
+    artifact = build_state.new_artifact("dummy-artifact", sources=())
+    with artifact.update(), artifact.open("w"):
+        pass
+    artifact_mode = Path(artifact.dst_filename).stat().st_mode
+
+    # applying oct makes failures more readable
+    assert oct(artifact_mode) == oct(new_file_mode)
+
+
 def test_FileInfo_unchanged(env, tmp_path):
     file_path = tmp_path / "file"
     file_path.write_text("foo")


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1213

This PR also fixes a related buglet having to do with the mode of files created/edited using `lektor.utils.atomic_open`.
`Atomic_open` is used when editing `contents.lr` files via the admin GUI.

<!---
### Related Issues / Links


Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

This fixes things so that artifacts are created with the same permissions as any normally created file would have.
I.e. newly created files will now have mode `0o666 & ~umask` — previously, artifacts either got mode 0o644 (prior to 3.4.0b7) or 0o600 (since then).

<!--- Thanks for your help making Lektor better for everyone! --->
