### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,12 +90,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - { os: "macos-latest", python: "3.9" }
+          - { os: "macos-latest", python: "3.10" }
           - { os: "macos-14", python: "3.14", install-ffmpeg: true }
           # macos-15 and newer have CI failures that do not reproduce on the other platforms
-          - { os: "windows-latest", python: "3.9" }
+          - { os: "windows-latest", python: "3.10" }
           - { os: "windows-latest", python: "3.14", install-ffmpeg: true }
           - { python: "3.14", install-ffmpeg: true }
     steps:

--- a/lektor/admin/modules/api.py
+++ b/lektor/admin/modules/api.py
@@ -1,5 +1,6 @@
 import os
 import posixpath
+from collections.abc import Callable
 from collections.abc import Iterator
 from collections.abc import Mapping
 from contextvars import ContextVar
@@ -7,9 +8,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from functools import wraps
 from typing import Any
-from typing import Callable
 from typing import cast
-from typing import Optional
 from typing import TypeVar
 
 import click
@@ -43,9 +42,7 @@ LEKTOR_CONFIG: ContextVar[Config] = ContextVar("lektor_config")
 
 
 @bp.url_value_preprocessor
-def pass_lektor_context(
-    endpoint: Optional[str], values: Optional[dict[str, Any]]
-) -> None:
+def pass_lektor_context(endpoint: str | None, values: dict[str, Any] | None) -> None:
     """Pass LektorContext to each view callable in a `ctx` parameter"""
     assert isinstance(values, dict)
     values["ctx"] = get_lektor_context()
@@ -55,8 +52,8 @@ class _ServerInfoField(marshmallow.fields.String):
     def _deserialize(
         self,
         value: str,
-        attr: Optional[str],
-        data: Optional[Mapping[str, Any]],
+        attr: str | None,
+        data: Mapping[str, Any] | None,
         **kwargs: Any,
     ) -> ServerInfo:
         lektor_config = LEKTOR_CONFIG.get()
@@ -225,7 +222,7 @@ def get_preview_info(validated: _PathAndAlt, ctx: LektorContext) -> Response:
 class _FindParams:
     q: str
     alt: _AltType = PRIMARY_ALT
-    lang: Optional[str] = None
+    lang: str | None = None
 
 
 @bp.route("/find", methods=["POST"])
@@ -356,8 +353,8 @@ def upload_new_attachments(validated: _PathAndAlt, ctx: LektorContext) -> Respon
 @dataclass
 class _NewRecordParams:
     id: str
-    model: Optional[str]
-    data: dict[str, Optional[str]]
+    model: str | None
+    data: dict[str, str | None]
     path: _PathType
     alt: _AltType = PRIMARY_ALT
 
@@ -401,7 +398,7 @@ def delete_record(validated: _DeleteRecordParams, ctx: LektorContext) -> Respons
 
 @dataclass
 class _UpdateRawRecordParams:
-    data: dict[str, Optional[str]]
+    data: dict[str, str | None]
     path: _PathType
     alt: _AltType = PRIMARY_ALT
 

--- a/lektor/admin/modules/serve.py
+++ b/lektor/admin/modules/serve.py
@@ -6,7 +6,6 @@ import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Union
 from zlib import adler32
 
 from flask import abort
@@ -42,7 +41,7 @@ if TYPE_CHECKING:
 bp = Blueprint("serve", __name__)
 
 
-Filename = Union[str, os.PathLike[str]]
+Filename = str | os.PathLike[str]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/lektor/admin/utils.py
+++ b/lektor/admin/utils.py
@@ -1,9 +1,9 @@
+from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
 from functools import update_wrapper
 from itertools import chain
 from typing import Any
-from typing import Callable
 
 from flask import json
 from flask import Response

--- a/lektor/imagetools/exif.py
+++ b/lektor/imagetools/exif.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import numbers
-import sys
+from collections.abc import Callable
 from collections.abc import Mapping
 from contextlib import suppress
 from datetime import datetime
@@ -11,10 +11,9 @@ from fractions import Fraction
 from functools import wraps
 from pathlib import Path
 from typing import Any
-from typing import Callable
 from typing import TYPE_CHECKING
+from typing import TypeAlias
 from typing import TypeVar
-from typing import Union
 
 import PIL.Image
 
@@ -26,11 +25,6 @@ from .image_info import TiffOrientation
 if TYPE_CHECKING:
     from _typeshed import SupportsRead
     from typing import Literal
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
 
 
 def _combine_make(make: str | None, model: str | None) -> str:
@@ -102,8 +96,8 @@ def _to_string(value: str) -> str:
 
 # NB: Older versions of Pillow return (numerator, denominator) tuples
 # for EXIF rational numbers.  New versions return a Fraction instance.
-ExifRational: TypeAlias = Union[numbers.Rational, tuple[int, int]]
-ExifReal: TypeAlias = Union[numbers.Real, tuple[int, int]]
+ExifRational: TypeAlias = numbers.Rational | tuple[int, int]
+ExifReal: TypeAlias = numbers.Real | tuple[int, int]
 
 
 def _to_rational(value: ExifRational) -> numbers.Rational:

--- a/lektor/imagetools/image_info.py
+++ b/lektor/imagetools/image_info.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import enum
 import re
-import sys
 import warnings
 from collections.abc import Generator
 from collections.abc import Mapping
@@ -16,7 +15,7 @@ from typing import BinaryIO
 from typing import Final
 from typing import NamedTuple
 from typing import TYPE_CHECKING
-from typing import Union
+from typing import TypeAlias
 from xml.etree import ElementTree as etree
 
 import PIL.Image
@@ -28,12 +27,6 @@ from ._compat import UnidentifiedImageError
 if TYPE_CHECKING:
     from _typeshed import SupportsRead
     from typing import Literal
-
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
 
 
 class SvgImageInfo(NamedTuple):
@@ -54,7 +47,7 @@ class UnknownImageInfo(NamedTuple):
     height: None = None
 
 
-ImageInfo: TypeAlias = Union[PILImageInfo, SvgImageInfo, UnknownImageInfo]
+ImageInfo: TypeAlias = PILImageInfo | SvgImageInfo | UnknownImageInfo
 
 
 class TiffOrientation(enum.IntEnum):

--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -3,7 +3,6 @@ import warnings
 from collections.abc import Hashable
 from importlib import metadata
 from typing import Any
-from typing import Optional
 from typing import TYPE_CHECKING
 from weakref import ref as weakref
 
@@ -39,7 +38,7 @@ get_controller = ControllerCache(controller_class)
 
 class Markdown:
     def __init__(
-        self, source: str, record: Optional[SourceObject], field_options: FieldOptions
+        self, source: str, record: SourceObject | None, field_options: FieldOptions
     ) -> None:
         self.source = source
         self.__record = weakref(record) if record is not None else None

--- a/lektor/markdown/controller.py
+++ b/lektor/markdown/controller.py
@@ -1,12 +1,12 @@
 import threading
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Callable
 from collections.abc import Hashable
 from collections.abc import Mapping
 from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Any
-from typing import Callable
 from typing import NamedTuple
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -45,7 +45,7 @@ def require_ctx() -> Context:
 class RendererContext(NamedTuple):
     """Extra data used during Markdown rendering."""
 
-    record: Optional[SourceObject]
+    record: SourceObject | None
     meta: Meta
     field_options: FieldOptions
 
@@ -68,7 +68,7 @@ class RendererHelper:
     """Various helpers used by our markdown renderer subclasses."""
 
     @property
-    def record(self) -> Optional[SourceObject]:
+    def record(self) -> SourceObject | None:
         """The record that owns the markdown field being rendered.
 
         This is used as the base for resolving relative URLs in the Markdown text.
@@ -154,7 +154,7 @@ class MarkdownController(ABC):
     def parser(self) -> Callable[[str], str]:  # () -> mistune.Mistune
         return self.make_parser()
 
-    def get_cache_key(self) -> Optional[Hashable]:
+    def get_cache_key(self) -> Hashable | None:
         """Get cache key.
 
         Identical keys guarantee that the rendered result for a given string,
@@ -169,7 +169,7 @@ class MarkdownController(ABC):
         return ctx.base_url
 
     def render(
-        self, source: str, record: Optional[SourceObject], field_options: FieldOptions
+        self, source: str, record: SourceObject | None, field_options: FieldOptions
     ) -> RenderResult:
         """Render markdown string"""
         meta: Meta = {}

--- a/lektor/markdown/mistune0.py
+++ b/lektor/markdown/mistune0.py
@@ -2,7 +2,6 @@
 
 import threading
 from typing import ClassVar
-from typing import Optional
 
 import mistune  # type: ignore[import]
 
