### PR TITLE
Fix racelet in atomic open

### DIFF
--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -574,6 +574,8 @@ def atomic_open(
     filename: StrPath,
     mode: _AtomicOpenTextMode = "r",
     encoding: str | None = None,
+    *,
+    fsync: bool = True,
 ) -> Iterator[io.TextIOWrapper]: ...
 
 
@@ -583,6 +585,8 @@ def atomic_open(
     filename: StrPath,
     mode: _AtomicOpenBinaryModeWriting,
     encoding: None = None,
+    *,
+    fsync: bool = True,
 ) -> Iterator[io.BufferedWriter]: ...
 
 
@@ -592,12 +596,18 @@ def atomic_open(
     filename: StrPath,
     mode: _AtomicOpenBinaryModeReading,
     encoding: None = None,
+    *,
+    fsync: bool = True,
 ) -> Iterator[io.BufferedReader]: ...
 
 
 @contextmanager
 def atomic_open(
-    filename: StrPath, mode: _AtomicOpenMode = "r", encoding: str | None = None
+    filename: StrPath,
+    mode: _AtomicOpenMode = "r",
+    encoding: str | None = None,
+    *,
+    fsync: bool = True,
 ) -> Iterator[IO[Any]]:
     """Open a file for atomic update.
 
@@ -609,6 +619,12 @@ def atomic_open(
 
     If an exception is thrown during this process the temporary file is silently
     deleted.
+
+    To avoid to possibility of leaving a partially written file (e.g. in the event of
+    sudden power loss), when ``fsync`` is ``True`` (the default), an attempt is made to
+    ensure that all buffers are flushed to disc before the file is renamed to the
+    target. This can take a bit of time.  If that additional delay is unacceptable, set
+    ``fsync`` to ``False``.
 
     """
     if any(c in mode for c in "ax+"):
@@ -627,6 +643,9 @@ def atomic_open(
     try:
         with open(fd, mode, encoding=encoding) as fp:
             yield fp
+            if fsync:
+                fp.flush()
+                os.fsync(fd)
         os.replace(tmp_filename, filename)
     except Exception:
         with suppress(OSError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path
+from unittest import mock
 from urllib.parse import urlsplit
 
 import pytest
@@ -317,6 +318,21 @@ def test_atomic_open_raises_on_bad_mode(tmp_path, mode):
     with pytest.raises(ValueError, match="mode"):
         with atomic_open(tmp_path / "file.txt", mode):
             pass
+
+
+def test_atomic_open_fsync(tmp_path):
+    with mock.patch("os.fsync", autospec=True) as os_fsync:
+        with atomic_open(tmp_path / "file.txt", "w") as fp:
+            fd = fp.fileno()
+            fp.write("x")
+    os_fsync.assert_called_once_with(fd)
+
+
+def test_atomic_open_no_fsync(tmp_path):
+    with mock.patch("os.fsync", autospec=True) as os_fsync:
+        with atomic_open(tmp_path / "file.txt", "w", fsync=False) as fp:
+            fp.write("x")
+    os_fsync.assert_not_called()
 
 
 def test_create_temp(tmp_path):


### PR DESCRIPTION
In [utils.atomic_open], `fsync` the temporary file before attempting to `os.replace` it to its final destination.

This prevents replacing the destination with a partially written file if, e.g., power is lost before the file content is flushed to disc.

### Possible performance bottleneck?

The call to `fsync` does not return until all kernel file buffers associated with the file are written to disc; this can take some time.

Currently, we only call `atomic_open` from [EditorSession], which, in turn, is only used by the admin API for saving edits and uploading attachments.  In these cases, a short delay seems acceptable.



[utils.atomic_open]: https://github.com/lektor/lektor/blob/addd26df9e13080989b6d9d2e437b15b3c2c9041/lektor/utils.py#L579-L614
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->





### Description of Changes

- [ ] Added unit test(s) covering the changes (if testable)


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
