### PR TITLE
Fix Directory Traversal Vulnerability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ These are all the changes in Lektor since the first public release.
 
 ### Fixes
 
+- Fix directory traversal vulnerability. When running on Windows, it was possible to write outside of the project's `content` sub-directory via the admin API.
+  Thank you to Arpit Jain (@arpitjain099) for the detailed report.
+
 - Update pins to exclude `mistune` 2.0.x, which have a bug relating to
   overzealous unescaping of HTML entities. ([#1272])
 

--- a/lektor/editor.py
+++ b/lektor/editor.py
@@ -19,7 +19,6 @@ from lektor.utils import atomic_open
 from lektor.utils import cleanup_path
 from lektor.utils import increment_filename
 from lektor.utils import is_valid_id
-from lektor.utils import parse_path
 from lektor.utils import secure_filename
 
 
@@ -35,18 +34,13 @@ class BadDelete(BadEdit):
     pass
 
 
-def _is_valid_path(path: str) -> bool:
-    split_path = path.strip("/").split("/")
-    if split_path == [""]:
-        split_path = []
-    return parse_path(path) == split_path
-
-
 def make_editor_session(pad, path, is_attachment=None, alt=PRIMARY_ALT, datamodel=None):
-    """Creates an editor session for the given path object."""
-    if not _is_valid_path(path):
+    """Creates an editor session for the object at the given db path and alt."""
+    # path must be a canonical db-path,
+    # though for b/c we will accept paths without a leading "/"
+    path = path if path.startswith("/") else f"/{path}"
+    if cleanup_path(path) != path:
         raise BadEdit("Invalid path")
-    path = cleanup_path(path)
 
     if alt != PRIMARY_ALT and not pad.db.config.is_valid_alternative(alt):
         raise BadEdit(f"Attempted to edit an invalid alternative ({alt})")

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -108,7 +108,20 @@ def join_path(a, b):
     return rv
 
 
-def cleanup_path(path):
+def cleanup_path(path: str) -> str:
+    """Normalize up a db path.
+
+    A normalized db path will follows the semantics of an absolute POSIX path, with any
+    directory traversal path elements (``..`` or ``.``) resolved.
+
+    NB: This function is intended for use only on Lektor DB paths.  It is not intended
+    to be used on file-system paths. Lektor DB paths assume POSIX path semantics, so if
+    running under Windows, file-system semantics will differ.
+
+    """
+    # Protect against directory traversal attacks when running under Windows.
+    path = path.replace("\\", "/")
+
     # NB: POSIX allows for two leading slashes in a pathname, so we have to
     # deal with the possiblity of leading double-slash ourself.
     return posixpath.normpath("/" + path.lstrip("/"))
@@ -158,7 +171,14 @@ def is_path_child_of(a, b, strict=True):
     return a_p[: len(b_p)] == b_p and len(a_p) > len(b_p)
 
 
-def untrusted_to_os_path(path):
+def untrusted_to_os_path(path: str | bytes) -> str:
+    """Convert an untrusted (user-input) DB path to a relative file-system path.
+
+    NB: This function is intended for use only on Lektor DB paths.  It is not intended
+    to be used on file-system paths. Lektor DB paths assume POSIX path semantics, so if
+    running under Windows, file-system semantics will differ.
+
+    """
     if not isinstance(path, str):
         path = path.decode(fs_enc, "replace")
     clean_path = cleanup_path(path)

--- a/lektor/utils.py
+++ b/lektor/utils.py
@@ -693,11 +693,13 @@ def portable_popen(cmd, *args, **kwargs):
     return subprocess.Popen(cmd, *args, **kwargs)
 
 
-def is_valid_id(value):
+def is_valid_id(value: str) -> bool:
+    """Determine whether value is a valid id for a db object."""
     if value == "":
         return True
     return (
         "/" not in value
+        and "\\" not in value
         and value.strip() == value
         and value.split() == [value]
         and not value.startswith(".")

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -306,6 +306,7 @@ def test_upload_new_attachment_failure(scratch_client, scratch_content_path, pat
         ),
         ("/page", ".new", {"valid_id": False, "exists": False, "path": None}, None),
         ("/", "page", {"valid_id": True, "exists": True, "path": "/page"}, None),
+        ("/", "x\\..\\new", {"valid_id": False, "exists": False, "path": None}, None),
     ],
 )
 def test_add_new_record(scratch_client, scratch_project, path, id, expect, creates):
@@ -334,6 +335,8 @@ def test_add_new_record(scratch_client, scratch_project, path, id, expect, creat
         # Ensure that attempts to create records outside of the `content` subtree fail.
         # (Reported by Riku Bamba)
         ("/../../templates", ""),
+        # (Reported by Arpit Jain)
+        ("/..\\..\\templates", ""),
     ],
 )
 def test_add_new_record_bad_request(scratch_client, scratch_project, path, id):

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -44,6 +44,7 @@ def test_make_editor_session(pad, path, kwargs, expect):
             marks=pytest.mark.xfail(reason="buglet that should be fixed"),
         ),
         ("/../../templates", {}, "Invalid path"),
+        ("/..\\..\\templates", {}, "Invalid path"),
     ],
 )
 def test_make_editor_session_raises_bad_edit(pad, path, kwargs, expect):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from lektor.utils import build_url
 from lektor.utils import create_temp
 from lektor.utils import deprecated
 from lektor.utils import is_path_child_of
+from lektor.utils import is_valid_id
 from lektor.utils import join_path
 from lektor.utils import magic_split_ext
 from lektor.utils import make_relative_url
@@ -332,6 +333,16 @@ def test_create_temp(tmp_path):
 def test_create_temp_respects_umask(tmp_path, mode, umask):
     _, filename = create_temp(dir=tmp_path, mode=mode)
     assert oct(stat.S_IMODE(os.stat(filename).st_mode)) == oct(mode & ~umask)
+
+
+@pytest.mark.parametrize("id_", ["", "foo", "x.y", "x.", "x..y"])
+def test_is_valid_id_true(id_):
+    assert is_valid_id(id_)
+
+
+@pytest.mark.parametrize("id_", [".", "..", " x", "x y", "\N{EM QUAD}", "a/b", "a\\b"])
+def test_is_valid_id_false(id_):
+    assert not is_valid_id(id_)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

This fixes a directory traversal vulnerability that occurs only when running the admin server under Windows.
In that case, it was possible to write outside of the project's `content` directory via the admin API, e.g. by creating a new page whose _id_ contained backslashes.

The exposure for this vulnerability is small. In order to be vulnerable:
- The attacker must be able to access the admin API (normally available on `localhost:5000`).
- The admin server must be running on Windows.

### Possible Breakage

Note that as part of this fix, we now disallow backslashes from Lektor DB paths.

### Credit

Thank you to Arpit Jain (@arpitjain099) for the detailed report of this issue.


### Description of Changes

- [x] Wrote at least one-line docstrings (for any new functions)
- [x] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->


<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
