### PR TITLE
Support mistune 3

### DIFF
--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -25,10 +25,12 @@ controller_class: type[MarkdownController]
 
 
 MISTUNE_VERSION = metadata.version("mistune")
-if MISTUNE_VERSION.startswith("0."):
-    from lektor.markdown.mistune0 import MarkdownController0 as controller_class
+if MISTUNE_VERSION.startswith("3."):
+    from lektor.markdown.mistune3 import MarkdownController3 as controller_class
 elif MISTUNE_VERSION.startswith("2."):
     from lektor.markdown.mistune2 import MarkdownController2 as controller_class
+elif MISTUNE_VERSION.startswith("0."):
+    from lektor.markdown.mistune0 import MarkdownController0 as controller_class
 else:  # pragma: no cover
     raise ImportError("Unsupported version of mistune")
 

--- a/lektor/markdown/__init__.py
+++ b/lektor/markdown/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 from weakref import ref as weakref
 
+import packaging.version
 from markupsafe import Markup
 
 from lektor.markdown.controller import ControllerCache
@@ -25,14 +26,19 @@ controller_class: type[MarkdownController]
 
 
 MISTUNE_VERSION = metadata.version("mistune")
-if MISTUNE_VERSION.startswith("3."):
-    from lektor.markdown.mistune3 import MarkdownController3 as controller_class
-elif MISTUNE_VERSION.startswith("2."):
-    from lektor.markdown.mistune2 import MarkdownController2 as controller_class
-elif MISTUNE_VERSION.startswith("0."):
-    from lektor.markdown.mistune0 import MarkdownController0 as controller_class
-else:  # pragma: no cover
-    raise ImportError("Unsupported version of mistune")
+_mistune_version = packaging.version.parse(MISTUNE_VERSION)
+MISTUNE_MAJOR_VERSION = _mistune_version.major
+MISTUNE_VERSION_TUPLE = _mistune_version.release
+
+match MISTUNE_MAJOR_VERSION:
+    case 3:
+        from lektor.markdown.mistune3 import MarkdownController3 as controller_class
+    case 2:
+        from lektor.markdown.mistune2 import MarkdownController2 as controller_class
+    case 0:
+        from lektor.markdown.mistune0 import MarkdownController0 as controller_class
+    case _:
+        raise ImportError("Unsupported version of mistune")  # pragma: no cover
 
 
 get_controller = ControllerCache(controller_class)

--- a/lektor/markdown/mistune0.py
+++ b/lektor/markdown/mistune0.py
@@ -17,7 +17,6 @@ def escape(text: str) -> str:
 
 
 class ImprovedRenderer(
-    # pylint: disable=no-member
     mistune.Renderer  # type: ignore[misc]
 ):
     lektor: ClassVar = RendererHelper()
@@ -74,5 +73,4 @@ class MarkdownController0(MarkdownController, threading.local):
         env.plugin_controller.emit(
             "markdown-lexer-config", config=cfg, renderer=renderer
         )
-        # pylint: disable=unexpected-keyword-arg
         return mistune.Markdown(renderer, **cfg.options)

--- a/lektor/markdown/mistune0.py
+++ b/lektor/markdown/mistune0.py
@@ -61,7 +61,7 @@ class MarkdownConfig:
 
 class MarkdownController0(MarkdownController, threading.local):
     # NB: making this a threading.local means the results in the
-    # cached_property MarkdownController.parser having a separate
+    # cached_property MarkdownController.parser have a separate
     # value in each thread.
     #
     # We need that since the mistune 0.x parser is not thread-safe.