@@ -33,13 +32,13 @@ class ImprovedRenderer(
     def meta(self) -> Meta:
         return self.lektor.meta
 
-    def link(self, link: str, title: Optional[str], text: str) -> str:
+    def link(self, link: str, title: str | None, text: str) -> str:
         url = self.lektor.resolve_url(link)
         if not title:
             return f'<a href="{escape(url)}">{text}</a>'
         return f'<a href="{escape(url)}" title="{escape(title)}">{text}</a>'
 
-    def image(self, src: str, title: Optional[str], text: str) -> str:
+    def image(self, src: str, title: str | None, text: str) -> str:
         url = escape(self.lektor.resolve_url(src))
         if not title:
             return f'<img src="{url}" alt="{escape(text)}">'

--- a/lektor/markdown/mistune2.py
+++ b/lektor/markdown/mistune2.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Sequence
 from importlib import import_module
-from typing import Callable
 from typing import ClassVar
 from typing import TypedDict
 

--- a/lektor/publisher.py
+++ b/lektor/publisher.py
@@ -6,6 +6,7 @@ import io
 import os
 import posixpath
 import urllib.parse
+from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterable
 from collections.abc import Iterator
@@ -25,7 +26,6 @@ from subprocess import PIPE
 from subprocess import STDOUT
 from tempfile import TemporaryDirectory
 from typing import Any
-from typing import Callable
 from typing import NoReturn
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit

--- a/lektor/quickstart.py
+++ b/lektor/quickstart.py
@@ -9,7 +9,6 @@ from importlib import import_module
 from subprocess import PIPE
 from subprocess import run
 from tempfile import TemporaryDirectory
-from typing import Optional
 
 import click
 from jinja2 import Environment
@@ -144,7 +143,7 @@ def get_default_author() -> str:
     return getpass.getuser()
 
 
-def get_default_author_email() -> Optional[str]:
+def get_default_author_email() -> str | None:
     """Attempt to guess an email address for the current user.
 
     May return an empty string if not reasonable guess can be made.

--- a/lektor/types/multi.py
+++ b/lektor/types/multi.py
@@ -43,9 +43,12 @@ def _parse_choices(options):
             implied_labels.append(item.strip())
 
     if user_labels:
-        rv = list(zip(choices, _reflow_and_split_labels(user_labels)))
+        rv = list(zip(choices, _reflow_and_split_labels(user_labels), strict=False))
     else:
-        rv = [(key, {"en": label}) for key, label in zip(choices, implied_labels)]
+        rv = [
+            (key, {"en": label})
+            for key, label in zip(choices, implied_labels, strict=False)
+        ]
 
     return rv
 

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -14,6 +14,7 @@ import unicodedata
 import urllib.parse
 import uuid
 import warnings
+from collections.abc import Callable
 from collections.abc import Hashable
 from collections.abc import Iterable
 from collections.abc import Iterator
@@ -26,14 +27,12 @@ from functools import wraps
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any
-from typing import Callable
 from typing import ClassVar
 from typing import IO
 from typing import Literal
 from typing import overload
 from typing import TYPE_CHECKING
 from typing import TypeVar
-from typing import Union
 
 from jinja2 import is_undefined
 from markupsafe import Markup
@@ -282,7 +281,7 @@ def merge(a, b):
     if a is None:
         return b
     if isinstance(a, list) and isinstance(b, list):
-        for idx, (item_1, item_2) in enumerate(zip(a, b)):
+        for idx, (item_1, item_2) in enumerate(zip(a, b, strict=False)):
             a[idx] = merge(item_1, item_2)
     if isinstance(a, dict) and isinstance(b, dict):
         for key, value in b.items():
@@ -536,9 +535,9 @@ def get_dependent_url(url_path, suffix, ext=None):
 _AtomicOpenTextMode = Literal["w", "wt", "tw", "r", "rt", "tr"]
 _AtomicOpenBinaryModeWriting = Literal["wb", "bw"]
 _AtomicOpenBinaryModeReading = Literal["rb", "br"]
-_AtomicOpenMode = Union[
-    _AtomicOpenTextMode, _AtomicOpenBinaryModeWriting, _AtomicOpenBinaryModeReading
-]
+_AtomicOpenMode = (
+    _AtomicOpenTextMode | _AtomicOpenBinaryModeWriting | _AtomicOpenBinaryModeReading
+)
 
 
 @overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "Babel",
     "click>=6.0",
@@ -47,7 +47,6 @@ dependencies = [
     "pip",
     "python-slugify",
     "requests",
-    "typing-extensions>=3.10; python_version<'3.10'",
     "tzdata; sys_platform == 'win32'",
     "watchfiles>=0.12",
     "Werkzeug>=2.1.0",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,6 +1,5 @@
 import re
 import threading
-from typing import Union
 
 import pytest
 from markupsafe import Markup
@@ -393,7 +392,7 @@ class TestMarkdown:
         assert markdown.__html__().rstrip() == "<p>text</p>"
 
 
-def _normalize_html(output: Union[str, Markup]) -> str:
+def _normalize_html(output: str | Markup) -> str:
     html = str(output).strip()
     html = html.replace("&copy;", "©")
     html = re.sub(r"(<img [^>]*?)\s*/>", r"\1>", html)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -78,11 +78,7 @@ def test_VirtualEnv_run_pip_install(tmp_path: Path) -> None:
     prog = inspect.cleandoc(
         """
         import sys
-        if sys.version_info < (3, 10):
-            # need "selectable" entry_points
-            import importlib_metadata as metadata
-        else:
-            from importlib import metadata
+        from importlib import metadata
 
         for ep in metadata.entry_points(group="lektor.plugins", name="dummy"):
             print(ep.load().__name__)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -5,11 +5,11 @@ import shutil
 import sys
 import threading
 import warnings
+from collections.abc import Callable
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 import pytest
 from watchfiles import Change

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ deps =
     pytest-click
     pytest-mock
     coverage[toml]
-    importlib_metadata; python_version<"3.10"
     iniconfig
     hatchling
     mistune0: mistune<2
@@ -72,7 +71,6 @@ deps =
     pylint==4.0.4
     pytest>=6
     pytest-mock
-    importlib_metadata; python_version<"3.10"
     iniconfig
 commands =
     pylint {posargs:lektor tests}


### PR DESCRIPTION
Python 3.9 is EOL, so drop support (it's that time of the year again, just like back in #1203 and #1173)

The pyupgrade fixes are mostly for changed types.
