### PR TITLE
feat: Support marshmallow 4

### DIFF
--- a/lektor/admin/modules/api.py
+++ b/lektor/admin/modules/api.py
@@ -67,16 +67,15 @@ class _ServerInfoField(marshmallow.fields.String):
         return server_info
 
 
-def _is_valid_path(value: str) -> bool:
+def _is_valid_path(value: str) -> None:
     if not cleanup_path(value) == value:
         raise marshmallow.ValidationError("Invalid value.")
 
 
-def _is_valid_alt(value: str) -> bool:
+def _is_valid_alt(value: str) -> None:
     lektor_config = get_lektor_context().config
     if not lektor_config.is_valid_alternative(value):
         raise marshmallow.ValidationError("Invalid alternative.")
-    return bool(lektor_config.is_valid_alternative(value))
 
 
 # Mark types for special validation


### PR DESCRIPTION
Marshmallow 4 contained backward breaking changes. This commit fixes the broken parts.
All fixes also work with previous marshmallow versions

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

Fixes #1221 

### Description of Changes

- All custom marshmallow validators now raise ValidationErrors on failure, instead of returning False
- No more usage of context in schemas, instead using ContextVar