--- a/lektor/markdown/mistune3.py
+++ b/lektor/markdown/mistune3.py
@@ -1,0 +1,108 @@
+"""MarkdownController implementation for mistune 2.x"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from collections.abc import Sequence
+from typing import ClassVar
+from typing import TypedDict
+
+import mistune.util
+
+from lektor.markdown.controller import MarkdownController
+from lektor.markdown.controller import RendererHelper
+from lektor.markdown.controller import UnknownPluginError
+from lektor.utils import unique_everseen
+
+
+def escape(text: str) -> str:
+    # This is only here to provide the implementation for the
+    # deprecated lektor.markdown.escape method.
+    #
+    # (We don't use it below and it can be deleted once access
+    # to lektor.markdown.escape is removed.)
+    return mistune.util.escape(text, quote=True)
+
+
+class ImprovedRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
+    lektor: ClassVar = RendererHelper()
+
+    # The deprecated .record and .meta attributes are not made available here, since old
+    # renderer mixins (written for Lektor<3.4 and mistune 0.x) are not going to work
+    # with mistune 2.x anyway.
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        url = self.lektor.resolve_url(url)
+        return super().link(text, url, title)
+
+    def image(self, text: str, url: str, title: str | None = None) -> str:
+        url = self.lektor.resolve_url(url)
+        return super().image(text, url, title)
+
+
+class ParserConfigDict(TypedDict, total=False):
+    block: mistune.BlockParser
+    inline: mistune.InlineParser
+    plugins: Sequence[Callable[[mistune.Markdown], None] | str]
+
+
+MistunePlugin = Callable[[mistune.Markdown], None]
+
+
+class MarkdownConfig:
+    # Enabling these plugins give us feature parity with mistune 0.8.4.
+    # We enable them by default for the sake of backwards-compatibility.
+    DEFAULT_PLUGINS = ("url", "strikethrough", "footnotes", "table")
+
+    def __init__(self) -> None:
+        self.renderer_options = {
+            "escape": False,
+            "allow_harmful_protocols": True,
+        }
+        self.renderer_base = ImprovedRenderer
+        self.renderer_mixins: list[type] = []
+        self.parser_options: ParserConfigDict = {
+            "plugins": list(self.DEFAULT_PLUGINS),
+        }
+
+    def make_renderer(self) -> ImprovedRenderer:
+        bases = tuple(self.renderer_mixins) + (self.renderer_base,)
+        renderer_cls = type("renderer_cls", bases, {})
+        return renderer_cls(**self.renderer_options)
+
+
+class MarkdownController3(MarkdownController):
+    def make_parser(self) -> mistune.Markdown:
+        env = self.env
+        cfg = MarkdownConfig()
+        # FIXME: call different hooks here for mistune 3?
+        env.plugin_controller.emit("markdown-config", config=cfg)
+        renderer = cfg.make_renderer()
+        env.plugin_controller.emit(
+            "markdown-lexer-config", config=cfg, renderer=renderer
+        )
+        parser_options = cfg.parser_options
+        # FIXME: handle other parser_options.
+        # Pass, as appropriate to BlockParser, InlineParser, Renderer
+        plugins = parser_options.get("plugins")
+        if plugins:
+            plugins = tuple(unique_everseen(map(self.resolve_plugin, plugins)))
+        return mistune.Markdown(renderer, plugins=plugins)
+
+    def resolve_plugin(self, plugin: str | MistunePlugin) -> MistunePlugin:
+        if callable(plugin):
+            return plugin
+        if not isinstance(plugin, str):
+            raise TypeError(
+                f"Plugins should be specified as strings or callables, not {plugin!r}"
+            )
+
+        # Mistune3 uses '.' instead of ':' to separate module from
+        # function name. E.g. instead of `my.module:plugin`, mistune3
+        # wants `my.module.plugin`.
+        alldots = re.sub(r"(?<=\w) : (?= \w+ \Z)", ".", plugin, flags=re.VERBOSE)
+        try:
+            return mistune.plugins.import_plugin(alldots)
+        except (ImportError, AttributeError, ValueError) as exc:
+            raise UnknownPluginError(f"Can not load plugin {plugin!r}") from exc

--- a/lektor/markdown/mistune3.py
+++ b/lektor/markdown/mistune3.py
@@ -99,7 +99,8 @@ class MarkdownController3(MarkdownController):
             plugins = tuple(unique_everseen(map(self.resolve_plugin, plugins)))
         return mistune.Markdown(renderer, inline=LektorInlineParser(), plugins=plugins)
 
-    def resolve_plugin(self, plugin: str | MistunePlugin) -> MistunePlugin:
+    @staticmethod
+    def resolve_plugin(plugin: str | MistunePlugin) -> MistunePlugin:
         if callable(plugin):
             return plugin
         if not isinstance(plugin, str):

--- a/lektor/markdown/mistune3.py
+++ b/lektor/markdown/mistune3.py
@@ -32,6 +32,10 @@ class ImprovedRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
     # renderer mixins (written for Lektor<3.4 and mistune 0.x) are not going to work
     # with mistune 2.x anyway.
 
+    # NB: Under mistune 3 the renderer is responsible for xml-escaping the `url`
+    # parameter of `HTMLRenderer.link` and `.image`.  Under mistune 0 and 2 the URLs
+    # were passed the the renderer already escaped.
+
     def link(self, text: str, url: str, title: str | None = None) -> str:
         url = self.lektor.resolve_url(url)
         return super().link(text, url, title)
@@ -39,6 +43,11 @@ class ImprovedRenderer(mistune.HTMLRenderer):  # type: ignore[misc]
     def image(self, text: str, url: str, title: str | None = None) -> str:
         url = self.lektor.resolve_url(url)
         return super().image(text, url, title)
+
+
+class LektorInlineParser(mistune.InlineParser):
+    # FIXME: clean this up
+    lektor: ClassVar = ImprovedRenderer.lektor
 
 
 class ParserConfigDict(TypedDict, total=False):
@@ -88,7 +97,7 @@ class MarkdownController3(MarkdownController):
         plugins = parser_options.get("plugins")
         if plugins:
             plugins = tuple(unique_everseen(map(self.resolve_plugin, plugins)))
-        return mistune.Markdown(renderer, plugins=plugins)
+        return mistune.Markdown(renderer, inline=LektorInlineParser(), plugins=plugins)
 
     def resolve_plugin(self, plugin: str | MistunePlugin) -> MistunePlugin:
         if callable(plugin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "marshmallow",
     "marshmallow_dataclass>=8.5.9",
     "mistune>=0.7.0",
+    "packaging",
     "Pillow>=6",
     "pip",
     "python-slugify",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ pylint = [                      # requirements for running pylint
     "pytest-mock",
     "iniconfig",
 ]
-mistune0 = ["mistune<2"]        # pin old mistune for testing
-tzdata = ["tzdata"]             # test with tzdata rather than system zone data
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "MarkupSafe",
     "marshmallow",
     "marshmallow_dataclass>=8.5.9",
-    "mistune>=0.7.0,<3",
+    "mistune>=0.7.0",
     "Pillow>=6",
     "pip",
     "python-slugify",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -12,16 +12,15 @@ from subprocess import run
 import pytest
 
 import lektor
-from lektor.markdown import MISTUNE_VERSION
+from lektor.markdown import MISTUNE_MAJOR_VERSION
 
-
-ignored = set()
 
 # Do not check importability of module for the non-installed version of mistune
-if MISTUNE_VERSION.startswith("2"):
-    ignored.add("lektor.markdown.mistune0")
-else:
-    ignored.add("lektor.markdown.mistune2")
+ignored = {
+    f"lektor.markdown.mistune{mistune_version}"
+    for mistune_version in (0, 2, 3)
+    if mistune_version != MISTUNE_MAJOR_VERSION
+}
 
 
 def iter_lektor_modules():

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -198,6 +198,7 @@ def test_controller_cache(env):
 
 
 match MISTUNE_MAJOR_VERSION:
+    # pylint: disable=no-name-in-module
     case 0:
         plugin_url = ...
     case 2:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -11,7 +11,7 @@ from lektor.markdown import get_controller
 from lektor.markdown import make_markdown
 from lektor.markdown import Markdown
 from lektor.markdown import markdown_to_html
-from lektor.markdown import MISTUNE_VERSION
+from lektor.markdown import MISTUNE_MAJOR_VERSION
 from lektor.markdown.controller import get_renderer_context
 from lektor.markdown.controller import RendererContext
 from lektor.markdown.controller import RendererHelper
@@ -20,12 +20,22 @@ from lektor.markdown.controller import UnknownPluginError
 from lektor.pluginsystem import Plugin
 
 
-skip_mistune0 = pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
-only_mistune0 = pytest.mark.skipif(
-    not MISTUNE_VERSION.startswith("0."), reason="not mistune0"
-)
-skip_mistune2 = pytest.mark.skipif(MISTUNE_VERSION.startswith("2."), reason="mistune2")
-skip_mistune3 = pytest.mark.skipif(MISTUNE_VERSION.startswith("3."), reason="mistune3")
+def skip_mistune(major: int) -> pytest.MarkDecorator:
+    return pytest.mark.skipif(
+        MISTUNE_MAJOR_VERSION == major, reason=f"mistune {major}.x"
+    )
+
+
+def only_mistune(major: int) -> pytest.MarkDecorator:
+    return pytest.mark.skipif(
+        MISTUNE_MAJOR_VERSION != major, reason=f"not mistune {major}.x"
+    )
+
+
+def xfail_mistune(major: int) -> pytest.MarkDecorator:
+    return pytest.mark.xfail(
+        MISTUNE_MAJOR_VERSION == major, reason=f"mistune {major}.x"
+    )
 
 
 @pytest.fixture
@@ -163,12 +173,13 @@ def test_markdown_controller_parser_caching(markdown_controller):
     assert len(parsers) == 1
 
     _run_in_thread(get_parser)
-    if MISTUNE_VERSION.startswith("0."):
-        # mistune 0.x's parser is not thread-safe. We need one for each thread.
-        assert len(parsers) == 2
-    else:
-        # mistune 2.x's parser is thread-safe. It need not be thread-local.
-        assert len(parsers) == 1
+    match MISTUNE_MAJOR_VERSION:
+        case 0:
+            # mistune 0.x's parser is not thread-safe. We need one for each thread.
+            assert len(parsers) == 2
+        case _:
+            # mistune 2.x's parser is thread-safe. It need not be thread-local.
+            assert len(parsers) == 1
 
 
 @pytest.mark.parametrize("base_url", ["/BASE/"])
@@ -186,41 +197,42 @@ def test_controller_cache(env):
     assert get_controller(env) is controller
 
 
-if MISTUNE_VERSION.startswith("0."):
-    plugin_url = ...
-elif MISTUNE_VERSION.startswith("2."):
-    from mistune.plugins import plugin_url
-else:
-    from mistune.plugins.url import url as plugin_url
+match MISTUNE_MAJOR_VERSION:
+    case 0:
+        plugin_url = ...
+    case 2:
+        from mistune.plugins import plugin_url
+    case _:
+        from mistune.plugins.url import url as plugin_url
 
 
 def plugin_null(md):
     return md
 
 
-@skip_mistune0
+@skip_mistune(0)
 @pytest.mark.parametrize(
     "plugin, resolved",
     [
         (plugin_null, plugin_null),  # callable is already resolved
         ("url", plugin_url),  # resolve through mistune.PLUGINS
         # resolve via import
-        pytest.param("mistune.plugins:plugin_url", plugin_url, marks=skip_mistune3),
-        pytest.param("mistune.plugins.url:url", plugin_url, marks=skip_mistune2),
+        pytest.param("mistune.plugins:plugin_url", plugin_url, marks=skip_mistune(3)),
+        pytest.param("mistune.plugins.url:url", plugin_url, marks=skip_mistune(2)),
     ],
 )
 def test_markdown_controller_resolve_plugin(plugin, resolved, markdown_controller):
     assert markdown_controller.resolve_plugin(plugin) is resolved
 
 
-@skip_mistune0
+@skip_mistune(0)
 @pytest.mark.parametrize("plugin", ["badplugin", "unknown_module:badplugin"])
 def test_markdown_controller_resolve_plugin_unknown(plugin, markdown_controller):
     with pytest.raises(UnknownPluginError):
         markdown_controller.resolve_plugin(plugin)
 
 
-@skip_mistune0
+@skip_mistune(0)
 def test_markdown_controller_resolve_plugin_raises_typeerror(markdown_controller):
     with pytest.raises(TypeError):
         markdown_controller.resolve_plugin(None)
@@ -229,12 +241,13 @@ def test_markdown_controller_resolve_plugin_raises_typeerror(markdown_controller
 @pytest.fixture
 def improved_renderer():
     # pylint: disable=import-outside-toplevel
-    if MISTUNE_VERSION.startswith("0."):
-        from lektor.markdown.mistune0 import ImprovedRenderer
-    elif MISTUNE_VERSION.startswith("2."):
-        from lektor.markdown.mistune2 import ImprovedRenderer
-    else:
-        from lektor.markdown.mistune3 import ImprovedRenderer
+    match MISTUNE_MAJOR_VERSION:
+        case 0:
+            from lektor.markdown.mistune0 import ImprovedRenderer
+        case 2:
+            from lektor.markdown.mistune2 import ImprovedRenderer
+        case _:
+            from lektor.markdown.mistune3 import ImprovedRenderer
     return ImprovedRenderer()
 
 
@@ -249,18 +262,20 @@ def improved_renderer():
         ("a", None, "text", r'<a href="a/">text</a>\Z'),
         ("missing", None, "text", r'<a href="missing">text</a>\Z'),
         ("/", "T", "text", r'<a href="../" title="T">text</a>\Z'),
-        ("a&amp;b", None, "x", r'.* href="a&amp;b"'),
+        pytest.param("a&amp;b", None, "x", r'.* href="a&amp;b"', marks=skip_mistune(3)),
+        pytest.param("a&b", None, "x", r'.* href="a&amp;b"', marks=only_mistune(3)),
         ("/", "<title>", "x", r'.* title="&lt;title&gt;"'),
     ],
 )
 @pytest.mark.usefixtures("renderer_context")
 def test_ImprovedRenderer_link(link, title, text, expected, improved_renderer):
-    if MISTUNE_VERSION.startswith("0."):
-        result = improved_renderer.link(link, title, text)
-    elif MISTUNE_VERSION.startswith("2."):
-        result = improved_renderer.link(link, text, title)
-    else:
-        result = improved_renderer.link(text, link, title)
+    match MISTUNE_MAJOR_VERSION:
+        case 0:
+            result = improved_renderer.link(link, title, text)
+        case 2:
+            result = improved_renderer.link(link, text, title)
+        case _:
+            result = improved_renderer.link(text, link, title)
 
     assert re.match(expected, result)
 
@@ -275,52 +290,58 @@ def test_ImprovedRenderer_link(link, title, text, expected, improved_renderer):
         # this file.
         ("/test.jpg", None, "text", r'<img src="../test.jpg" alt="text"\s*/?>\Z'),
         ("/test.jpg", "T", "x", r'.* title="T"'),
-        ("&amp;c.gif", None, "x", r'.* src="&amp;c.gif"'),
+        pytest.param(
+            "&amp;c.gif", None, "x", r'.* src="&amp;c.gif"', marks=skip_mistune(3)
+        ),
+        pytest.param(
+            "&c.gif", None, "x", r'.* src="&amp;c.gif"', marks=only_mistune(3)
+        ),
         ("/test.jpg", "<title>", "x", r'.* title="&lt;title&gt;"'),
         ("/test.jpg", None, "x&y", r'.* alt="x&amp;y"'),
     ],
 )
 @pytest.mark.usefixtures("renderer_context")
 def test_ImprovedRenderer_image(src, title, alt, expected, improved_renderer):
-    if MISTUNE_VERSION.startswith("0."):
-        result = improved_renderer.image(src, title, alt)
-    elif MISTUNE_VERSION.startswith("2."):
-        result = improved_renderer.image(src, alt, title)
-    else:
-        result = improved_renderer.image(alt, src, title)
+    match MISTUNE_MAJOR_VERSION:
+        case 0:
+            result = improved_renderer.image(src, title, alt)
+        case 2:
+            result = improved_renderer.image(src, alt, title)
+        case _:
+            result = improved_renderer.image(alt, src, title)
     assert re.match(expected, result.rstrip())
 
 
-def plugin_linkcount(md):
+def plugin_motd2(md):
     """A test mistune2 plugin.
 
