### PR TITLE
Allow .lektorproject [project]path to point outside of project file directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 These are all the changes in Lektor since the first public release.
 
+## 3.4.0b16 (Unreleased)
+
+### Fixed
+
+- Allow _project tree_ to be located outside of the directory containing the _project file_.
+  The [documentation][docs-project-path] has always claimed that this was possible, but
+  it has not been (until now). ([#1289], [#858])
+
+[docs-project-path]: https://www.getlektor.com/docs/project/file/#:~:text=you%20can%20set%20the%20path%20in%20the%20file%20to%20a%20path%20(absolute%20or%20relative%20to%20the%20project%20file)%20which%20resolves%20to%20the%20project%20tree "Documentation on the `path` setting in the Lektor Project File"
+[#858]: https://github.com/lektor/lektor/issues/858
+[#1289]: https://github.com/lektor/lektor/pull/1289
+
 ## 3.4.0b15 (2026-08-07)
 
 ### Fixes

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -12,7 +12,6 @@ from werkzeug.utils import cached_property
 from lektor.environment import Environment
 from lektor.utils import comma_delimited
 from lektor.utils import get_cache_dir
-from lektor.utils import untrusted_to_os_path
 
 
 class Project:
@@ -41,7 +40,7 @@ class Project:
         )
         path = os.path.join(
             os.path.dirname(filename),
-            untrusted_to_os_path(inifile.get("project.path") or "."),
+            inifile.get("project.path") or ".",
         )
 
         themes = inifile.get("project.themes")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,8 @@
 import inspect
+import os
 from pathlib import Path
+
+import pytest
 
 from lektor.project import Project
 
@@ -26,3 +29,19 @@ def test_Project_get_output_path_is_relative_to_project_file(tmp_path: Path) -> 
 
     project = Project.from_file(project_file)
     assert project.get_output_path() == str(tmp_path / "htdocs")
+
+
+@pytest.mark.parametrize("path", [None, "rel", "../sibling", "/absolute/path"])
+def test_Project_tree(path: str | None, tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    project_file = config_dir / "test.lektorproject"
+    project_file.parent.mkdir(parents=True, exist_ok=True)
+    with project_file.open("w") as fp:
+        fp.write("[project]\n")
+        if path is not None:
+            fp.write(f"path = {path}\n")
+    project = Project.from_file(project_file)
+
+    assert os.path.normpath(project.tree) == project.tree
+    expected = config_dir.joinpath(path).resolve() if path is not None else config_dir
+    assert Path(project.tree) == expected


### PR DESCRIPTION
While working on #1288, I rediscovered #858.  Namely that, while our [documentation says otherwise][docs-path], it was not possible to point `[project]path` to a directory outside of the one containing the project file.

This fixes that.

[docs-path]: https://www.getlektor.com/docs/project/file/#:~:text=you%20can%20set%20the%20path%20in%20the%20file%20to%20a%20path%20(absolute%20or%20relative%20to%20the%20project%20file)%20which%20resolves%20to%20the%20project%20tree "Documentation on the `path` setting in the Lektor Project File"
 
<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #858

### Related Issues / Links

<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [x] Added unit test(s) covering the changes (if testable)

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
