### PR TITLE
add hint when it cannot find a project.

### DIFF
--- a/lektor/cli_utils.py
+++ b/lektor/cli_utils.py
@@ -89,7 +89,7 @@ class Context:
                     "Could not automatically discover "
                     "project.  A Lektor project must "
                     "exist in the working directory or "
-                    "any of the parent directories."
+                    "any of the parent directories (use --project <path> flag)."
                 )
             raise click.UsageError(f'Could not find project "{self._project_path}"')
         self._project = rv

--- a/lektor/cli_utils.py
+++ b/lektor/cli_utils.py
@@ -86,10 +86,11 @@ class Context:
                 return None
             if self._project_path is None:
                 raise click.UsageError(
-                    "Could not automatically discover "
-                    "project.  A Lektor project must "
-                    "exist in the working directory or "
-                    "any of the parent directories (use --project <path> flag)."
+                    "Could not automatically discover a "
+                    "project in the working or ancestor directories. "
+                    "The --project global parameter or the "
+                    "LEKTOR_PROJECT environment variable may be used "
+                    "to explicitly specify the path to the project."
                 )
             raise click.UsageError(f'Could not find project "{self._project_path}"')
         self._project = rv

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_alias(project_cli_runner):
 def test_dev_cmd_alias(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["dev", "s"])  # short for 'shell'
     assert result.exit_code == 2
-    assert "Error: Could not automatically discover project" in result.output
+    assert "Error: Could not automatically discover a project" in result.output
 
 
 def test_alias_multiple_matches(project_cli_runner):
@@ -60,7 +60,7 @@ def test_alias_no_matches(project_cli_runner):
 def test_build_no_project(isolated_cli_runner):
     result = isolated_cli_runner.invoke(cli, ["build"])
     assert result.exit_code == 2
-    assert "Could not automatically discover project." in result.output
+    assert "Could not automatically discover a project" in result.output
 
 
 def test_build(project_cli_runner):


### PR DESCRIPTION
### Issue(s) Resolved

improving the error message when there's no project in a standard location:
```
uv run lektor build -O build/site

Error: Could not automatically discover project.  A Lektor project must exist in the working directory or any of the parent directories.
```

This will add an hint:
```
Error: Could not automatically discover project.  A Lektor project must exist in the working directory or any of the parent directories (use --project <path> flag).
```

Eg. It adds `(use --project <path> flag)` and the end.

Fixes #1258

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
