### PR TITLE
Fix.issue 1229 include hidden

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -176,7 +176,7 @@ def test_undiscoverable_basics(pad):
 
     q = secret.children
     assert q._include_undiscoverable is False
-    assert q._include_hidden is None
+    assert q._include_hidden is False
     q = q.include_undiscoverable(True)
     assert q._include_undiscoverable is True
     assert q._include_hidden is False

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -13,6 +13,7 @@ from lektor.db import Image
 from lektor.db import Query
 from lektor.db import Video
 from lektor.filecontents import FileContents
+from lektor.metaformat import serialize
 
 
 def test_root(pad):
@@ -556,3 +557,28 @@ def test_Pad_make_url_raises_runtime_error_if_no_project_url(pad):
 def test_Pad_make_url_raises_runtime_error_if_no_base_url(pad):
     with pytest.raises(RuntimeError, match="(?i)no base url"):
         pad.make_url("/a/b")
+
+
+def test_Query_include_hidden_and_undiscoverable(scratch_project_data, scratch_pad):
+    def make_child(name, data):
+        contents_lr = scratch_project_data / "content" / name / "contents.lr"
+        contents_lr.parent.mkdir()
+        contents_lr.write_text("".join(serialize(data.items())))
+
+    make_child("hidden", {"_hidden": "yes"})
+    make_child("undiscoverable", {"_discoverable": "no"})
+    make_child("hidden-undiscoverable", {"_hidden": "yes", "_discoverable": "no"})
+
+    children = scratch_pad.root.children
+
+    def paths(query: Query) -> set:
+        return {child.path for child in query}
+
+    assert paths(children) == set()
+    assert paths(children.include_hidden(True)) == {"/hidden"}
+    assert paths(children.include_undiscoverable(True)) == {"/undiscoverable"}
+    assert paths(children.include_hidden(True).include_undiscoverable(True)) == {
+        "/hidden",
+        "/undiscoverable",
+        "/hidden-undiscoverable",
+    }


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

Fixes for `Query.include_hidden`, which currently, unless (`include_undiscoverable` is also set), does not actually include hidden descendants in the query.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1229, #358.

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

#### Record.is_discoverable

Currently, `Record.is_discoverable` is forced to `False` when the record is hidden, even if `_discoverable` is set.
https://github.com/lektor/lektor/blob/7522911c482efbbe8024e6a2f30b8785b5fa13f0/lektor/db.py#L364-L367
I don't see how this makes sense.  (I suspect it is a remnant of initial attempts to support the hidden flag.)
This PR makes the `Record.is_discoverable` logic independent of `Record.is_hidden`.

 
This is a change in semantics, and so could affect current projects.  I'm having trouble imaging how the original semantics might be useful, however.

#### Query._include_hidden tri-state logic

Currently, `Query._include_hidden` is treated as a tri-state (`None`, `False`, or `True`) value, with `None` meaning "not explicitly set".

There is logic in `Query.include_undiscoverable` that sets `include_hidden` to False, if it hadn't been explicitly set, when `include_undiscoverable` is set.

https://github.com/lektor/lektor/blob/7522911c482efbbe8024e6a2f30b8785b5fa13f0/lektor/db.py#L1074-L1083

There was also logic in `Query._matches` that treated Queries with no explicit setting of include_hidden specially.  On careful inspection, this all seems to do nothing.  `Query._matches` treats `_include_hidden = None` the same as `_include_hidden = False`. 

https://github.com/lektor/lektor/blob/7522911c482efbbe8024e6a2f30b8785b5fa13f0/lektor/db.py#L1001-L1005

The PR removes all the tri-state logic around `Query._include_hidden`

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