-    This replaces ``[link-count]`` in text with the current link count
+    This replaces ``[motd]`` in text with the value of ``meta["motd"]``
     wrapped in a <code> element.
     """
 
-    def parse_linkcount(inline, _m, state):
-        nlinks = inline.renderer.lektor.meta["nlinks"]
-        if MISTUNE_VERSION.startswith("2."):
-            return "codespan", str(nlinks)
-        else:
-            state.append_token({"type": "codespan", "raw": str(nlinks)})
+    def parse_motd(inline, _m, _state):
+        # FIXME: stick lektor helper on inline renderer here, too
+        motd = inline.renderer.lektor.meta["motd"]
+        return "codespan", str(motd)
 
-    if MISTUNE_VERSION.startswith("2."):
+    md.inline.register_rule("motd", r"\[motd\]", parse_motd)
+    index = md.inline.rules.index("ref_link2")
+    md.inline.rules.insert(index, "motd")
 
-        def parse_linkcount(inline, _m, _state):
-            nlinks = inline.renderer.lektor.meta["nlinks"]
-            return "codespan", str(nlinks)
 
-        md.inline.register_rule("link_count", r"\[link-count\]", parse_linkcount)
-        index = md.inline.rules.index("ref_link2")
-        md.inline.rules.insert(index, "link_count")
-    else:
+def plugin_motd3(md):
+    """A test mistune3 plugin.
 
