### PR TITLE
builder: fix db connection leak

### DIFF
--- a/lektor/builder.py
+++ b/lektor/builder.py
@@ -912,10 +912,12 @@ class Artifact:
         con = self.build_state.connect_to_database()
         try:
             f(con)
+            con.commit()
         except:  # noqa
             con.rollback()
             raise
-        con.commit()
+        finally:
+            con.close()
 
     @contextmanager
     def update(self):


### PR DESCRIPTION

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1227

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

This should be semantically identical - if there's no error, we commit,
otherwise we rollback. Before, the connection was implicitly closed on
the delete of con, which generates warning since Python 3.13.
<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
