### PR TITLE
Move test dependencies into pyproject.toml (PEP735)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For installation instructions head to the official documentation:
 
 ## Want to develop on Lektor?
 
-This gets you started (assuming you have Python, pip, npm, and pre-commit
+This gets you started (assuming you have Python, npm, and pre-commit
 installed):
 
 ```bash
@@ -40,10 +40,13 @@ $ cd lektor
 $ python -m venv _venv
 $ . _venv/bin/activate
 
-# pip>=21.3 is required for PEP 610 support
-$ pip install -U "pip>=21.3"
+# pip>=25.1 is required for PEP 735 support
+$ pip install -U "pip>=25.1"
 
-$ pip install --editable .
+$ pip install --group dev --editable .
+
+# build the frontend javascript (requires npm to be installed)
+$ make build-js
 
 # If you plan on committing:
 $ pre-commit install
@@ -54,8 +57,15 @@ $ cp -r example example-project
 $ lektor --project example-project server
 ```
 
-If you want to run the test suite (you'll need tox installed):
+If you want to run the whole test suite, under various versions of
+python, etc. (you'll need tox installed):
 
 ```sh
 $ tox
+```
+
+Or run the tests directly in your dev environment
+
+```sh
+$ pytest [...]
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To see how it works look at the top-level `example/` folder, which contains
 a showcase of the wide variety of Lektor's features.
 
 For a more complete example look at the [lektor/lektor-website](https://github.com/lektor/lektor-website)
-repository, which contains the sourcecode for the official lektor website.
+repository, which contains the source code for the official Lektor website.
 
 ## How do I use this?
 
@@ -31,8 +31,12 @@ For installation instructions head to the official documentation:
 
 ## Want to develop on Lektor?
 
-This gets you started (assuming you have Python, npm, and pre-commit
-installed):
+This gets you started (assuming you have [Python] >= 3.10, [npm], and
+[pre-commit] installed):
+
+[python]: https://www.python.org/
+[pre-commit]: https://pre-commit.com/
+[npm]: https://nodejs.org/
 
 ```bash
 $ git clone https://github.com/lektor/lektor
@@ -43,10 +47,8 @@ $ . _venv/bin/activate
 # pip>=25.1 is required for PEP 735 support
 $ pip install -U "pip>=25.1"
 
+# NB: this step requires that npm is installed (see below)
 $ pip install --group dev --editable .
-
-# build the frontend javascript (requires npm to be installed)
-$ make build-js
 
 # If you plan on committing:
 $ pre-commit install
@@ -58,7 +60,9 @@ $ lektor --project example-project server
 ```
 
 If you want to run the whole test suite, under various versions of
-python, etc. (you'll need tox installed):
+python, etc. (you'll need [tox] installed):
+
+[tox]: https://tox.wiki/
 
 ```sh
 $ tox
@@ -69,3 +73,16 @@ Or run the tests directly in your dev environment
 ```sh
 $ pytest [...]
 ```
+
+> [!NOTE]
+> The admin front-end resources (e.g. `.js` and `.css` files) in `lektor/admin/static`
+> get built as part of the python distribution build process.
+> This happens, e.g., when running `pip install -e .`
+>
+> That magic may be disabled (you might want to do this if, e.g., `npm` is not
+> available in your dev environment) by setting the `HATCH_BUILD_NO_HOOKS`
+> environment variable during the build. E.g.
+>
+> ```sh
+> HATCH_BUILD_NO_HOOKS=true pip install --group dev --editable .
+> ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,27 @@ optional-dependencies.ipython = [
 [project.scripts]
 lektor = "lektor.cli:main"
 
+[dependency-groups]
+dev = [                         # generally useful during development
+    {include-group = "pytest"},
+]
+pytest = [                 # requirements for running our pytest tests
+    "pytest>=6",
+    "pytest-click",
+    "pytest-mock",
+    "coverage[toml]",
+    "iniconfig",
+    "hatchling",
+]
+pylint = [                      # requirements for running pylint
+    "pylint==4.0.4",
+    "pytest>=6",
+    "pytest-mock",
+    "iniconfig",
+]
+mistune0 = ["mistune<2"]        # pin old mistune for testing
+tzdata = ["tzdata"]             # test with tzdata rather than system zone data
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 4.1
+minversion = 4.22
 envlist =
     lint
     {py310,py311,py312,py313,py314}{,-mistune0}
@@ -24,14 +24,9 @@ setenv =
     HATCH_BUILD_NO_HOOKS=true
     # do not run marked slow tests in every variant testenv
     {mistune0,noutils,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
-deps =
-    pytest>=6
-    pytest-click
-    pytest-mock
-    coverage[toml]
-    iniconfig
-    hatchling
-    mistune0: mistune<2
+dependency_groups =
+    pytest
+    mistune0: mistune0
     tzdata: tzdata
 depends =
     py{310,311,312,313,314}: cover-clean
@@ -47,11 +42,7 @@ commands =
 [testenv:lint]
 base_python = py314,py313,py312,py311,py310
 use_develop = true
-deps =
-    pylint==4.0.4
-    pytest>=6
-    pytest-mock
-    iniconfig
+dependency_groups = pylint
 commands =
     pylint {posargs:lektor tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,27 +17,24 @@ python =
 
 [testenv]
 commands =
-    coverage run -m pytest {posargs:tests -ra --durations=20}
+    {env:command_prefix:} coverage run -m pytest {posargs:tests -ra --durations=20}
 passenv = USERNAME
 setenv =
     # skip building frontend js/css
     HATCH_BUILD_NO_HOOKS=true
     # do not run marked slow tests in every variant testenv
     {mistune0,noutils,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
+    # To test in environment without external utitilities like ffmpeg and git installed,
+    # break PATH in noutils environment(s).
+    noutils: command_prefix=env PATH="{env_bin_dir}"
 dependency_groups =
     pytest
     mistune0: mistune0
     tzdata: tzdata
+allowlist_externals = env
 depends =
     py{310,311,312,313,314}: cover-clean
     cover-report: py{310,311,312,313,314}{,-mistune0,-noutils,-tzdata}
-
-[testenv:py{310,311,312,313,314}-noutils]
-# To test in environment without external utitilities like ffmpeg and git installed,
-# break PATH in noutils environment(s).
-allowlist_externals = env
-commands =
-    env PATH="{env_bin_dir}" coverage run -m pytest {posargs:tests -ra --durations=20}
 
 [testenv:lint]
 base_python = py314,py313,py312,py311,py310


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->
### Description of Changes

#### Test/dev dependencies declared in pyproject.toml

This PR moves the declaration of test dependencies from `tox.ini` to  `pyproject.toml`'s `dependency-groups` ([PEP735]).

This allows developers to initialize a local dev environment with these same dependencies by running, e.g.
```sh
python3 -m venv .venv
# need pip>=25.1 for --group support
.venv/bin/python -m pip install -U pip
.venv/bin/pip install --group dev -e .
```
(Of course, `uv`, `pdm`, and other project management tools also support PEP735 dependency-groups.)

#### Other tox.ini cleanup

It also unifies the configuration for the `*-noutils` test environments with that for the default test environment.

#### Update development instructions in README

This PR also updates to development howto at the bottom of `README.md` to match changes made.

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Resolves #1057

### Related Issues / Links

This partially overlaps with #1218

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->



<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
[PEP735]: https://peps.python.org/pep-0735/