-        def parse_linkcount(inline, _m, state):
-            nlinks = inline.renderer.lektor.meta["nlinks"]
-            state.append_token({"type": "codespan", "raw": str(nlinks)})
+    This replaces ``[motd]`` in text with the value of ``meta["motd"]``
+    wrapped in a <code> element.
+    """
 
-        md.inline.register("link_count", r"\[link-count\]", parse_linkcount)
+    def parse_motd(inline, m, state):
+        motd = inline.lektor.meta["motd"]
+        state.append_token({"type": "codespan", "raw": str(motd)})
+        return m.end()
+
+    md.inline.register("motd", r"\[motd\]", parse_motd, before="link")
 
 
 class LinkCounterPlugin(Plugin):
@@ -339,14 +360,17 @@ class LinkCounterPlugin(Plugin):
 
     @staticmethod
     def on_markdown_lexer_config(config, renderer, **kwargs):
-        if not hasattr(config, "parser_options"):
-            return  # mistune 0
         # Configure a plugin just to make sure we can
-        config.parser_options.setdefault("plugins", []).append(plugin_linkcount)
+        match MISTUNE_MAJOR_VERSION:
+            case 2:
+                config.parser_options.setdefault("plugins", []).append(plugin_motd2)
+            case 3:
+                config.parser_options.setdefault("plugins", []).append(plugin_motd3)
 
     def on_markdown_meta_init(self, meta, **kwargs):
         # pylint: disable=no-self-use
         meta["nlinks"] = 0
+        meta["motd"] = "hello"
 
 
 @pytest.fixture
@@ -411,12 +435,12 @@ class TestMarkdown:
     def test_getitem(self, markdown):
         assert markdown["nlinks"] == 0
 
-    @pytest.mark.parametrize("source", ["[x](/y) [link-count]"])
+    @pytest.mark.parametrize("source", ["[x](/y) [motd]"])
     @pytest.mark.usefixtures("context", "link_counter_plugin")
-    @skip_mistune0
+    @skip_mistune(0)
     def test_linkcount_plugin(self, markdown):
         assert markdown["nlinks"] == 1
-        assert re.search(r"<code>1</code>", markdown.html)
+        assert re.search(r"<code>hello</code>", markdown.html)
 
     @pytest.mark.usefixtures("context")
     def test_str(self, markdown):
@@ -432,9 +456,6 @@ def _normalize_html(output: str | Markup) -> str:
     html = html.replace("&copy;", "©")
     html = re.sub(r"(<img [^>]*?)\s*/>", r"\1>", html)
     return html
-
-
-xfail_mistune3 = pytest.mark.xfail(MISTUNE_VERSION.startswith("3."), reason="mistune 3")
 
 
 @pytest.mark.parametrize(
@@ -464,10 +485,12 @@ xfail_mistune3 = pytest.mark.xfail(MISTUNE_VERSION.startswith("3."), reason="mis
         ("![&copy;](x)", r'.*<img\b[^>]* alt="©"'),
         # mistune3 bug? see https://github.com/miyuchina/mistletoe/issues/266
         pytest.param(
-            "![<br>](x)", r'.*<img\b[^>]* alt="&lt;br&gt;"', marks=xfail_mistune3
+            "![<br>](x)", r'.*<img\b[^>]* alt="&lt;br&gt;"', marks=xfail_mistune(3)
         ),
-        pytest.param("![&](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune3),
-        pytest.param("![&amp;](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune3),
+        pytest.param("![&](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune(3)),
+        pytest.param(
+            "![&amp;](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune(3)
+        ),
         # Various image titles
         ('![x](y "<br>")', r'.*<img\b[^>]* title="&lt;br&gt;"'),
         ('![x](y "&lt;")', r'.*<img\b[^>]* title="&lt;"'),
@@ -520,7 +543,7 @@ def test_deprecated_ImprovedRenderer(improved_renderer):
     assert isinstance(improved_renderer, ImprovedRenderer)
 
 
-@only_mistune0
+@only_mistune(0)
 @pytest.mark.usefixtures("renderer_context")
 def test_deprecated_ImprovedRenderer_record(record):
     with pytest.deprecated_call():
@@ -535,7 +558,7 @@ def test_deprecated_ImprovedRenderer_record(record):
     assert all(w.filename == __file__ for w in warnings)
 
 
-@only_mistune0
+@only_mistune(0)
 def test_deprecated_ImprovedRenderer_meta(renderer_context):
     with pytest.deprecated_call():
         # pylint: disable-next=import-outside-toplevel,no-name-in-module
@@ -574,6 +597,8 @@ def test_getattr_raises():
 def test_dir():
     expected = {
         "MISTUNE_VERSION",
+        "MISTUNE_MAJOR_VERSION",
+        "MISTUNE_VERSION_TUPLE",
         "Markdown",
         "get_controller",
         "escape",
@@ -600,7 +625,7 @@ def test_deprecated_markdown_to_html(record, field_options):
     assert result.html.rstrip() == "<p>goober</p>"
 
 
-@only_mistune0
+@only_mistune(0)
 @pytest.mark.usefixtures("context")
 def test_legacy_plugin(env, record, field_options):
     # Test that Lektor<3.4 style plugin works

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -198,7 +198,7 @@ def test_controller_cache(env):
 
 
 match MISTUNE_MAJOR_VERSION:
-    # pylint: disable=no-name-in-module
+    # pylint: disable=no-name-in-module,import-error
     case 0:
         plugin_url = ...
     case 2:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -20,6 +20,14 @@ from lektor.markdown.controller import UnknownPluginError
 from lektor.pluginsystem import Plugin
 
 
+skip_mistune0 = pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+only_mistune0 = pytest.mark.skipif(
+    not MISTUNE_VERSION.startswith("0."), reason="not mistune0"
+)
+skip_mistune2 = pytest.mark.skipif(MISTUNE_VERSION.startswith("2."), reason="mistune2")
+skip_mistune3 = pytest.mark.skipif(MISTUNE_VERSION.startswith("3."), reason="mistune3")
+
+
 @pytest.fixture
 def record_path():
     return "/extra"
@@ -155,12 +163,12 @@ def test_markdown_controller_parser_caching(markdown_controller):
     assert len(parsers) == 1
 
     _run_in_thread(get_parser)
-    if MISTUNE_VERSION.startswith("2."):
-        # mistune 2.x's parser is thread-safe. It need not be thread-local.
-        assert len(parsers) == 1
-    else:
+    if MISTUNE_VERSION.startswith("0."):
         # mistune 0.x's parser is not thread-safe. We need one for each thread.
         assert len(parsers) == 2
+    else:
+        # mistune 2.x's parser is thread-safe. It need not be thread-local.
+        assert len(parsers) == 1
 
 
 @pytest.mark.parametrize("base_url", ["/BASE/"])
@@ -180,35 +188,39 @@ def test_controller_cache(env):
 
 if MISTUNE_VERSION.startswith("0."):
     plugin_url = ...
-else:
+elif MISTUNE_VERSION.startswith("2."):
     from mistune.plugins import plugin_url
+else:
+    from mistune.plugins.url import url as plugin_url
 
 
 def plugin_null(md):
     return md
 
 
-@pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+@skip_mistune0
 @pytest.mark.parametrize(
     "plugin, resolved",
     [
         (plugin_null, plugin_null),  # callable is already resolved
         ("url", plugin_url),  # resolve through mistune.PLUGINS
-        ("mistune.plugins:plugin_url", plugin_url),  # resolve via import
+        # resolve via import
+        pytest.param("mistune.plugins:plugin_url", plugin_url, marks=skip_mistune3),
+        pytest.param("mistune.plugins.url:url", plugin_url, marks=skip_mistune2),
     ],
 )
 def test_markdown_controller_resolve_plugin(plugin, resolved, markdown_controller):
     assert markdown_controller.resolve_plugin(plugin) is resolved
 
 
-@pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+@skip_mistune0
 @pytest.mark.parametrize("plugin", ["badplugin", "unknown_module:badplugin"])
 def test_markdown_controller_resolve_plugin_unknown(plugin, markdown_controller):
     with pytest.raises(UnknownPluginError):
         markdown_controller.resolve_plugin(plugin)
 
 
-@pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+@skip_mistune0
 def test_markdown_controller_resolve_plugin_raises_typeerror(markdown_controller):
     with pytest.raises(TypeError):
         markdown_controller.resolve_plugin(None)
@@ -217,10 +229,12 @@ def test_markdown_controller_resolve_plugin_raises_typeerror(markdown_controller
 @pytest.fixture
 def improved_renderer():
     # pylint: disable=import-outside-toplevel
-    if MISTUNE_VERSION.startswith("2."):
+    if MISTUNE_VERSION.startswith("0."):
+        from lektor.markdown.mistune0 import ImprovedRenderer
+    elif MISTUNE_VERSION.startswith("2."):
         from lektor.markdown.mistune2 import ImprovedRenderer
     else:
-        from lektor.markdown.mistune0 import ImprovedRenderer
+        from lektor.markdown.mistune3 import ImprovedRenderer
     return ImprovedRenderer()
 
 
@@ -241,10 +255,13 @@ def improved_renderer():
 )
 @pytest.mark.usefixtures("renderer_context")
 def test_ImprovedRenderer_link(link, title, text, expected, improved_renderer):
-    if MISTUNE_VERSION.startswith("2."):
+    if MISTUNE_VERSION.startswith("0."):
+        result = improved_renderer.link(link, title, text)
+    elif MISTUNE_VERSION.startswith("2."):
         result = improved_renderer.link(link, text, title)
     else:
-        result = improved_renderer.link(link, title, text)
+        result = improved_renderer.link(text, link, title)
+
     assert re.match(expected, result)
 
 
@@ -265,10 +282,12 @@ def test_ImprovedRenderer_link(link, title, text, expected, improved_renderer):
 )
 @pytest.mark.usefixtures("renderer_context")
 def test_ImprovedRenderer_image(src, title, alt, expected, improved_renderer):
-    if MISTUNE_VERSION.startswith("2."):
+    if MISTUNE_VERSION.startswith("0."):
+        result = improved_renderer.image(src, title, alt)
+    elif MISTUNE_VERSION.startswith("2."):
         result = improved_renderer.image(src, alt, title)
     else:
-        result = improved_renderer.image(src, title, alt)
+        result = improved_renderer.image(alt, src, title)
     assert re.match(expected, result.rstrip())
 
 
@@ -279,13 +298,29 @@ def plugin_linkcount(md):
     wrapped in a <code> element.
     """
 
