### PR TITLE
Address bitrot in the 3.3 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,20 +88,18 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - python: "3.6"
-            os: "ubuntu-20.04"
           - python: "3.8"
             os: "macos-latest"
-          - python: "3.12"
+          - python: "3.14"
             os: "macos-latest"
-          - python: "3.7"
+          - python: "3.8"
             os: "windows-latest"
-          - python: "3.12"
+          - python: "3.14"
             os: "windows-latest"
 
-          - python: "3.12"
+          - python: "3.14"
             install-imagemagick: true
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,17 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: "22.12.0"
+    # NB: Using any black past 23.12.1 results in conflict between
+    # black and reorder-python-imports.
+    # See https://github.com/psf/black/issues/4175
+    rev: "23.12.1"
     hooks:
       - id: black
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: "v3.9.0"
+    rev: "v3.16.0"
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/pycqa/flake8
-    rev: "6.0.0"
+    rev: "7.3.0"
     hooks:
       - id: flake8
         language_version: python3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,30 @@
 
 These are all the changes in Lektor since the first public release.
 
+## 3.3.13 (unreleased)
+
+Lucky 13!
+
+This release addresses various pieces of bit-rot.
+
+### Breaking Changes
+
+- Drop support for long-since-EOLed python 3.6 and 3.7.
+
+### Features
+
+- Test under python 3.13 and 3.14
+
+### Fixes
+
+- Pin `setuptools<81` to address the removal of `pkg_resources` from `setuptools`.
+- Fix "unclosed database" warnings. (Backport [#1242])
+- Fix a few brittle tests (`test_new_theme_varying_names`,
+  `test_no_reference_cycle_in_environment`,
+  `test_datetime_timezone_est`).
+
+[#1242]: https://github.com/lektor/lektor/pull/1142
+
 ## 3.3.12 (2024-08-18)
 
 - Test under python 3.12

--- a/lektor/cli_utils.py
+++ b/lektor/cli_utils.py
@@ -54,7 +54,6 @@ def buildflag(cli):
 
 
 class AliasedGroup(click.Group):
-
     # pylint: disable=inconsistent-return-statements
     def get_command(self, ctx, cmd_name):
         rv = click.Group.get_command(self, ctx, cmd_name)

--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -48,6 +48,7 @@ def _prevent_inlining(wrapped):
 
     Applying this decorator to them will ensure they are not inlined.
     """
+
     # the use of @pass_context will prevent inlining
     @jinja2.pass_context
     def wrapper(_jinja_ctx, *args, **kwargs):

--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -48,7 +48,6 @@ class Plugin:
 
     @property
     def version(self):
-
         return get_distribution("lektor-" + self.id).version
 
     @property

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,13 +21,13 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
 
@@ -35,7 +35,7 @@ classifiers =
 packages = find:
 include_package_data = True
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     Babel
     click>=6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     python-slugify
     pytz
     requests
-    setuptools>=45.2
+    setuptools>=45.2,<81
     watchdog
     Werkzeug<2.4
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -149,7 +149,6 @@ def test_undiscoverable_basics(pad):
 
 
 def test_attachment_api(pad):
-
     root = pad.root
     root_attachments = [
         "hello.txt",

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -439,6 +439,7 @@ def test_new_theme_path_and_name_params(project_cli_runner):
         ("Lektor Theme New", "lektor-theme-new"),
     ),
 )
+@pytest.mark.usefixtures("default_author", "default_author_email")
 def test_new_theme_varying_names(project_cli_runner, theme_name, expected_id):
     result = project_cli_runner.invoke(
         cli,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import weakref
 from html import unescape
 from pathlib import Path
 
@@ -49,11 +50,14 @@ def test_jinja2_feature_do(compile_template):
     assert tmpl.render() == "a-b"
 
 
+@pytest.mark.skipif(
+    not hasattr(sys, "getrefcount"), reason="interpreter does not support ref counting"
+)
 def test_no_reference_cycle_in_environment(project):
-    env = project.make_env(load_plugins=False)
-    # reference count should be two: one from our `env` variable, and
-    # another from the argument to sys.getrefcount
-    assert sys.getrefcount(env) == 2
+    ref = weakref.ref(project.make_env(load_plugins=False))
+    # With ref counts (and no ref cycle), the environment should be immediately
+    # garbage collected
+    assert ref() is None
 
 
 @pytest.fixture

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -56,19 +56,16 @@ def theme_project(theme_project_tmpdir, request):
 
 @pytest.fixture(scope="function")
 def theme_env(theme_project):
-
     return Environment(theme_project)
 
 
 @pytest.fixture(scope="function")
 def theme_pad(theme_env):
-
     return Database(theme_env).new_pad()
 
 
 @pytest.fixture(scope="function")
 def theme_builder(theme_pad, tmpdir):
-
     return Builder(theme_pad, str(tmpdir.mkdir("output")))
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -247,7 +247,9 @@ def test_datetime_timezone_est(env, pad):
         assert rv.hour == 1
         assert rv.minute == 2
         assert rv.second == 3
-        assert rv.tzinfo is get_timezone("EST")
+        naive = rv.replace(tzinfo=None)
+        tz = get_timezone("EST")
+        assert rv.tzinfo.utcoffset(naive) == tz.utcoffset(naive)
 
 
 def test_datetime_timezone_location(env, pad):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -4,7 +4,6 @@ from lektor.utils import cleanup_path
 
 
 def test_cleanup_path():
-
     assert cleanup_path("/") == "/"
     assert cleanup_path("/foo") == "/foo"
     assert cleanup_path("/foo/") == "/foo"
@@ -17,7 +16,6 @@ def test_cleanup_path():
 
 
 def test_basic_url_to_with_alts(pad):
-
     wolf_en = pad.get("/projects/wolf", alt="en")
     slave_en = pad.get("/projects/slave", alt="en")
     wolf_de = pad.get("/projects/wolf", alt="de")
@@ -78,7 +76,6 @@ def test_basic_url_to_with_alts(pad):
     ],
 )
 def test_url_to_all_params(pad, path, alt, absolute, external, base_url, expected):
-
     if external and not absolute:
         pad.db.config.base_url = "/projects/slave1/"
 
@@ -97,7 +94,6 @@ def test_url_to_all_params(pad, path, alt, absolute, external, base_url, expecte
     ],
 )
 def test_url_to_all_params_error_cases(pad, path, alt, absolute, external, base_url):
-
     wolf_en = pad.get("/projects/wolf")
 
     with pytest.raises(RuntimeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,6 @@ from lektor.utils import Url
 
 
 def test_join_path():
-
     assert join_path("a", "b") == "a/b"
     assert join_path("/a", "b") == "/a/b"
     assert join_path("a@b", "c") == "a@b/c"
@@ -47,7 +46,6 @@ def test_join_path():
 
 
 def test_is_path_child_of():
-
     assert not is_path_child_of("a/b", "a/b")
     assert is_path_child_of("a/b", "a/b", strict=False)
     assert is_path_child_of("a/b/c", "a")
@@ -62,7 +60,6 @@ def test_is_path_child_of():
 
 
 def test_magic_split_ext():
-
     assert magic_split_ext("wow") == ("wow", "")
     assert magic_split_ext("aaa.jpg") == ("aaa", "jpg")
     assert magic_split_ext("aaa. jpg") == ("aaa. jpg", "")
@@ -71,7 +68,6 @@ def test_magic_split_ext():
 
 
 def test_slugify():
-
     assert slugify("w o w") == "w-o-w"
     assert slugify("Șö prĕtty") == "so-pretty"
     assert slugify("im age.jpg") == "im-age.jpg"
@@ -176,7 +172,6 @@ def test_secure_url(url, expected):
 
 
 def test_url_builder():
-
     assert build_url([]) == "/"
     assert build_url(["a", "b/c"]) == "/a/b/c/"
     assert build_url(["a", "b/c"], trailing_slash=False) == "/a/b/c"
@@ -186,7 +181,6 @@ def test_url_builder():
 
 
 def test_parse_path():
-
     assert parse_path("") == []
     assert parse_path("/") == []
     assert parse_path("/foo") == ["foo"]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -78,7 +78,6 @@ class WatcherTest:
         should_set_event: bool = True,
         timeout: float = 1.2,
     ) -> Generator[Path, None, None]:
-
         kwargs: dict[str, Any] = {}
         if observer_class is not None:
             kwargs.update(

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,19 @@
 [tox]
 minversion = 3.28
 requires =
-    # https://tox.wiki/en/4.9.0/faq.html#testing-end-of-life-python-versions
-    virtualenv<20.22.0
     tox-gh-actions
-# needed for tox3 (when running under py36)
-isolated_build = true
 
-envlist = lint,py36,py37,py38,py39,py310,py311,py312{,-noutils}
+envlist = lint,py38,py39,py310,py311,py312,py313,py314{,-noutils}
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 # workaround pip-cache issues when running 'tox parallel' (py37+)
@@ -28,8 +24,6 @@ setenv =
     # Use per-testenv coverage files to prevent contention when parallel
     # tests (using `tox -p`)
     COVERAGE_FILE=.coverage.{envname}
-    # workaround pip-cache issues when running 'tox parallel' (py36)
-    py36: PIP_CACHE_DIR={envtmpdir}{/}pip-cache
 deps =
     pytest>=6
     pytest-click
@@ -37,7 +31,7 @@ deps =
     pytest-mock
     coverage[toml]
 
-[testenv:py{37,38,39,310,311}-noutils]
+[testenv:py{38,39,310,311,312,313,314}-noutils]
 # To test in environment without external utitilities like imagemagick and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

This PR addresses various elements of bitrot in the 3.3 branch.

- Test under python 3.13 and 3.14.
- Drop support for python 3.6 and 3.7.
- Pin `setuptools<81` to address removal of `pkg_resources` from `setuptools`. (Ref lektor/lektor-website@69c53ff314e5ee094514303620a0c65c83050c87.)
- Backport #1242. (See also #1227.)
- Fix some brittle tests
  - `test_datetime_timezone_est`
  - `test_no_reference_cycle_in_environment` (ref  2353d0e020970d65586810d54f6c4d8b3154de2e)
  - `test_new_theme_varying_names` (ref 3c32e2f28fa8c2c23c1dd6051349dbccb1c83d52)
- Update pre-commit hook versions

### Issue(s) Resolved


### Related Issues / Links


<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Updated `CHANGES.md`
- [ ] (n/a) ~Wrote at least one-line docstrings (for any new functions)~
- [ ] (n/a) ~Added unit test(s) covering the changes (if testable)~
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] (n/a) ~Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))~
- [ ] (n/a) ~Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)~

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
