### PR TITLE
allow use of lektor without install

### DIFF
--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from importlib import metadata
 from itertools import chain
+from pathlib import Path
 
 import click
 
@@ -19,7 +20,10 @@ from lektor.project import Project
 from lektor.utils import secure_url
 
 
-version = metadata.version("Lektor")
+try:
+    version = metadata.version("Lektor")
+except metadata.PackageNotFoundError:
+    version = f"local ({Path(__file__).absolute().parent})"
 
 
 @click.group(cls=AliasedGroup)


### PR DESCRIPTION
### Issue(s) Resolved

Allows running lektor without `pip install -e`, using a simple `PYTHONPATH`.

This allows scenario like for testing versions side by side like:
```
git clone https://github.com/lektor/lektor lektor.master
PYTHONPATH=$(pwd)/lektor.master pytest -vvs lektor.master/tests
```

Fixes #1261

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