-    def parse_linkcount(inline, _m, _state):
+    def parse_linkcount(inline, _m, state):
         nlinks = inline.renderer.lektor.meta["nlinks"]
-        return "codespan", str(nlinks)
+        if MISTUNE_VERSION.startswith("2."):
+            return "codespan", str(nlinks)
+        else:
+            state.append_token({"type": "codespan", "raw": str(nlinks)})
 
-    md.inline.register_rule("link_count", r"\[link-count\]", parse_linkcount)
-    index = md.inline.rules.index("ref_link2")
-    md.inline.rules.insert(index, "link_count")
+    if MISTUNE_VERSION.startswith("2."):
+
+        def parse_linkcount(inline, _m, _state):
+            nlinks = inline.renderer.lektor.meta["nlinks"]
+            return "codespan", str(nlinks)
+
+        md.inline.register_rule("link_count", r"\[link-count\]", parse_linkcount)
+        index = md.inline.rules.index("ref_link2")
+        md.inline.rules.insert(index, "link_count")
+    else:
+
+        def parse_linkcount(inline, _m, state):
+            nlinks = inline.renderer.lektor.meta["nlinks"]
+            state.append_token({"type": "codespan", "raw": str(nlinks)})
+
+        md.inline.register("link_count", r"\[link-count\]", parse_linkcount)
 
 
 class LinkCounterPlugin(Plugin):
