### PR TITLE
Make attachments use title in sidebar

### DIFF
--- a/frontend/js/components/types.ts
+++ b/frontend/js/components/types.ts
@@ -21,6 +21,7 @@ export interface RecordAttachment {
   id: string;
   path: RecordPath;
   type: string;
+  label_i18n: Translatable;
 }
 
 // Returned by /recordinfo

--- a/frontend/js/sidebar/AttachmentActions.tsx
+++ b/frontend/js/sidebar/AttachmentActions.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import AdminLink from "../components/AdminLink";
 import { useRecordAlt } from "../context/record-context";
 import { RecordInfo } from "../components/types";
-import { trans } from "../i18n";
+import { trans, trans_obj } from "../i18n";
 
 function AttachmentActions({ recordInfo }: { recordInfo: RecordInfo }) {
   const alt = useRecordAlt();
@@ -16,7 +16,7 @@ function AttachmentActions({ recordInfo }: { recordInfo: RecordInfo }) {
             return (
               <li key={atch.id}>
                 <AdminLink page="edit" path={atch.path} alt={alt}>
-                  {atch.id} ({atch.type})
+                  {trans_obj(atch.label_i18n)} ({atch.type})
                 </AdminLink>
               </li>
             );

--- a/lektor/admin/modules/api.py
+++ b/lektor/admin/modules/api.py
@@ -178,6 +178,7 @@ def get_record_info(validated: _PathAndAlt, ctx: LektorContext) -> Response:
                 "id": x.id,
                 "path": x.path,
                 "type": x.attachment_type,
+                "label_i18n": x.get_record_label_i18n(alt),
             }
             for x in tree_item.iter_attachments()
         ],


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

Currently attachments are displayed in the sidebar with their path. The path can be uninformative for the content of the attachment, which can produce confusion when trying to find a specific attachment out of a list of many attachments.

This pull request changes the UI to make attachments use titles  in the sidebar as subpages in the sidebar do. I've used the same implementation as for the subpages using `trans_obj(atch.label_i18n)`.

- Tests successfully run through locally.
- No added unit tests
- I can provide a screenshot on request

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
