### PR TITLE
Small cleanups/refactors/features in pluginsystem

### DIFF
--- a/lektor/pluginsystem.py
+++ b/lektor/pluginsystem.py
@@ -91,17 +91,14 @@ class Plugin:
         return None
 
     @property
-    def path(self) -> str:
+    def path(self) -> str | None:
         mod = sys.modules[self.__class__.__module__.split(".", maxsplit=1)[0]]
+        if mod.__file__ is None:
+            return None  # pragma: no cover
         path = Path(mod.__file__).resolve().parent
-        package_cache = self.env.project.get_package_cache_path()
-        try:
-            # We could use Path.is_relative_to(), except that's py39+ only
-            path.relative_to(package_cache)
+        if path.is_relative_to(self.env.project.get_package_cache_path()):
             # We're only interested in local, editable packages. This is not one.
             return None
-        except ValueError:
-            pass
         return os.fspath(path)
 
     @property

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -786,6 +786,14 @@ def format_lat_long(lat=None, long=None, secs=True):
     return ", ".join(rv)
 
 
+def split_camel_case(s: str) -> list[str]:
+    """Split camel-cased words.
+
+    This currently only works with ASCII strings.
+    """
+    return re.split(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|\s+", s.strip())
+
+
 def get_cache_dir():
     if is_windows:
         folder = os.environ.get("LOCALAPPDATA")

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -898,7 +898,7 @@ class RecursionCheck(threading.local):
 
     level = 0
 
-    def __enter__(self) -> bool:
+    def __enter__(self) -> int:
         self.level += 1
         return self.level
 

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -22,9 +22,6 @@ from lektor.pluginsystem import PluginController
 
 
 class DummyPlugin(Plugin):
-    name = "Dummy Plugin"
-    description = "For testing"
-
     # DummyPlugin.calls is test-local (see fixture dummy_plugin_calls, below)
     calls = []
 
@@ -121,6 +118,7 @@ def dummy_plugin_distribution(save_sys_path):
     dist = DummyDistribution(
         {
             "Name": "lektor-dummy-plugin",
+            "Summary": "The description.",
             "Version": "1.23",
         }
     )
@@ -186,6 +184,18 @@ class TestPlugin:
         del env
         with pytest.raises(RuntimeError, match=r"Environment went away"):
             _ = plugin.env
+
+    def test_name(self, dummy_plugin, dummy_plugin_distribution):
+        assert dummy_plugin.name == "Dummy"
+
+    def test_description(self, dummy_plugin, dummy_plugin_distribution):
+        assert dummy_plugin.description == dummy_plugin_distribution.metadata["Summary"]
+
+    def test_description_fallback(self, env):
+        # Create a plugin with no associated distribution.
+        # (This shouldn't happen in real Lektor runs.)
+        plugin = DummyPlugin(env, "dummy")
+        assert "no description available" in plugin.description
 
     def test_version(self, dummy_plugin, dummy_plugin_distribution):
         assert dummy_plugin.version == dummy_plugin_distribution.version
@@ -258,8 +268,8 @@ class TestPlugin:
     def test_to_json(self, dummy_plugin, dummy_plugin_distribution):
         assert dummy_plugin.to_json() == {
             "id": "dummy-plugin",
-            "name": DummyPlugin.name,
-            "description": DummyPlugin.description,
+            "name": dummy_plugin.name,
+            "description": dummy_plugin.description,
             "version": dummy_plugin_distribution.version,
             "import_name": f"{__name__}:DummyPlugin",
             "path": str(Path(__file__).parent),

--- a/tests/test_pluginsystem.py
+++ b/tests/test_pluginsystem.py
@@ -16,7 +16,6 @@ from lektor.cli import cli
 from lektor.context import Context
 from lektor.packages import add_package_to_project
 from lektor.pluginsystem import _check_dist_name
-from lektor.pluginsystem import _find_plugins
 from lektor.pluginsystem import get_plugin
 from lektor.pluginsystem import Plugin
 from lektor.pluginsystem import PluginController
@@ -265,11 +264,6 @@ class TestPlugin:
             "import_name": f"{__name__}:DummyPlugin",
             "path": str(Path(__file__).parent),
         }
-
-
-def test_find_plugins(dummy_plugin_distribution):
-    (ep,) = dummy_plugin_distribution.entry_points
-    assert list(_find_plugins()) == [(dummy_plugin_distribution, ep)]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from lektor.utils import make_relative_url
 from lektor.utils import parse_path
 from lektor.utils import secure_url
 from lektor.utils import slugify
+from lektor.utils import split_camel_case
 from lektor.utils import unique_everseen
 from lektor.utils import untrusted_to_os_path
 from lektor.utils import Url
@@ -186,6 +187,24 @@ def test_Url_anchor(sample_url):
 )
 def test_secure_url(url, expected):
     assert secure_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("ASeriousNote", ["A", "Serious", "Note"]),
+        ("TheIRSNeverSleeps", ["The", "IRS", "Never", "Sleeps"]),
+        ("Space Separated", ["Space", "Separated"]),
+        (" stripped ", ["stripped"]),
+        pytest.param(
+            "GrußGott",
+            ["Gruß", "Gott"],
+            marks=pytest.mark.xfail(reason="does not yet work with non-ascii"),
+        ),
+    ],
+)
+def test_split_camel_case(input, expected):
+    assert split_camel_case(input) == expected
 
 
 def test_url_builder():


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->
### Use importlib.metadata.entry_points to find entry points

The API to [importlib.metadata.entry_points] only stabilized in Python 3.10. Because of this, we had rolled-our-own solution to finding entry points that involved `importlib.metadata.distributions`.

Here we switch to using the `metadata.entry_points` API.  Not only does it result in cleaner code, but it also avoids a weird edge-case.

In certain circumstances, e.g. when setuptools installs a plugin in editable mode, one can wind up with both an `.egg-info` directory in the project source directory, as well as a `.dist-info` directory in the venv's `site-packages`, both for the same distribution packages. When this happens, `importlib.metadata.distributions` will return two `Distribution` instances for the same package.  This would confuse Lektor and elicit a `"RuntimeError: Plugin <xxx> is already registered"` exception. (Ref python/importlib_metadata#481, pypa/setuptools#3649.)

### Add properties to the `Plugin` base class to provide sane defaults for `.name` and `.description`

The default name is taken from the plugin subclass name, word-split on camel-case, and with any trailing `Plugin` discarded.  E.g. as plugin class named `MinifyPlugin` will get the default `.name` of `"Minify"`.

The default description is retrieved from the _Summary_ field of the distribution that contains the plugin.  This value is set by the `description` key in the `[project]` section of `pyproject.toml`, or by the `description` parameter to `setup()`, for example.

In any case, the old way of setting explicit `name` and/or `description` attributes on the plugin subclass still works and may be used if the defaults are not suitable.

### Misc

A few typing issues and checks for `None` have been fixed.  (I'm sure there are still plenty to fix.)

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->

[importlib.metadata.entry_points]: https://docs.python.org/3.10/library/importlib.metadata.html#entry-points