### PR TITLE
Miscellaneous test cleanup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,8 +93,9 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - { os: "macos-latest", python: "3.10" }
-          - { os: "macos-14", python: "3.14", install-ffmpeg: true }
-          # macos-15 and newer have CI failures that do not reproduce on the other platforms
+          - { os: "macos-14", python: "3.14" }
+          - { os: "macos-latest", python: "3.14", install-ffmpeg: true }
+          - { os: "macos-26", python: "3.14" }
           - { os: "windows-latest", python: "3.10" }
           - { os: "windows-latest", python: "3.14", install-ffmpeg: true }
           - { python: "3.14", install-ffmpeg: true }

--- a/tests/test_devcli.py
+++ b/tests/test_devcli.py
@@ -376,7 +376,7 @@ def test_new_theme_path_and_name_params(project_cli_runner):
         ("Lektor Theme New", "lektor-theme-new"),
     ),
 )
-@pytest.mark.xfail(strict=False, reason="seems to be broken in CI")
+@pytest.mark.usefixtures("default_author", "default_author_email")
 def test_new_theme_varying_names(project_cli_runner, theme_name, expected_id):
     result = project_cli_runner.invoke(
         cli,

--- a/tox.ini
+++ b/tox.ini
@@ -36,24 +36,6 @@ deps =
 depends =
     py{310,311,312,313,314}: cover-clean
     cover-report: py{310,311,312,313,314}{,-mistune0,-noutils,-tzdata}
-# XXX: I've been experiencing sporadic failures when running tox in parallel mode.
-# The crux of the error messages when this happens appears to be something like:
-#
-#     WARNING: Skipping page https://pypi.org/simple/coverage/ because the GET request
-#         got Content-Type: Unknown. The only supported Content-Types are
-#         application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html, and
-#         text/html
-#
-#     ERROR: Could not find a version that satisfies the requirement
-#         coverage[toml] (from versions: none)
-#
-# It may be this issue: https://github.com/pypa/pip/issues/11340
-#
-# Setting download=true — which tells tox to upgrade pip to the latest version —
-# seems to fix the issue for me.
-#
-# Hopefully, at some point this can be removed.
-download = true
 
 [testenv:py{310,311,312,313,314}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,

--- a/tox.ini
+++ b/tox.ini
@@ -85,11 +85,3 @@ commands =
     -coverage combine --append
     coverage xml
     coverage report
-
-[flake8]
-max-line-length = 91
-extend-ignore =
-    # E203: Whitespace before ':'
-    E203,
-    # E402: Module level import not at top of file
-    E402

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,13 @@
 minversion = 4.1
 envlist =
     lint
-    {py39,py310,py311,py312,py313,py314}{,-mistune0}
+    {py310,py311,py312,py313,py314}{,-mistune0}
     py311-noutils
     py311-tzdata
     cover-{clean,report}
-isolated_build = true
 
 [gh-actions]
 python =
-    3.9: py39, cover-report
     3.10: py310, cover-report
     3.11: py311, cover-report
     3.12: py312, cover-report
@@ -36,8 +34,8 @@ deps =
     mistune0: mistune<2
     tzdata: tzdata
 depends =
-    py{39,310,311,312,313}: cover-clean
-    cover-report: py{39,310,311,312,313}{,-mistune0,-noutils,-tzdata}
+    py{310,311,312,313,314}: cover-clean
+    cover-report: py{310,311,312,313,314}{,-mistune0,-noutils,-tzdata}
 # XXX: I've been experiencing sporadic failures when running tox in parallel mode.
 # The crux of the error messages when this happens appears to be something like:
 #
@@ -57,7 +55,7 @@ depends =
 # Hopefully, at some point this can be removed.
 download = true
 
-[testenv:py{39,310,311,312,313,314}-noutils]
+[testenv:py{310,311,312,313,314}-noutils]
 # To test in environment without external utitilities like ffmpeg and git installed,
 # break PATH in noutils environment(s).
 allowlist_externals = env
@@ -65,7 +63,7 @@ commands =
     env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
 [testenv:lint]
-base_python = py314,py313,py312,py311,py310,py39
+base_python = py314,py313,py312,py311,py310
 use_develop = true
 deps =
     pylint==4.0.4


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

- Fixes fragile tests in `test_new_theme_varying_names` and `test_no_reference_cycle_in_environment`.
- Clean up `tox.ini`. Remove old workarounds and unused bits.
- Re-enable CI tests on `macos-latest`. They appear to pass, atm.  Also run under `macos-14` and `macos-26` just to maximize the chance of detecting any funniness that may remain.