@@ -378,7 +413,7 @@ class TestMarkdown:
 
     @pytest.mark.parametrize("source", ["[x](/y) [link-count]"])
     @pytest.mark.usefixtures("context", "link_counter_plugin")
-    @pytest.mark.skipif(MISTUNE_VERSION.startswith("0."), reason="mistune0")
+    @skip_mistune0
     def test_linkcount_plugin(self, markdown):
         assert markdown["nlinks"] == 1
         assert re.search(r"<code>1</code>", markdown.html)
@@ -397,6 +432,9 @@ def _normalize_html(output: str | Markup) -> str:
     html = html.replace("&copy;", "©")
     html = re.sub(r"(<img [^>]*?)\s*/>", r"\1>", html)
     return html
+
+
+xfail_mistune3 = pytest.mark.xfail(MISTUNE_VERSION.startswith("3."), reason="mistune 3")
 
 
 @pytest.mark.parametrize(
@@ -424,9 +462,12 @@ def _normalize_html(output: str | Markup) -> str:
         # Various image alts
         ("![©](x)", r'.*<img\b[^>]* alt="©"'),
         ("![&copy;](x)", r'.*<img\b[^>]* alt="©"'),
-        ("![<br>](x)", r'.*<img\b[^>]* alt="&lt;br&gt;"'),
-        ("![&](x)", r'.*<img\b[^>]* alt="&amp;"'),
-        ("![&amp;](x)", r'.*<img\b[^>]* alt="&amp;"'),
+        # mistune3 bug? see https://github.com/miyuchina/mistletoe/issues/266
+        pytest.param(
+            "![<br>](x)", r'.*<img\b[^>]* alt="&lt;br&gt;"', marks=xfail_mistune3
+        ),
+        pytest.param("![&](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune3),
+        pytest.param("![&amp;](x)", r'.*<img\b[^>]* alt="&amp;"', marks=xfail_mistune3),
         # Various image titles
         ('![x](y "<br>")', r'.*<img\b[^>]* title="&lt;br&gt;"'),
         ('![x](y "&lt;")', r'.*<img\b[^>]* title="&lt;"'),
@@ -479,7 +520,7 @@ def test_deprecated_ImprovedRenderer(improved_renderer):
     assert isinstance(improved_renderer, ImprovedRenderer)
 
 
-@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+@only_mistune0
 @pytest.mark.usefixtures("renderer_context")
 def test_deprecated_ImprovedRenderer_record(record):
     with pytest.deprecated_call():
@@ -494,7 +535,7 @@ def test_deprecated_ImprovedRenderer_record(record):
     assert all(w.filename == __file__ for w in warnings)
 
 
-@pytest.mark.skipif(not MISTUNE_VERSION.startswith("0."), reason="not mistune0")
+@only_mistune0
 def test_deprecated_ImprovedRenderer_meta(renderer_context):
     with pytest.deprecated_call():
         # pylint: disable-next=import-outside-toplevel,no-name-in-module
@@ -559,10 +600,7 @@ def test_deprecated_markdown_to_html(record, field_options):
     assert result.html.rstrip() == "<p>goober</p>"
 
 
-@pytest.mark.skipif(
-    not MISTUNE_VERSION.startswith("0."),
-    reason="Legacy renderer mixins will only work with mistune 0.x",
-)
+@only_mistune0
 @pytest.mark.usefixtures("context")
 def test_legacy_plugin(env, record, field_options):
     # Test that Lektor<3.4 style plugin works

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
     # skip building frontend js/css
     HATCH_BUILD_NO_HOOKS=true
     # do not run marked slow tests in every variant testenv
-    {mistune0,noutils,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
+    {mistune0,mistune2,noutils,tzdata}: PYTEST_ADDOPTS=-m "not slowtest"
     # To test in environment without external utitilities like ffmpeg and git installed,
     # break PATH in noutils environment(s).
     noutils: command_prefix=env PATH="{env_bin_dir}"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.22
 envlist =
     lint
-    {py310,py311,py312,py313,py314}{,-mistune0}
+    {py310,py311,py312,py313,py314}{,-mistune0,-mistune2}
     py311-noutils
     py311-tzdata
     cover-{clean,report}
@@ -27,9 +27,10 @@ setenv =
     # To test in environment without external utitilities like ffmpeg and git installed,
     # break PATH in noutils environment(s).
     noutils: command_prefix=env PATH="{env_bin_dir}"
-dependency_groups =
-    pytest
-    mistune0: mistune0
+dependency_groups = pytest
+deps =
+    mistune0: mistune==0.*
+    mistune2: mistune==2.*
     tzdata: tzdata
 allowlist_externals = env
 depends =

--- a/tox.ini
+++ b/tox.ini
@@ -39,10 +39,24 @@ depends =
 
 [testenv:lint]
 base_python = py314,py313,py312,py311,py310
-use_develop = true
 dependency_groups = pylint
+use_develop = true
 commands =
     pylint {posargs:--ignore mistune0.py,mistune2.py lektor tests}
+
+[testenv:lint-mistune2]
+base_python = {[testenv:lint]base_python}
+dependency_groups = pylint
+use_develop = true
+commands =
+    pylint {posargs:--ignore mistune0.py,mistune3.py lektor tests}
+
+[testenv:lint-mistune0]
+base_python = {[testenv:lint]base_python}
+dependency_groups = pylint
+use_develop = true
+commands =
+    pylint {posargs:--ignore mistune2.py,mistune3.py lektor tests}
 
 [testenv:cover-clean]
 deps = coverage[toml]

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ base_python = py314,py313,py312,py311,py310
 use_develop = true
 dependency_groups = pylint
 commands =
-    pylint {posargs:lektor tests}
+    pylint {posargs:--ignore mistune0.py,mistune2.py lektor tests}
 
 [testenv:cover-clean]
 deps = coverage[toml]


### PR DESCRIPTION
Work on supporting mistune 3.x.

Every major version of mistune subtly changes the API to, e.g., the Renderers.  Things like argument order to `Renderer.link`, as well as whether some of the arguments are already xml-escaped or whether that is the responsibility of the rendering method.

Really, I'd like to only have to support one version of mistune, however, that would likely break any existing Lektor plugins that are assume a different version of mistune.
Once we relax our pin on `mistune<3`, those plugins are likely to break anyway, but, if Lektor supports any mistune version, the plugin (or user) can pin an appropriate version of mistune and things will still work.

Ugh.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #1156

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
