### PR TITLE
lint: use prek for pre-commit hooks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,15 +24,15 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Install node dependencies
         run: make frontend/node_modules
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
           cache: "pip"
@@ -46,7 +46,7 @@ jobs:
       - name: Run pylint
         run: tox -e lint
       - name: Run prek
-        uses: j178/prek-action@v2
+        uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
         # run pre-commit check even if pylint check fails
         if: steps.pip.outcome == 'success'
 
@@ -65,8 +65,8 @@ jobs:
           - node: "current"
             os: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
@@ -96,13 +96,13 @@ jobs:
           - { os: "windows-latest", python: "3.14", install-ffmpeg: true }
           - { python: "3.14", install-ffmpeg: true }
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
           cache: "npm"
@@ -138,7 +138,7 @@ jobs:
         env:
           TOX_SKIP_ENV: ${{ matrix.tox_skip_env }}
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data-${{ matrix.python }}-${{ matrix.os }}
           path: .coverage*
@@ -151,10 +151,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv tool install coverage[toml]
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -165,7 +165,7 @@ jobs:
           coverage html
           coverage xml
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: |
@@ -179,13 +179,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -198,7 +198,7 @@ jobs:
         run: python -m build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -223,12 +223,12 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,22 +37,18 @@ jobs:
           python-version: "3.x"
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install python dependencies
         id: pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox tox-uv pre-commit
+          python -m pip install tox tox-uv
           python -m pip freeze --local
       - name: Run pylint
         run: tox -e lint
-      - name: Run pre-commit
+      - name: Run prek
+        uses: j178/prek-action@v2
         # run pre-commit check even if pylint check fails
         if: steps.pip.outcome == 'success'
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   ############################################################################
   # Node tests

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-js: frontend/node_modules
 .PHONY: lint
 # Lint code.
 lint:
-	pre-commit run -a
+	uv run prek run -v -a
 	tox -e lint
 
 .PHONY: test
@@ -35,5 +35,5 @@ test: lint test-python test-js
 .PHONY: test-all
 # Run tests on all supported Python versions.
 test-all: test-js
-	pre-commit run -a
+	uv run prek run -v -a
 	tox

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ For installation instructions head to the official documentation:
 ## Want to develop on Lektor?
 
 This gets you started (assuming you have [Python] >= 3.10, [npm], and
-[pre-commit] installed):
+[uv] installed):
 
 [python]: https://www.python.org/
-[pre-commit]: https://pre-commit.com/
+[uv]: https://docs.astral.sh/uv/
 [npm]: https://nodejs.org/
 
 ```bash
@@ -50,7 +50,7 @@ $ pip install -U "pip>=25.1"
 $ pip install --group dev --editable .
 
 # If you plan on committing:
-$ pre-commit install
+$ uv run prek install
 
 # Run the Lektor server
 $ export LEKTOR_DEV=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ lektor = "lektor.cli:main"
 [dependency-groups]
 dev = [                         # generally useful during development
     {include-group = "pytest"},
+    {include-group = "prek"},
 ]
 pytest = [                 # requirements for running our pytest tests
     "pytest>=6",
@@ -77,6 +78,7 @@ pylint = [                      # requirements for running pylint
     "pytest-mock",
     "iniconfig",
 ]
+prek = ["prek"]                 # Running pre-commit hooks with prek.
 mistune0 = ["mistune<2"]        # pin old mistune for testing
 tzdata = ["tzdata"]             # test with tzdata rather than system zone data
 


### PR DESCRIPTION
pre-commit broke for our node-based hooks, prek is more reliable and
performance AFAICT while being very compatible

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Wrote at least one-line docstrings (for any new functions)
- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
- [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))
- [ ] Link to corresponding documentation pull request for [getlektor.com](https://github.com/lektor/lektor-website)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
